### PR TITLE
Feature/limit ingress networks

### DIFF
--- a/terraform_nessus_only/scripts/fetch_production_tfvars.sh
+++ b/terraform_nessus_only/scripts/fetch_production_tfvars.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Fetch the current version of production.tfvars from an S3 bucket and put it
+# in the terraform directory
+# Requirement: AWS command line interface must be installed/setup on your system
+
+TERRAFORM_TFVARS_S3_BUCKET="ncats-terraform-production-tfvars"
+TERRAFORM_DIR="terraform_nessus_only"
+TFVARS_FILE="production.tfvars"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+aws s3 cp s3://${TERRAFORM_TFVARS_S3_BUCKET}/${TERRAFORM_DIR}/${TFVARS_FILE} ${SCRIPT_DIR}/../${TFVARS_FILE}

--- a/terraform_nessus_only/variables.tf
+++ b/terraform_nessus_only/variables.tf
@@ -16,3 +16,15 @@ variable "tags" {
   }
   description = "Tags to apply to all AWS resources created"
 }
+
+# This should be overridden by a production.tfvars file,
+# most-likely stored outside of version control
+variable "trusted_ingress_networks_ipv4" {
+  type = "list"
+  default = [ "0.0.0.0/0" ]
+}
+
+variable "trusted_ingress_networks_ipv6" {
+  type = "list"
+  default = [ "::/0" ]
+}

--- a/terraform_nessus_only/vpc.tf
+++ b/terraform_nessus_only/vpc.tf
@@ -147,20 +147,30 @@ resource "aws_security_group" "nessus_scanner_sg" {
   tags = "${merge(var.tags, map("Name", "CyHy Nessus Scanners"))}"
 }
 
-# Allow ingress from anywhere via ssh
-resource "aws_security_group_rule" "scanner_ingress_anywhere_via_ssh" {
+# Allow ingress from trusted ingress networks via ssh
+resource "aws_security_group_rule" "scanner_ingress_trusted_via_ssh" {
   security_group_id = "${aws_security_group.nessus_scanner_sg.id}"
   type = "ingress"
   protocol = "tcp"
-  cidr_blocks = [
-    "0.0.0.0/0"
-  ]
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
   from_port = 22
   to_port = 22
 }
 
-# Allow ingress from anywhere via ephemeral ports
-resource "aws_security_group_rule" "scanner_ingress_anywhere_via_ephemeral_ports_tcp" {
+# Allow ingress from trusted ingress networks via Nessus
+resource "aws_security_group_rule" "scanner_ingress_trusted_via_nessus" {
+  security_group_id = "${aws_security_group.nessus_scanner_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
+  from_port = 8834
+  to_port = 8834
+}
+
+# Allow ingress from anywhere via ephemeral ports (except Nessus TCP 8834)
+resource "aws_security_group_rule" "scanner_ingress_anywhere_via_lower_ephemeral_ports_tcp" {
   security_group_id = "${aws_security_group.nessus_scanner_sg.id}"
   type = "ingress"
   protocol = "tcp"
@@ -168,6 +178,16 @@ resource "aws_security_group_rule" "scanner_ingress_anywhere_via_ephemeral_ports
     "0.0.0.0/0"
   ]
   from_port = 1024
+  to_port = 8833
+}
+resource "aws_security_group_rule" "scanner_ingress_anywhere_via_upper_ephemeral_ports_tcp" {
+  security_group_id = "${aws_security_group.nessus_scanner_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port = 8835
   to_port = 65535
 }
 resource "aws_security_group_rule" "scanner_ingress_anywhere_via_ephemeral_ports_udp" {


### PR DESCRIPTION
Enable limiting access to Nessus instance via trusted networks list in variables.tf (or any other supplied variables file, like production.tfvars)