### PR TITLE
Make the gold VPC immortal

### DIFF
--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,8 +1,9 @@
-aws_region = "us-east-2"
+aws_region = "us-east-1"
 
 aws_availability_zone = "a"
 
 tags = {
   Team = "NCATS OIS - Development"
   Application = "Cyber Hygiene"
+  Workspace = "Production"
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -3,6 +3,21 @@ resource "aws_vpc" "cyhy_vpc" {
   cidr_block = "10.10.10.0/23"
 
   tags = "${merge(var.tags, map("Name", "CyHy"))}"
+
+  # Note that this VPC's ID is flagged by AWS as one from which we are
+  # allowed to perform penetration scanning.  Therefore we need this
+  # resource to be immortal in the "production" workspace, and so I am
+  # using the prevent_destroy lifecycle element to disallow the
+  # destruction of it via terraform in that case.
+  #
+  # I'd like to use "${terraform.workspace == "production" ? true :
+  # false}" here, so the prevent_destroy only applies to the
+  # production, but it appears that interpolations are not supported
+  # inside of the lifecycle block
+  # (https://github.com/hashicorp/terraform/issues/3116).
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Private subnet of the VPC, for database and CyHy commander


### PR DESCRIPTION
I'd like to do this only for the production environment, but that isn't possible while this issue is still out there:
hashicorp/terraform#3116

The VPC can be destroyed either by:
- Temporarily changing `prevent_destroy` to `false`
- Clicking in the AWS web UI