### PR TITLE
Change code to use the cheaper r4.xlarge instance type.

### DIFF
--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -22,10 +22,14 @@ data "aws_ami" "bod_docker" {
 }
 
 # The docker EC2 instance
+locals {
+  production_instance = "${terraform.workspace == "production" || terraform.workspace == "planet_piss" ? true : false}"
+}
+
 resource "aws_instance" "bod_docker" {
   ami = "${data.aws_ami.bod_docker.id}"
-  instance_type = "${terraform.workspace == "production" || terraform.workspace == "planet_piss" ? "r4.4xlarge" : "t2.micro"}"
-  ebs_optimized = "${terraform.workspace == "production" || terraform.workspace == "planet_piss" ? true : false}"
+  instance_type = "${local.production_instance ? "r4.xlarge" : "t2.micro"}"
+  ebs_optimized = "${local.production_instance}"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the private subnet
@@ -33,7 +37,7 @@ resource "aws_instance" "bod_docker" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = "${terraform.workspace == "production" || terraform.workspace == "planet_piss" ? 100 : 10}"
+    volume_size = "${local.production_instance ? 100 : 10}"
     delete_on_termination = true
   }
 


### PR DESCRIPTION
I watched the memory consumption while running BOD scanning, and it appears to consume about 13GB.  I could probably get by with 16GB of RAM, but this is an economical option that has almost 32GB of RAM.

I did a full test run with no issues.