### PR TITLE
Improve networking

### DIFF
--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -16,7 +16,7 @@ resource "aws_instance" "cyhy_bastion" {
   }
 
   vpc_security_group_ids = [
-    "${aws_security_group.cyhy_scanner_sg.id}"
+    "${aws_security_group.cyhy_bastion_sg.id}"
   ]
 
   user_data = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"

--- a/terraform/cyhy_bastion_security_group_rules.tf
+++ b/terraform/cyhy_bastion_security_group_rules.tf
@@ -1,0 +1,45 @@
+# Allow ingress from trusted networks via ssh
+resource "aws_security_group_rule" "bastion_ingress_from_trusted_via_ssh" {
+  security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
+  from_port = 22
+  to_port = 22
+}
+
+# Allow ingress from the bastion's public IP via ssh.
+#
+# We need this because Ansible uses the ssh proxy even when connecting
+# to the bastion.
+resource "aws_security_group_rule" "bastion_self_ingress" {
+  security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  cidr_blocks = [
+    "${aws_instance.cyhy_bastion.public_ip}/32"
+  ]
+  from_port = 22
+  to_port = 22
+}
+
+# Allow egress via ssh to the private security group
+resource "aws_security_group_rule" "bastion_egress_to_private_sg_via_ssh" {
+  security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
+  type = "egress"
+  protocol = "tcp"
+  source_security_group_id = "${aws_security_group.cyhy_private_sg.id}"
+  from_port = 22
+  to_port = 22
+}
+
+# Allow egress via ssh to the scanner security group
+resource "aws_security_group_rule" "bastion_egress_to_scanner_sg_via_ssh" {
+  security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
+  type = "egress"
+  protocol = "tcp"
+  source_security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
+  from_port = 22
+  to_port = 22
+}

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -51,10 +51,11 @@ module "cyhy_nessus_ansible_provisioner" {
 
   arguments = [
     "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no'"
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
   ]
   envs = [
-    "host=${aws_instance.cyhy_nessus.public_ip}",
+    "host=${aws_instance.cyhy_nessus.private_ip}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_runner"
   ]
   playbook = "../ansible/playbook.yml"

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -51,10 +51,11 @@ module "cyhy_nmap_ansible_provisioner" {
 
   arguments = [
     "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no'"
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
   ]
   envs = [
-    "host=${aws_instance.cyhy_nmap.public_ip}",
+    "host=${aws_instance.cyhy_nmap.private_ip}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_runner"
   ]
   playbook = "../ansible/playbook.yml"

--- a/terraform/cyhy_private_acl_rules.tf
+++ b/terraform/cyhy_private_acl_rules.tf
@@ -1,45 +1,21 @@
-# Allow ingress from scanner subnet via ephemeral ports
-resource "aws_network_acl_rule" "private_ingress_from_scanner_via_ephemeral_ports" {
-  network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
-  egress = false
-  protocol = "tcp"
-  rule_number = 100
-  rule_action = "allow"
-  cidr_block = "${aws_subnet.cyhy_scanner_subnet.cidr_block}"
-  from_port = 1024
-  to_port = 65535
-}
-
-# Allow ingress from the scanner subnet via ssh
-resource "aws_network_acl_rule" "private_ingress_from_scanner_via_ssh" {
-  network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
-  egress = false
-  protocol = "tcp"
-  rule_number = 110
-  rule_action = "allow"
-  cidr_block = "${aws_subnet.cyhy_scanner_subnet.cidr_block}"
-  from_port = 22
-  to_port = 22
-}
-
 # Allow egress to the scanner subnet via ssh
 resource "aws_network_acl_rule" "private_egress_to_scanner_via_ssh" {
   network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
   egress = true
   protocol = "tcp"
-  rule_number = 120
+  rule_number = 100
   rule_action = "allow"
   cidr_block = "${aws_subnet.cyhy_scanner_subnet.cidr_block}"
   from_port = 22
   to_port = 22
 }
 
-# Allow egress to the scanner subnet via ephemeral ports
-resource "aws_network_acl_rule" "private_egress_to_scanner_via_ephemeral_ports" {
+# Allow ingress from scanner subnet via ephemeral ports
+resource "aws_network_acl_rule" "private_ingress_from_scanner_via_ephemeral_ports" {
   network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
-  egress = true
+  egress = false
   protocol = "tcp"
-  rule_number = 130
+  rule_number = 120
   rule_action = "allow"
   cidr_block = "${aws_subnet.cyhy_scanner_subnet.cidr_block}"
   from_port = 1024

--- a/terraform/cyhy_private_acl_rules.tf
+++ b/terraform/cyhy_private_acl_rules.tf
@@ -15,9 +15,33 @@ resource "aws_network_acl_rule" "private_ingress_from_scanner_via_ephemeral_port
   network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
   egress = false
   protocol = "tcp"
-  rule_number = 120
+  rule_number = 101
   rule_action = "allow"
   cidr_block = "${aws_subnet.cyhy_scanner_subnet.cidr_block}"
+  from_port = 1024
+  to_port = 65535
+}
+
+# Allow ingress from the bastion via ssh
+resource "aws_network_acl_rule" "private_ingress_from_bastion_via_ssh" {
+  network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
+  egress = false
+  protocol = "tcp"
+  rule_number = 110
+  rule_action = "allow"
+  cidr_block = "${aws_instance.cyhy_bastion.private_ip}/32"
+  from_port = 22
+  to_port = 22
+}
+
+# Allow egress to the bastion via ephemeral ports
+resource "aws_network_acl_rule" "private_egress_to_bastion_via_ephemeral_ports" {
+  network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
+  egress = true
+  protocol = "tcp"
+  rule_number = 111
+  rule_action = "allow"
+  cidr_block = "${aws_instance.cyhy_bastion.private_ip}/32"
   from_port = 1024
   to_port = 65535
 }
@@ -27,7 +51,7 @@ resource "aws_network_acl_rule" "private_ingress_from_bod_private_via_mongodb" {
   network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
   egress = false
   protocol = "tcp"
-  rule_number = 140
+  rule_number = 120
   rule_action = "allow"
   cidr_block = "${aws_subnet.bod_private_subnet.cidr_block}"
   from_port = 27017
@@ -39,7 +63,7 @@ resource "aws_network_acl_rule" "private_egress_to_bod_private_via_ephemeral_por
   network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
   egress = true
   protocol = "tcp"
-  rule_number = 150
+  rule_number = 121
   rule_action = "allow"
   cidr_block = "${aws_subnet.bod_private_subnet.cidr_block}"
   from_port = 1024

--- a/terraform/cyhy_private_security_group_rules.tf
+++ b/terraform/cyhy_private_security_group_rules.tf
@@ -8,6 +8,18 @@ resource "aws_security_group_rule" "private_ssh_egress_to_scanner" {
   to_port = 22
 }
 
+# Allow SSH ingress from the bastion
+resource "aws_security_group_rule" "private_ssh_ingress_from_bastion" {
+  security_group_id = "${aws_security_group.cyhy_private_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  cidr_blocks = [
+    "${aws_instance.cyhy_bastion.private_ip}/32"
+  ]
+  from_port = 22
+  to_port = 22
+}
+
 # Allow MongoDB ingress from the BOD private security group
 resource "aws_security_group_rule" "private_mongodb_ingress_from_bod_private" {
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"

--- a/terraform/cyhy_private_security_group_rules.tf
+++ b/terraform/cyhy_private_security_group_rules.tf
@@ -1,25 +1,3 @@
-# Allow ingress via ephemeral ports from anywhere
-resource "aws_security_group_rule" "private_ingress_from_anywhere_via_ephemeral_ports" {
-  security_group_id = "${aws_security_group.cyhy_private_sg.id}"
-  type = "ingress"
-  protocol = "tcp"
-  cidr_blocks = [
-    "0.0.0.0/0"
-  ]
-  from_port = 1024
-  to_port = 65535
-}
-
-# Allow SSH ingress from the scanner security group
-resource "aws_security_group_rule" "private_ssh_ingress_from_scanner" {
-  security_group_id = "${aws_security_group.cyhy_private_sg.id}"
-  type = "ingress"
-  protocol = "tcp"
-  source_security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
-  from_port = 22
-  to_port = 22
-}
-
 # Allow SSH egress to the scanner security group
 resource "aws_security_group_rule" "private_ssh_egress_to_scanner" {
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"

--- a/terraform/cyhy_scanner_acl_rules.tf
+++ b/terraform/cyhy_scanner_acl_rules.tf
@@ -1,43 +1,25 @@
-# Allow ingress from anywhere via the Nessus UI port
-resource "aws_network_acl_rule" "scanner_ingress_from_anywhere_via_nessus" {
+# Allow ingress from anywhere via the Nessus UI and ssh ports
+resource "aws_network_acl_rule" "scanner_ingress_from_anywhere_via_nessus_and_ssh" {
+  count = "${length(local.cyhy_trusted_ingress_ports)}"
+  
   network_acl_id = "${aws_network_acl.cyhy_scanner_acl.id}"
   egress = false
   protocol = "tcp"
-  rule_number = 100
+  rule_number = "${100 + count.index}"
   rule_action = "allow"
   cidr_block = "0.0.0.0/0"
-  from_port = 8834
-  to_port = 8834
-}
-
-# Allow ingress from anywhere via ssh
-resource "aws_network_acl_rule" "scanner_ingress_from_anywhere_via_ssh" {
-  network_acl_id = "${aws_network_acl.cyhy_scanner_acl.id}"
-  egress = false
-  protocol = "tcp"
-  rule_number = 110
-  rule_action = "allow"
-  cidr_block = "0.0.0.0/0"
-  from_port = 22
-  to_port = 22
+  from_port = "${local.cyhy_trusted_ingress_ports[count.index]}"
+  to_port = "${local.cyhy_trusted_ingress_ports[count.index]}"
 }
 
 # Allow ingress from anywhere via ephemeral ports
-resource "aws_network_acl_rule" "scanner_ingress_from_anywhere_via_ephemeral_ports_tcp" {
+resource "aws_network_acl_rule" "scanner_ingress_from_anywhere_via_ephemeral_ports" {
+  count = "${length(local.tcp_and_udp)}"
+  
   network_acl_id = "${aws_network_acl.cyhy_scanner_acl.id}"
   egress = false
-  protocol = "tcp"
-  rule_number = 120
-  rule_action = "allow"
-  cidr_block = "0.0.0.0/0"
-  from_port = 1024
-  to_port = 65535
-}
-resource "aws_network_acl_rule" "scanner_ingress_from_anywhere_via_ephemeral_ports_udp" {
-  network_acl_id = "${aws_network_acl.cyhy_scanner_acl.id}"
-  egress = false
-  protocol = "udp"
-  rule_number = 130
+  protocol = "${local.tcp_and_udp[count.index]}"
+  rule_number = "${120 + count.index}"
   rule_action = "allow"
   cidr_block = "0.0.0.0/0"
   from_port = 1024

--- a/terraform/cyhy_scanner_security_group_rules.tf
+++ b/terraform/cyhy_scanner_security_group_rules.tf
@@ -1,28 +1,18 @@
-# Allow ingress from trusted networks via the Nessus UI port
-resource "aws_security_group_rule" "scanner_ingress_from_trusted_via_nessus" {
+# Allow ingress from trusted networks via the Nessus UI and ssh ports
+resource "aws_security_group_rule" "scanner_ingress_from_trusted" {
+  count = "${length(local.cyhy_trusted_ingress_ports)}"
+
   security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
   type = "ingress"
   protocol = "tcp"
   cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
   # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
-  from_port = 8834
-  to_port = 8834
+  from_port = "${local.cyhy_trusted_ingress_ports[count.index]}"
+  to_port = "${local.cyhy_trusted_ingress_ports[count.index]}"
 }
 
-# Allow ingress from trusted networks via ssh
-resource "aws_security_group_rule" "scanner_ingress_from_trusted_via_ssh" {
-  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
-  type = "ingress"
-  protocol = "tcp"
-  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
-  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
-  from_port = 22
-  to_port = 22
-}
-
-# Allow ingress from bastion via ssh.  This is necessary because
-# Ansible applies the ssh proxy even when sshing to the bastion.
-resource "aws_security_group_rule" "scanner_ingress_from_self_via_ssh" {
+# Allow ingress from the bastion via ssh
+resource "aws_security_group_rule" "scanner_ingress_from_bastion_via_ssh" {
   security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
   type = "ingress"
   protocol = "tcp"
@@ -31,28 +21,6 @@ resource "aws_security_group_rule" "scanner_ingress_from_self_via_ssh" {
   ]
   from_port = 22
   to_port = 22
-}
-
-# Allow ingress from anywhere via ephemeral ports
-resource "aws_security_group_rule" "scanner_ingress_anywhere_tcp" {
-  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
-  type = "ingress"
-  protocol = "tcp"
-  cidr_blocks = [
-    "0.0.0.0/0"
-  ]
-  from_port = 1024
-  to_port = 65535
-}
-resource "aws_security_group_rule" "scanner_ingress_anywhere_udp" {
-  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
-  type = "ingress"
-  protocol = "udp"
-  cidr_blocks = [
-    "0.0.0.0/0"
-  ]
-  from_port = 1024
-  to_port = 65535
 }
 
 # Allow ingress via ssh from the private security group
@@ -76,14 +44,4 @@ resource "aws_security_group_rule" "scanner_egress_anywhere" {
   ]
   from_port = 0
   to_port = 0
-}
-
-# Allow egress via ssh to the private security group
-resource "aws_security_group_rule" "scanner_egress_to_private_sg_via_ssh" {
-  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
-  type = "egress"
-  protocol = "tcp"
-  source_security_group_id = "${aws_security_group.cyhy_private_sg.id}"
-  from_port = 22
-  to_port = 22
 }

--- a/terraform/cyhy_scanner_security_group_rules.tf
+++ b/terraform/cyhy_scanner_security_group_rules.tf
@@ -12,6 +12,9 @@ resource "aws_security_group_rule" "scanner_ingress_from_trusted" {
 }
 
 # Allow ingress from the bastion via ssh
+#
+# We have to include the public IP because Ansible uses the ssh proxy
+# even when connecting to the bastion.
 resource "aws_security_group_rule" "scanner_ingress_from_bastion_via_ssh" {
   security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
   type = "ingress"

--- a/terraform/cyhy_scanner_security_group_rules.tf
+++ b/terraform/cyhy_scanner_security_group_rules.tf
@@ -17,7 +17,8 @@ resource "aws_security_group_rule" "scanner_ingress_from_bastion_via_ssh" {
   type = "ingress"
   protocol = "tcp"
   cidr_blocks = [
-    "${aws_instance.cyhy_bastion.public_ip}/32"
+    "${aws_instance.cyhy_bastion.public_ip}/32",
+    "${aws_instance.cyhy_bastion.private_ip}/32"
   ]
   from_port = 22
   to_port = 22

--- a/terraform/cyhy_scanner_security_group_rules.tf
+++ b/terraform/cyhy_scanner_security_group_rules.tf
@@ -1,30 +1,14 @@
-# Allow ingress from trusted networks via the Nessus UI and ssh ports
-resource "aws_security_group_rule" "scanner_ingress_from_trusted" {
+# Allow ingress from the bastion security group via the ssh and Nessus
+# ports
+resource "aws_security_group_rule" "scanner_ingress_from_bastion_sg" {
   count = "${length(local.cyhy_trusted_ingress_ports)}"
-
+  
   security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
   type = "ingress"
   protocol = "tcp"
-  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
-  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
+  source_security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
   from_port = "${local.cyhy_trusted_ingress_ports[count.index]}"
   to_port = "${local.cyhy_trusted_ingress_ports[count.index]}"
-}
-
-# Allow ingress from the bastion via ssh
-#
-# We have to include the public IP because Ansible uses the ssh proxy
-# even when connecting to the bastion.
-resource "aws_security_group_rule" "scanner_ingress_from_bastion_via_ssh" {
-  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
-  type = "ingress"
-  protocol = "tcp"
-  cidr_blocks = [
-    "${aws_instance.cyhy_bastion.public_ip}/32",
-    "${aws_instance.cyhy_bastion.private_ip}/32"
-  ]
-  from_port = 22
-  to_port = 22
 }
 
 # Allow ingress via ssh from the private security group

--- a/terraform/cyhy_vpc.tf
+++ b/terraform/cyhy_vpc.tf
@@ -153,3 +153,10 @@ resource "aws_security_group" "cyhy_scanner_sg" {
 
   tags = "${merge(var.tags, map("Name", "CyHy Scanners"))}"
 }
+
+# Security group for the bastion host
+resource "aws_security_group" "cyhy_bastion_sg" {
+  vpc_id = "${aws_vpc.cyhy_vpc.id}"
+
+  tags = "${merge(var.tags, map("Name", "CyHy Bastion"))}"
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -2,4 +2,17 @@ locals {
   # This is a goofy but necessary way to determine if
   # terraform.workspace contains the substring "production"
   production_workspace = "${replace(terraform.workspace, "production", "") != terraform.workspace}"
+
+  # These are the ports via which trusted networks are allowed to
+  # access the public-facing CyHy hosts
+  cyhy_trusted_ingress_ports = [
+    22,
+    8834
+  ]
+
+  # Pretty obvious what this is
+  tcp_and_udp = [
+    "tcp",
+    "udp"
+  ]
 }


### PR DESCRIPTION
These changes simplify the networking rules and allow the scanners to be provisioned by Ansible using the bastion host as an ssh proxy.