### PR TITLE
add public DNS entry for the bastion host

### DIFF
--- a/terraform/cyhy_public_dns.tf
+++ b/terraform/cyhy_public_dns.tf
@@ -1,0 +1,11 @@
+data "aws_route53_zone" "public_zone" {
+  name = "${local.public_zone}"
+}
+
+resource "aws_route53_record" "bastion_pub_A" {
+  zone_id = "${aws_route53_zone.private_zone.zone_id}"
+  name    = "bastion.${terraform.workspace}.${local.public_subdomain}${data.aws_route53_zone.public_zone.name}"
+  type    = "A"
+  ttl     = 30
+  records = [ "${aws_instance.cyhy_bastion.public_ip}" ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -24,6 +24,14 @@ locals {
   # domain name to use for internal DNS
   private_domain = "local"
 
+  # zone to use for public DNS
+  public_zone  = "cyber.dhs.gov"
+
+  # subdomains to use in the public_zone.
+  # to create records directly in the public_zone set to ""
+  # otherwise it must end in a period
+  public_subdomain = "cyhy."
+
   # DNS zone calculations based on requested instances
   # The numbers represent the count of IP addresses in a subnet
   # and are used by the cidrhost() function.


### PR DESCRIPTION
Add a spiffy record so you can find your bastion.  Also, lets introduce the world to our unique and fun workspace names!  

NOTE:  until we get _NoneNet_ to point to the new SOA we're not actually going to be able to use these records.  