### PR TITLE
Only update plugins and rebuild database when previously unregistered

### DIFF
--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -68,11 +68,13 @@
   command: /opt/nessus/sbin/nessuscli update --plugins-only
   async: 300
   poll: 5
+  when: registered.rc != 0
 
 - name: Rebuild the plugin database
   command: /opt/nessus/sbin/nessusd -R
   async: 1200
   poll: 30
+  when: registered.rc != 0
 
 - name: Start Nessus service
   service:


### PR DESCRIPTION
Only update the Nessus plugins and rebuild the Nessus database when Nessus does not already have an activation code.