### PR TITLE
Add an Ansible role for expanding the ephemeral port range

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -25,6 +25,7 @@
     - pip
     - cyhy_runner
     - nmap
+    - more_ephemeral_ports
 
 # MongoDB doesn't like transparent huge pages:
 # https://docs.mongodb.com/manual/tutorial/transparent-huge-pages/
@@ -47,6 +48,7 @@
   roles:
     - pip
     - cyhy_runner
+    - more_ephemeral_ports
 
 - hosts: docker
   name: Install Docker

--- a/packer/ansible/roles/more_ephemeral_ports/README.md
+++ b/packer/ansible/roles/more_ephemeral_ports/README.md
@@ -1,0 +1,40 @@
+more_ephemeral_ports
+====================
+
+A role for setting the ephemeral port range to 1024-65535.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Here's how to use it in a playbook:
+
+    - hosts: scanners
+      become: yes
+      become_method: sudo
+      roles:
+         - more_ephemeral_ports
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Shane Frasier <jeremy.frasier@beta.dhs.gov>

--- a/packer/ansible/roles/more_ephemeral_ports/defaults/main.yml
+++ b/packer/ansible/roles/more_ephemeral_ports/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for more_ephemeral_ports

--- a/packer/ansible/roles/more_ephemeral_ports/files/more_ephemeral_ports.conf
+++ b/packer/ansible/roles/more_ephemeral_ports/files/more_ephemeral_ports.conf
@@ -1,0 +1,1 @@
+net.ipv4.ip_local_port_range = 1024 65535

--- a/packer/ansible/roles/more_ephemeral_ports/handlers/main.yml
+++ b/packer/ansible/roles/more_ephemeral_ports/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for more_ephemeral_ports

--- a/packer/ansible/roles/more_ephemeral_ports/meta/main.yml
+++ b/packer/ansible/roles/more_ephemeral_ports/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/packer/ansible/roles/more_ephemeral_ports/tasks/main.yml
+++ b/packer/ansible/roles/more_ephemeral_ports/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for more_ephemeral_ports
+
+- name: Copy sysctl file
+  copy:
+    src: more_ephemeral_ports.conf
+    dest: /etc/sysctl.d/99-more_ephemeral_ports.conf
+    mode: 0644

--- a/packer/ansible/roles/more_ephemeral_ports/tests/inventory
+++ b/packer/ansible/roles/more_ephemeral_ports/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/packer/ansible/roles/more_ephemeral_ports/tests/test.yml
+++ b/packer/ansible/roles/more_ephemeral_ports/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - more_ephemeral_ports

--- a/packer/ansible/roles/more_ephemeral_ports/vars/main.yml
+++ b/packer/ansible/roles/more_ephemeral_ports/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for more_ephemeral_ports


### PR DESCRIPTION
This is for the scanners, which for best results will want the full 1024-65535 range of ephemeral ports.