### PR TITLE
Various changes for Production based on our testing

### DIFF
--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-default-section = testing-bonus
+default-section = production
 database-uri = mongodb://commander:PASSWORD@mongodb.host.flood:27017/cyhy
 jobs-per-nmap-host = 8
 jobs-per-nessus-host = 16
@@ -15,6 +15,10 @@ nessus-hosts = vulnscan1
 
 [production]
 database-name = cyhy
+jobs-per-nmap-host = 8
+jobs-per-nessus-host = 16
+nmap-hosts = portscan1, portscan2, portscan3, portscan4
+nessus-hosts = vulnscan1
 
 [purge]
 # use to collect remaining jobs without creating new ones

--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -17,7 +17,7 @@ nessus-hosts = vulnscan1
 database-name = cyhy
 jobs-per-nmap-host = 12
 jobs-per-nessus-host = 16
-nmap-hosts = portscan1, portscan2, portscan3, portscan4, portscan5, portscan6, portscan7, portscan8, portscan9, portscan10
+nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8, portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24
 nessus-hosts = vulnscan1
 
 [purge]
@@ -46,7 +46,7 @@ nessus-hosts = vulnscan1
 [testing-bonus]
 # test-mode = true
 database-name = cyhy
-jobs-per-nmap-host = 32
+jobs-per-nmap-host = 12
 jobs-per-nessus-host = 16
-nmap-hosts = portscan1
+nmap-hosts = portscan1, portscan2, portscan3, portscan4
 nessus-hosts = vulnscan1

--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -10,8 +10,8 @@ keep-failures = true
 keep-successes = false
 shutdown-when-idle = false
 debug-logging = true
-nmap-hosts = portscan1, portscan2
-nessus-hosts = vulnscan1, vulnscan2
+nmap-hosts = portscan1
+nessus-hosts = vulnscan1
 
 [production]
 database-name = cyhy
@@ -42,7 +42,7 @@ nessus-hosts = vulnscan1
 [testing-bonus]
 # test-mode = true
 database-name = cyhy
-jobs-per-nmap-host = 64
-jobs-per-nessus-host = 32
+jobs-per-nmap-host = 16
+jobs-per-nessus-host = 8
 nmap-hosts = portscan1
 nessus-hosts = vulnscan1

--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -42,7 +42,7 @@ nessus-hosts = vulnscan1
 [testing-bonus]
 # test-mode = true
 database-name = cyhy
-jobs-per-nmap-host = 16
-jobs-per-nessus-host = 8
+jobs-per-nmap-host = 32
+jobs-per-nessus-host = 16
 nmap-hosts = portscan1
 nessus-hosts = vulnscan1

--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -17,7 +17,7 @@ nessus-hosts = vulnscan1
 database-name = cyhy
 jobs-per-nmap-host = 8
 jobs-per-nessus-host = 16
-nmap-hosts = portscan1, portscan2, portscan3, portscan4
+nmap-hosts = portscan1, portscan2, portscan3, portscan4, portscan5, portscan6, portscan7, portscan8, portscan9, portscan10
 nessus-hosts = vulnscan1
 
 [purge]

--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -15,7 +15,7 @@ nessus-hosts = vulnscan1
 
 [production]
 database-name = cyhy
-jobs-per-nmap-host = 8
+jobs-per-nmap-host = 12
 jobs-per-nessus-host = 16
 nmap-hosts = portscan1, portscan2, portscan3, portscan4, portscan5, portscan6, portscan7, portscan8, portscan9, portscan10
 nessus-hosts = vulnscan1

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -197,12 +197,12 @@
   become: no
 
 #
-# Run cyhy-nvdsync daily at 2315 (UTC) as cyhy user
+# Run cyhy-nvdsync daily at 0815 (UTC) as cyhy user
 #
 - name: Set up nightly cron job to sync NVD data
   cron:
     name: Nightly cyhy-nvdsync
-    hour: 23
+    hour: 08
     minute: 15
     user: cyhy
-    job: cyhy-nvdsync --use-network 2>&1 | /usr/bin/logger -t cyhy-nvdsync
+    job: /usr/local/bin/cyhy-nvdsync --use-network 2>&1 | /usr/bin/logger -t cyhy-nvdsync

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -22,8 +22,7 @@ data "aws_ami" "cyhy_mongo" {
 
 resource "aws_instance" "cyhy_mongo" {
   ami = "${data.aws_ami.cyhy_mongo.id}"
-  # Temp change from m4.2xlarge to m4.10xlarge when our AWS limit is increased
-  instance_type = "${local.production_workspace ? "m4.2xlarge" : "t2.micro"}"
+  instance_type = "${local.production_workspace ? "m4.10xlarge" : "t2.micro"}"
   #count = "${local.mongo_instance_count}"
   ebs_optimized = "${local.production_workspace}"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -27,6 +27,9 @@ resource "aws_instance" "cyhy_nmap" {
 
   # ebs_optimized = true
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+  # We may want to spread instances across all availability zones, however
+  # this will also require creating a scanner subnet in each availability zone
+  # availability_zone = "${element(data.aws_availability_zones.all.names, count.index)}"
 
   subnet_id = "${aws_subnet.cyhy_scanner_subnet.id}"
   private_ip = "${cidrhost(aws_subnet.cyhy_scanner_subnet.cidr_block, count.index + local.first_port_scanner)}"
@@ -62,6 +65,7 @@ resource "aws_instance" "cyhy_nmap" {
 resource "aws_ebs_volume" "cyhy_runner_data" {
   count = "${local.nmap_instance_count}"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+  # availability_zone = "${element(data.aws_availability_zones.all.names, count.index)}"
   type = "gp2"
   size = "${local.production_workspace ? 2 : 1}"
   encrypted = true
@@ -268,6 +272,244 @@ module "cyhy_nmap_ansible_provisioner_9" {
   ]
   envs = [
     "host=${aws_instance.cyhy_nmap.*.private_ip[9]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_10" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[10]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_11" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[11]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_12" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[12]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_13" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[13]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_14" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[14]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_15" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[15]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_16" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[16]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_17" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[17]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_18" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[18]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_19" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[19]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_20" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[20]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_21" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[21]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_22" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[22]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_23" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[23]}",
     "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_runner"
   ]

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -45,8 +45,8 @@ resource "aws_instance" "cyhy_nmap" {
 
   user_data = "${data.template_cloudinit_config.ssh_and_cyhy_runner_cloud_init_tasks.rendered}"
 
-  tags = "${merge(var.tags, map("Name", "CyHy Nmap"))}"
-  volume_tags = "${merge(var.tags, map("Name", "CyHy Nmap"))}"
+  tags = "${merge(var.tags, map("Name", format("CyHy Nmap - portscan%d", count.index+1)))}"
+  volume_tags = "${merge(var.tags, map("Name", format("CyHy Nmap - portscan%d", count.index+1)))}"
 }
 
 # Note that the EBS volume contains production data. Therefore we need
@@ -66,7 +66,7 @@ resource "aws_ebs_volume" "cyhy_runner_data" {
   size = "${local.production_workspace ? 2 : 1}"
   encrypted = true
 
-  tags = "${merge(var.tags, map("Name", "cyhy-runner (CyHy Nmap)"))}"
+  tags = "${merge(var.tags, map("Name", format("CyHy Nmap - portscan%d", count.index+1)))}"
 
   lifecycle {
     prevent_destroy = true
@@ -166,6 +166,108 @@ module "cyhy_nmap_ansible_provisioner_3" {
   ]
   envs = [
     "host=${aws_instance.cyhy_nmap.*.private_ip[3]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_4" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[4]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_5" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[5]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_6" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[6]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_7" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[7]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_8" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[8]}",
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host_groups=cyhy_runner"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
+module "cyhy_nmap_ansible_provisioner_9" {
+  source = "github.com/cloudposse/tf_ansible"
+  #count = "${local.nmap_instance_count}"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
+  ]
+  envs = [
+    "host=${aws_instance.cyhy_nmap.*.private_ip[9]}",
     "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_runner"
   ]

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -22,7 +22,7 @@ data "aws_ami" "nmap" {
 
 resource "aws_instance" "cyhy_nmap" {
   ami = "${data.aws_ami.nmap.id}"
-  instance_type = "${local.production_workspace ? "t2.large" : "t2.micro"}"
+  instance_type = "${local.production_workspace ? "t2.medium" : "t2.micro"}"
   count = "${local.nmap_instance_count}"
 
   # ebs_optimized = true

--- a/terraform/cyhy_scanner_security_group_rules.tf
+++ b/terraform/cyhy_scanner_security_group_rules.tf
@@ -22,6 +22,18 @@ resource "aws_security_group_rule" "scanner_ingress_from_private_sg_via_ssh" {
 }
 
 # Allow ingress from anywhere via all other tcp ports
+#
+# IMPORTANT NOTE: The reason we allow this ingress is to avoid connection
+# tracking in the stateful AWS security group for these ports.  Otherwise, our
+# scan (nmap and Nessus) volume quickly causes the connection tracking table to
+# fill up and our scans do not give valid results.
+# "If a security group rule permits TCP or UDP flows for all traffic
+# (0.0.0.0/0) and there is a corresponding rule in the other direction that
+# permits all response traffic (0.0.0.0/0) for all ports (0-65535), then that
+# flow of traffic is not tracked."
+# "ICMP traffic is always tracked, regardless of rules."
+# Above quotes from: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#security-group-connection-tracking
+# See also:  https://aerissecure.com/blog/vulnerability-scanning-from-aws/
 resource "aws_security_group_rule" "scanner_ingress_anywhere_tcp" {
   count = "${length(local.cyhy_untrusted_ingress_port_ranges)}"
 
@@ -36,6 +48,7 @@ resource "aws_security_group_rule" "scanner_ingress_anywhere_tcp" {
 }
 
 # Allow ingress from anywhere via all udp ports
+# See IMPORTANT NOTE above for explanation
 resource "aws_security_group_rule" "scanner_ingress_anywhere_udp" {
   security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
   type = "ingress"
@@ -48,6 +61,7 @@ resource "aws_security_group_rule" "scanner_ingress_anywhere_udp" {
 }
 
 # Allow ingress from anywhere via all icmp ports
+# See IMPORTANT NOTE above for explanation
 resource "aws_security_group_rule" "scanner_ingress_anywhere_icmp" {
   security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
   type = "ingress"

--- a/terraform/cyhy_scanner_security_group_rules.tf
+++ b/terraform/cyhy_scanner_security_group_rules.tf
@@ -2,7 +2,7 @@
 # ports
 resource "aws_security_group_rule" "scanner_ingress_from_bastion_sg" {
   count = "${length(local.cyhy_trusted_ingress_ports)}"
-  
+
   security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
   type = "ingress"
   protocol = "tcp"
@@ -19,6 +19,44 @@ resource "aws_security_group_rule" "scanner_ingress_from_private_sg_via_ssh" {
   source_security_group_id = "${aws_security_group.cyhy_private_sg.id}"
   from_port = 22
   to_port = 22
+}
+
+# Allow ingress from anywhere via all other tcp ports
+resource "aws_security_group_rule" "scanner_ingress_anywhere_tcp" {
+  count = "${length(local.cyhy_untrusted_ingress_port_ranges)}"
+
+  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port = "${lookup(local.cyhy_untrusted_ingress_port_ranges[count.index], "start")}"
+  to_port = "${lookup(local.cyhy_untrusted_ingress_port_ranges[count.index], "end")}"
+}
+
+# Allow ingress from anywhere via all udp ports
+resource "aws_security_group_rule" "scanner_ingress_anywhere_udp" {
+  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
+  type = "ingress"
+  protocol = "udp"
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port = 0
+  to_port = 0
+}
+
+# Allow ingress from anywhere via all icmp ports
+resource "aws_security_group_rule" "scanner_ingress_anywhere_icmp" {
+  security_group_id = "${aws_security_group.cyhy_scanner_sg.id}"
+  type = "ingress"
+  protocol = "icmp"
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port = -1
+  to_port = -1
 }
 
 # Allow egress anywhere via all ports and protocols, since we're

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   production_workspace = "${replace(terraform.workspace, "production", "") != terraform.workspace}"
 
   # TODO no dynamic workspace until we can loop modules (see below)
-  nmap_instance_count = "10"   #"${local.production_workspace ? 32 : 1}"
+  nmap_instance_count = "24"  #"${local.production_workspace ? 32 : 1}"
   nessus_instance_count = "1" #"${local.production_workspace ? 4 : 1}"
   mongo_instance_count = "1"  # TODO: stuck at one until we can scale mongo_ec2
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   production_workspace = "${replace(terraform.workspace, "production", "") != terraform.workspace}"
 
   # TODO no dynamic workspace until we can loop modules (see below)
-  nmap_instance_count = "4"   #"${local.production_workspace ? 32 : 1}"
+  nmap_instance_count = "10"   #"${local.production_workspace ? 32 : 1}"
   nessus_instance_count = "1" #"${local.production_workspace ? 4 : 1}"
   mongo_instance_count = "1"  # TODO: stuck at one until we can scale mongo_ec2
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -15,6 +15,14 @@ locals {
     8834
   ]
 
+  # These are the port ranges via which anyone is allowed to
+  # access the public-facing CyHy hosts
+  cyhy_untrusted_ingress_port_ranges = [
+    {start = 1, end = 21},
+    {start = 23, end = 8833},
+    {start = 8835, end = 65535}
+  ]
+
   # These are the ports on which the BOD Docker security group is
   # allowed to egress anywhere
   bod_docker_egress_anywhere_ports = [

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   production_workspace = "${replace(terraform.workspace, "production", "") != terraform.workspace}"
 
   # TODO no dynamic workspace until we can loop modules (see below)
-  nmap_instance_count = "1"   #"${local.production_workspace ? 32 : 1}"
+  nmap_instance_count = "4"   #"${local.production_workspace ? 32 : 1}"
   nessus_instance_count = "1" #"${local.production_workspace ? 4 : 1}"
   mongo_instance_count = "1"  # TODO: stuck at one until we can scale mongo_ec2
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,3 +5,6 @@ provider "aws" {
 
 # The AWS account ID being used
 data "aws_caller_identity" "current" {}
+
+# The list of available AWS availability zones
+data "aws_availability_zones" "all" {}


### PR DESCRIPTION
* Change to 16 jobs-per-nmap-host and 8 jobs-per-nessus-host for further Production testing
* Switch to smaller nmap EC2 instance type (t2.large -> t2.medium)
* Modify scanner security group to allow all traffic on non-SSH/Nessus ports to try to avoid connection table saturation (see https://aerissecure.com/blog/vulnerability-scanning-from-aws/)