### PR TITLE
Grab the master report password from S3 and add it to cyhy.conf

### DIFF
--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -2,23 +2,29 @@
 # tasks file for cyhy_reporter
 
 #
-# Replace commander.conf password
+# Grab mongo users and master report password
 #
-- name: Grab mongo users from S3
+- name: Grab mongo users and master report password from S3
   local_action:
     module: aws_s3
     bucket: ncats-cyhy-secrets
-    object: mongo_users.yml
-    dest: /tmp/mongo_users.yml
+    object: "{{ item }}"
+    dest: "/tmp/{{ item }}"
     mode: get
   become: no
+  loop:
+    - mongo_users.yml
+    - master_report_password.yml
 
-- name: Load mongo users token from YML file
+- name: Load mongo users and master report password from YML files
   local_action:
     module: include_vars
-    file: /tmp/mongo_users.yml
-    name: mongo_users
+    file: "/tmp/{{ item }}"
+    name: "{{ item | regex_replace('^(.*).yml$', '\\1') }}"
   become: no
+  loop:
+    - mongo_users.yml
+    - master_report_password.yml
 
 #
 # Set up /etc/cyhy/cyhy.conf
@@ -38,7 +44,7 @@
       [DEFAULT]
       default-section = cyhy
       database-uri = mongodb://localhost:27017/
-      report-key =
+      report-key = {{ master_report_password.password }}
 
       [cyhy]
       database-uri = mongodb://commander:{{ mongo_users.other_users | selectattr("user", "eq", "commander") | map(attribute="password") | first }}@database1:27017/cyhy
@@ -51,12 +57,15 @@
 #
 # Cleanup
 #
-- name: Delete /tmp/mongo_users.yml
+- name: Delete /tmp/mongo_users.yml and /tmp/master_report_password.yml
   local_action:
     module: file
-    path: /tmp/mongo_users.yml
+    path: "{{ item }}"
     state: absent
   become: no
+  loop:
+    - /tmp/mongo_users.yml
+    - /tmp/master_report_password.yml
 
 #
 # Add users to the cyhy group

--- a/packer/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -87,6 +87,7 @@
       - texlive
       - texlive-fonts-extra
       - texlive-latex-extra
+      - texlive-science
       - texlive-xetex
     state: latest
 


### PR DESCRIPTION
I also installed `texlive-science` in the `cyhy-reports` AMI, since it contains a font that is used in the scorecard.