### PR TITLE
Pipe (cron) cyhy-nvdsync output to /usr/bin/logger so it ends up in /…

### DIFF
--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -205,4 +205,4 @@
     hour: 23
     minute: 15
     user: cyhy
-    job: cyhy-nvdsync --use-network
+    job: cyhy-nvdsync --use-network 2>&1 | /usr/bin/logger -t cyhy-nvdsync


### PR DESCRIPTION
…var/log/syslog