### PR TITLE
Improvement/better egress pub

### DIFF
--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -43,7 +43,7 @@ resource "aws_instance" "cyhy_nessus" {
 
   user_data = "${data.template_cloudinit_config.cyhy_ssh_cloud_init_tasks.rendered}"
 
-  tags = "${merge(var.tags, map("Name", "CyHy Nessus"))}"
+  tags = "${merge(var.tags, map("Name", format("CyHy Nessus - vulnscan%d", count.index+1), "Publish Egress", "True"))}"
   volume_tags = "${merge(var.tags, map("Name", "CyHy Nessus"))}"
 
   # If the instance is destroyed we will have to reset the license to nessus

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -45,7 +45,7 @@ resource "aws_instance" "cyhy_nmap" {
 
   user_data = "${data.template_cloudinit_config.ssh_and_cyhy_runner_cloud_init_tasks.rendered}"
 
-  tags = "${merge(var.tags, map("Name", "CyHy Nmap"))}"
+  tags = "${merge(var.tags, map("Name", format("CyHy Nmap - portscan%d", count.index+1), "Publish Egress", "True"))}"
   volume_tags = "${merge(var.tags, map("Name", "CyHy Nmap"))}"
 }
 

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -1,9 +1,30 @@
 #!/usr/bin/env python3
 import boto3
 from datetime import datetime
+import re
 
+'''
+This script will gather and publish the public ips of ec2 instances that
+have been tagged for publication.
+'''
+
+# name of the bucket to publish into
 BUCKET_NAME = 's3-cdn.rules.ncats.cyber.dhs.gov'
+
+# the domain where the published files are located
 DOMAIN = 'rules.ncats.cyber.dhs.gov'
+
+# an AWS-style filter definition to limit the queried regions
+REGION_FILTERS = [{'Name':'endpoint', 'Values':['*.us-*']}]
+
+# the instance tag used to designate that a public ip should be published
+PUBLISH_EGRESS_TAG = 'Publish Egress'
+
+# the instance tag that will contain the application associated with an instance
+APPLICATION_TAG = 'Application'
+
+
+# the header template for each file
 HEADER = '''###
 # https://{domain}/{filename}
 # {timestamp}
@@ -12,31 +33,33 @@ HEADER = '''###
 # Please contact ncats@hq.dhs.gov with any questions
 ###
 '''
-REGION_FILTERS = [{'Name':'endpoint', 'Values':['*.us-*']}]
+
+# A list of dictionaries that define the files to be created and published.
+# When an ip is to be published, its assoicated application is compared to the
+# app_regex field.  If it matches it will be included in the associated
+# filename.
 
 FILE_CONFIGS = \
-    {   'all.txt': {
-            'static_ips':   ('64.69.57.0/24',),
-            'filters':      [{'Name': 'instance-state-name', 'Values': ['running']}],
-            'description':  'This file contains a consolidated list of all the IP addresses that NCATS is currently using for external scanning.'
-            },
-        'cyhy.txt':
-            {
-            'static_ips':   (),
-            'filters':  [   {'Name': 'instance-state-name', 'Values': ['running']},
-                            {'Name': 'tag:Application', 'Values': ['Cyber Hygiene','Manual Cyber Hygiene']},
-                        ],
-            'description':  'This file contains a list of all IPs used for Cyber Hygiene scanning.'
-            },
-        'pca.txt':  {
-            'static_ips':   (),
-            'filters':  [
-                            {'Name': 'instance-state-name', 'Values': ['running']},
-                            {'Name': 'tag:Application', 'Values': ['Phishing Campaign Assessment']},
-                        ],
-            'description':  'This file contains a list of all IPs used for Phishing Campaign Assessments'
-            },
-        }
+    [   {
+        'filename':     'all.txt',
+        'app_regex':    re.compile('.*'),
+        'static_ips':   ('64.69.57.0/24',),
+        'description':  'This file contains a consolidated list of all the IP addresses that NCATS is currently using for external scanning.'
+        },
+        {
+        'filename':     'cyhy.txt',
+        'app_regex':    re.compile('(Manual )?Cyber Hygiene$'),
+        'static_ips':   (),
+        'description':  'This file contains a list of all IPs used for Cyber Hygiene scanning.'
+        },
+        {
+        'filename':     'pca.txt',
+        'app_regex':    re.compile('Phishing Campaign Assessment$'),
+        'static_ips':   (),
+        'description':  'This file contains a list of all IPs used for Phishing Campaign Assessments'
+        },
+    ]
+
 
 def get_ec2_regions():
     '''get a filtered list of all the regions with ec2 support'''
@@ -46,23 +69,29 @@ def get_ec2_regions():
     result = [x['RegionName'] for x in response['Regions']]
     return result
 
-def get_ec2_ips(region, filters):
-    '''create a set of public IPs for the given region'''
+def get_ec2_ips(region):
+    '''create a set of public IPs for the given region
+       yields (application tag value, public_ip) tuples'''
 
     ec2 = boto3.resource('ec2', region_name=region)
-    instances = ec2.instances.filter(Filters=filters)
+    instances = ec2.instances.filter(Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
 
-    ips = set()
     for instance in instances:
+        # if the instance doesn't have a public ip we can skip
         if instance.public_ip_address == None:
             continue
-        #print('\t', instance.id, instance.instance_type, instance.public_ip_address)
-        ips.add(instance.public_ip_address)
-    return ips
+        # convert tags from aws dict into a real dictionary
+        tags = {x['Key']:x['Value'] for x in instance.tags}
+        # if the publish egress tag isn't set to True we can skip
+        if tags.get(PUBLISH_EGRESS_TAG, str(False)) != str(True):
+            continue
+        # send back a tuple associating the public ip to an application
+        # if application is unset use '', because we still want it in our "all" list
+        yield (tags.get(APPLICATION_TAG, ''), instance.public_ip_address)
 
 def update_bucket(bucket_name, filename, bucket_contents):
     '''update the s3 bucket with the new contents'''
-
+    return #DEBUG
     s3 = boto3.resource('s3')
 
     # get the bucket
@@ -90,37 +119,38 @@ def main():
     # start up message
     print('gathering public ips from %d regions' % len(all_regions))
 
-    # initialize a set for each publication in a dictionary
-    ip_sets = {k:set((FILE_CONFIGS[k]['static_ips'])) for k in FILE_CONFIGS.keys()}
+    # initialize a set to accumulate ips for each file
+    for config in FILE_CONFIGS:
+        config['ip_set'] = set(config['static_ips'])
 
     # loop through the region list and fetch the public ec2 ips
     for region in all_regions:
         print('querying region: %s' % region)
-        for (filename, config) in FILE_CONFIGS.items():
-            # get the public ips that match the filter for this configuration
-            public_ips = get_ec2_ips(region, config['filters'])
-            print('\t', filename, ':\t', len(public_ips))
-            # add the matching ips to the ip set for this file
-            ip_sets[filename].update(public_ips)
+        # get the public ips of instances that are tagged to be published
+        for application_tag, public_ip in get_ec2_ips(region):
+            # loop through all regexs and add ip to set if matched
+            for config in FILE_CONFIGS:
+                if config['app_regex'].match(application_tag):
+                    config['ip_set'].add(public_ip)
 
     # use a single timestamp for all files
     now = '{0:%a %b %d %H:%M:%S UTC %Y}'.format(datetime.utcnow())
 
     # update each file in the bucket
-    for (filename, config) in FILE_CONFIGS.items():
+    for config in FILE_CONFIGS:
         # initialize bucket contents
         bucket_contents = HEADER
-        for ip in sorted(ip_sets[filename]):
+        for ip in sorted(config['ip_set']):
             bucket_contents += ip + '\n'
 
         # fill in template
         bucket_contents = bucket_contents.format(domain=DOMAIN,
-                                                 filename=filename,
+                                                 filename=config['filename'],
                                                  timestamp=now,
                                                  description=config['description'])
 
         # send the contents to the s3 bucket
-        update_bucket(BUCKET_NAME, filename, bucket_contents)
+        update_bucket(BUCKET_NAME, config['filename'], bucket_contents)
 
         # print the contents for the user
         print()

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -4,42 +4,63 @@ from datetime import datetime
 
 BUCKET_NAME = 's3-cdn.rules.ncats.cyber.dhs.gov'
 DOMAIN = 'rules.ncats.cyber.dhs.gov'
-STATIC_IPS = ('64.69.57.0/24',)
-FILE_NAME = 'all.txt'
 HEADER = '''###
 # https://{domain}/{filename}
 # {timestamp}
 # DHS National Cybersecurity Assessments & Technical Services (NCATS)
-# This file contains a consolidated list of all the IP addresses that NCATS is
-# currently using for external scanning.
+# {description}
 # Please contact ncats@hq.dhs.gov with any questions
 ###
 '''
+REGION_FILTERS = [{'Name':'endpoint', 'Values':['*.us-*']}]
 
-def all_ec2_regions():
-    '''get a list of all the regions with ec2 support'''
+FILE_CONFIGS = \
+    {   'all.txt': {
+            'static_ips':   ('64.69.57.0/24',),
+            'filters':      [{'Name': 'instance-state-name', 'Values': ['running']}],
+            'description':  'This file contains a consolidated list of all the IP addresses that NCATS is currently using for external scanning.'
+            },
+        'cyhy.txt':
+            {
+            'static_ips':   (),
+            'filters':  [   {'Name': 'instance-state-name', 'Values': ['running']},
+                            {'Name': 'tag:Application', 'Values': ['Cyber Hygiene','Manual Cyber Hygiene']},
+                        ],
+            'description':  'This file contains a list of all IPs used for Cyber Hygiene scanning.'
+            },
+        'pca.txt':  {
+            'static_ips':   (),
+            'filters':  [
+                            {'Name': 'instance-state-name', 'Values': ['running']},
+                            {'Name': 'tag:Application', 'Values': ['Phishing Campaign Assessment']},
+                        ],
+            'description':  'This file contains a list of all IPs used for Phishing Campaign Assessments'
+            },
+        }
+
+def get_ec2_regions():
+    '''get a filtered list of all the regions with ec2 support'''
 
     ec2 = boto3.client('ec2')
-    response = ec2.describe_regions()
+    response = ec2.describe_regions(Filters=REGION_FILTERS)
     result = [x['RegionName'] for x in response['Regions']]
     return result
 
-def get_ec2_ips(region):
+def get_ec2_ips(region, filters):
     '''create a set of public IPs for the given region'''
 
     ec2 = boto3.resource('ec2', region_name=region)
-    instances = ec2.instances.filter(
-        Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
+    instances = ec2.instances.filter(Filters=filters)
 
     ips = set()
     for instance in instances:
         if instance.public_ip_address == None:
             continue
-        print('\t', instance.id, instance.instance_type, instance.public_ip_address)
+        #print('\t', instance.id, instance.instance_type, instance.public_ip_address)
         ips.add(instance.public_ip_address)
     return ips
 
-def update_bucket(bucket_name, bucket_contents):
+def update_bucket(bucket_name, filename, bucket_contents):
     '''update the s3 bucket with the new contents'''
 
     s3 = boto3.resource('s3')
@@ -48,7 +69,7 @@ def update_bucket(bucket_name, bucket_contents):
     bucket = s3.Bucket(bucket_name)
 
     # get the object within the bucket
-    b_object = bucket.Object(FILE_NAME)
+    b_object = bucket.Object(filename)
 
     # send the bytes contents to the object in the bucket
     # prevent caching of this object
@@ -63,38 +84,50 @@ def update_bucket(bucket_name, bucket_contents):
 
 
 def main():
-    # initialize the ip set with the static ips
-    ips = set(STATIC_IPS)
-
     # get a list of all the regions
-    all_regions = all_ec2_regions()
+    all_regions = get_ec2_regions()
 
     # start up message
     print('gathering public ips from %d regions' % len(all_regions))
 
+    # initialize a set for each publication in a dictionary
+    ip_sets = {k:set((FILE_CONFIGS[k]['static_ips'])) for k in FILE_CONFIGS.keys()}
+
     # loop through the region list and fetch the public ec2 ips
     for region in all_regions:
         print('querying region: %s' % region)
-        ips.update(get_ec2_ips(region))
+        for (filename, config) in FILE_CONFIGS.items():
+            # get the public ips that match the filter for this configuration
+            public_ips = get_ec2_ips(region, config['filters'])
+            print('\t', filename, ':\t', len(public_ips))
+            # add the matching ips to the ip set for this file
+            ip_sets[filename].update(public_ips)
 
-    # initialize bucket contents
-    bucket_contents = HEADER
-    for ip in sorted(ips):
-        bucket_contents += ip + '\n'
-
-    # fill in template
+    # use a single timestamp for all files
     now = '{0:%a %b %d %H:%M:%S UTC %Y}'.format(datetime.utcnow())
-    bucket_contents = bucket_contents.format(domain=DOMAIN, filename=FILE_NAME, timestamp=now)
 
-    # send the contents to the s3 bucket
-    update_bucket(BUCKET_NAME, bucket_contents)
+    # update each file in the bucket
+    for (filename, config) in FILE_CONFIGS.items():
+        # initialize bucket contents
+        bucket_contents = HEADER
+        for ip in sorted(ip_sets[filename]):
+            bucket_contents += ip + '\n'
 
-    # print the contents for the user
-    print()
-    print('-' * 40)
-    print(bucket_contents)
-    print('-' * 40)
-    print()
+        # fill in template
+        bucket_contents = bucket_contents.format(domain=DOMAIN,
+                                                 filename=filename,
+                                                 timestamp=now,
+                                                 description=config['description'])
+
+        # send the contents to the s3 bucket
+        update_bucket(BUCKET_NAME, filename, bucket_contents)
+
+        # print the contents for the user
+        print()
+        print('-' * 40)
+        print(bucket_contents)
+        print('-' * 40)
+        print()
     print('complete')
 
     #import IPython; IPython.embed() #<<< BREAKPOINT >>>

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -61,11 +61,11 @@ FILE_CONFIGS = \
     ]
 
 
-def get_ec2_regions():
+def get_ec2_regions(filter=None):
     '''get a filtered list of all the regions with ec2 support'''
 
     ec2 = boto3.client('ec2')
-    response = ec2.describe_regions(Filters=REGION_FILTERS)
+    response = ec2.describe_regions(Filters=filter)
     result = [x['RegionName'] for x in response['Regions']]
     return result
 
@@ -114,17 +114,17 @@ def update_bucket(bucket_name, filename, bucket_contents):
 
 def main():
     # get a list of all the regions
-    all_regions = get_ec2_regions()
+    regions = get_ec2_regions(REGION_FILTERS)
 
     # start up message
-    print('gathering public ips from %d regions' % len(all_regions))
+    print('gathering public ips from %d regions' % len(regions))
 
     # initialize a set to accumulate ips for each file
     for config in FILE_CONFIGS:
         config['ip_set'] = set(config['static_ips'])
 
     # loop through the region list and fetch the public ec2 ips
-    for region in all_regions:
+    for region in regions:
         print('querying region: %s' % region)
         # get the public ips of instances that are tagged to be published
         for application_tag, public_ip in get_ec2_ips(region):

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -23,7 +23,6 @@ PUBLISH_EGRESS_TAG = 'Publish Egress'
 # the instance tag that will contain the application associated with an instance
 APPLICATION_TAG = 'Application'
 
-
 # the header template for each file
 HEADER = '''###
 # https://{domain}/{filename}
@@ -110,7 +109,6 @@ def update_bucket(bucket_name, filename, bucket_contents):
     # by default new objects cannot be read by public
     # allow public reads of this object
     b_object.Acl().put(ACL='public-read')
-
 
 def main():
     # get a list of all the regions

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -91,7 +91,7 @@ def get_ec2_ips(region):
 
 def update_bucket(bucket_name, filename, bucket_contents):
     '''update the s3 bucket with the new contents'''
-    return #DEBUG
+
     s3 = boto3.resource('s3')
 
     # get the bucket

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "nessus" {
 
   user_data = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
 
-  tags = "${merge(var.tags, map("Name", format("Manual CyHy Nessus %02d", count.index+1)))}"
+  tags = "${merge(var.tags, map("Name", format("Manual CyHy Nessus %02d", count.index+1), "Publish Egress", "True"))}"
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
Better egress pub is ready.  Only instances that are tagged with `Publish Egress = True` will be published.  

I've manually added the `Publish Egress = True` tags to the instances using the [tag editor](https://resources.console.aws.amazon.com/r/tags).

Several files are now output to the bucket:

- https://rules.ncats.cyber.dhs.gov/all.txt
- https://rules.ncats.cyber.dhs.gov/cyhy.txt
- https://rules.ncats.cyber.dhs.gov/pca.txt

TODO: 

- ~the `Publish Egress` tags need to be added to the PCA terraform project.~
  - See sister pull request: https://github.com/dhs-ncats/pca-teamserver-aws/pull/7
- a history of public IPs needs to be stored