### PR TITLE
add registrations and conditionals to swap creation tasks

### DIFF
--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -3,15 +3,19 @@
 
 - name: Allocate swapfile
   command: fallocate --length {{ swapfile_size }} {{ swapfile_location }} creates={{ swapfile_location }}
+  register: allocate_swapfile
 
 - name: Set swapfile permissions
   file: path={{ swapfile_location }} mode=600
 
 - name: Create swapfile
   command: mkswap {{ swapfile_location }}
+  register: create_swapfile
+  when: allocate_swapfile.changed
 
 - name: Enable swapfile
   command: swapon {{ swapfile_location }}
+  when: create_swapfile.changed
 
 - name: Add swapfile to /etc/fstab
   lineinfile: dest=/etc/fstab line="{{ swapfile_location }}   none    swap    sw    0   0" state=present


### PR DESCRIPTION
fixes #82 

I wasn't expecting the EC2 provisioners to be called more than once on an instance, (or the inquisition).  
