### PR TITLE
Add cyhy_logrotate ansible role.

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -50,6 +50,7 @@
     - chown_cyhy_dirs
     - cyhy_commander
     - { role: swap, swapfile_size: 2GiB}
+    - cyhy_logrotate
 
 - hosts: nmap
   name: Configure nmap scanning hosts
@@ -64,6 +65,7 @@
   become_method: sudo
   roles:
     - chown_cyhy_dirs
+    - cyhy_logrotate
 
 - hosts: nessus
   name: Configure Nessus hosts
@@ -79,6 +81,7 @@
   roles:
     - chown_cyhy_dirs
     - cyhy_reporter
+    - cyhy_logrotate
 
 - hosts: cyhy_bastion
   name: Configure cyhy bastion hosts

--- a/ansible/roles/cyhy_logrotate/README.md
+++ b/ansible/roles/cyhy_logrotate/README.md
@@ -1,0 +1,40 @@
+cyhy_logrotate
+==============
+
+A role for configuring logrotate for cyhy logs.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Here's how to use it in a playbook:
+
+    - hosts: cyhy
+      become: yes
+      become_method: sudo
+      roles:
+         - cyhy_logrotate
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Shane Frasier <jeremy.frasier@beta.dhs.gov>

--- a/ansible/roles/cyhy_logrotate/defaults/main.yml
+++ b/ansible/roles/cyhy_logrotate/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for cyhy_logrotate

--- a/ansible/roles/cyhy_logrotate/files/cyhy
+++ b/ansible/roles/cyhy_logrotate/files/cyhy
@@ -1,0 +1,14 @@
+# Default log rotation / compression keeps 1 year of logs.
+/var/log/cyhy/*.log {
+    su cyhy cyhy
+    daily
+    rotate 365
+    dateext
+    copytruncate
+    delaycompress
+    compress
+    notifempty
+    extension gz
+    sharedscripts
+    missingok
+}

--- a/ansible/roles/cyhy_logrotate/handlers/main.yml
+++ b/ansible/roles/cyhy_logrotate/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for cyhy_logrotate

--- a/ansible/roles/cyhy_logrotate/meta/main.yml
+++ b/ansible/roles/cyhy_logrotate/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/cyhy_logrotate/tasks/main.yml
+++ b/ansible/roles/cyhy_logrotate/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for cyhy_logrotate
+
+- name: Install cyhy logrotate configuration
+  copy:
+    src: cyhy
+    dest: /etc/logrotate.d/cyhy
+    mode: 0644

--- a/ansible/roles/cyhy_logrotate/tasks/main.yml
+++ b/ansible/roles/cyhy_logrotate/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
 # tasks file for cyhy_logrotate
 
+- name: Turn on compression globally for rotated logs
+  lineinfile:
+    dest: /etc/logrotate.conf
+    regexp: '^#compress'
+    state: present
+    line: compress
+
 - name: Install cyhy logrotate configuration
   copy:
     src: cyhy

--- a/ansible/roles/cyhy_logrotate/tests/inventory
+++ b/ansible/roles/cyhy_logrotate/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible/roles/cyhy_logrotate/tests/test.yml
+++ b/ansible/roles/cyhy_logrotate/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - cyhy_logrotate

--- a/ansible/roles/cyhy_logrotate/vars/main.yml
+++ b/ansible/roles/cyhy_logrotate/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for cyhy_logrotate


### PR DESCRIPTION
This configures `logrotate` to rotate all the files that look like `/var/log/cyhy/*.log`.

This pull request resolves #89.