### PR TITLE
Networking changes for FTP

### DIFF
--- a/terraform/bod_docker_security_group_rules.tf
+++ b/terraform/bod_docker_security_group_rules.tf
@@ -8,7 +8,7 @@ resource "aws_security_group_rule" "docker_ssh_ingress_from_bastion" {
   to_port = 22
 }
 
-# Allow HTTP, HTTPS, and SMTP (587) egress anywhere
+# Allow HTTP, HTTPS, SMTP (587), and FTP egress anywhere
 resource "aws_security_group_rule" "docker_anywhere" {
   count = "${length(local.bod_docker_egress_anywhere_ports)}"
 

--- a/terraform/bod_docker_security_group_rules.tf
+++ b/terraform/bod_docker_security_group_rules.tf
@@ -22,6 +22,19 @@ resource "aws_security_group_rule" "docker_anywhere" {
   to_port = "${local.bod_docker_egress_anywhere_ports[count.index]}"
 }
 
+# Allow ephemeral port egress to anywhere.  This is necessary for
+# passive FTP to function.
+resource "aws_security_group_rule" "ephemeral_port_egress_anywhere" {
+  security_group_id = "${aws_security_group.bod_docker_sg.id}"
+  type = "egress"
+  protocol = "tcp"
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port = 1024
+  to_port = 65535
+}
+
 # Allow DNS egress to Google
 resource "aws_security_group_rule" "docker_dns_to_google" {
   count = "${length(local.tcp_and_udp)}"

--- a/terraform/bod_private_acl_rules.tf
+++ b/terraform/bod_private_acl_rules.tf
@@ -44,7 +44,7 @@ resource "aws_network_acl_rule" "private_ingress_from_google_dns_via_ephemeral_p
   to_port = 65535
 }
 
-# Allow outbound HTTP, HTTPS, and SMTP (587) anywhere
+# Allow outbound HTTP, HTTPS, SMTP (587), and FTP anywhere
 resource "aws_network_acl_rule" "private_egress_anywhere" {
   count = "${length(local.bod_docker_egress_anywhere_ports)}"
 

--- a/terraform/bod_private_acl_rules.tf
+++ b/terraform/bod_private_acl_rules.tf
@@ -84,14 +84,16 @@ resource "aws_network_acl_rule" "private_egress_to_google_dns_2" {
   to_port = 53
 }
 
-# Allow egress to the public subnet via ephemeral ports
+# Allow egress anywhere via ephemeral ports.  We could get away with
+# restricting this to the public subnet, except that FTP in passive
+# mode needs to be able to reach out anywhere.
 resource "aws_network_acl_rule" "private_egress_to_public_via_ephemeral_ports" {
   network_acl_id = "${aws_network_acl.bod_private_acl.id}"
   egress = true
   protocol = "tcp"
   rule_number = 140
   rule_action = "allow"
-  cidr_block = "${aws_subnet.bod_public_subnet.cidr_block}"
+  cidr_block = "0.0.0.0/0"
   from_port = 1024
   to_port = 65535
 }

--- a/terraform/bod_public_acl_rules.tf
+++ b/terraform/bod_public_acl_rules.tf
@@ -1,8 +1,9 @@
 # Allow ingress from the private subnet via HTTP (for downloading the
 # public suffix list), HTTPS (for AWS CLI), SMTP (for sending emails),
-# and DNS (for Google DNS).  This allows EC2 instances in the private
-# subnet to send the traffic they want via the NAT gateway, subject to
-# their own security group and network ACL restrictions.
+# FTP (for downloading ASN information), and DNS (for Google DNS).
+# This allows EC2 instances in the private subnet to send the traffic
+# they want via the NAT gateway, subject to their own security group
+# and network ACL restrictions.
 resource "aws_network_acl_rule" "public_ingress_from_private" {
   count = "${length(local.bod_docker_egress_anywhere_ports)}"
 
@@ -104,9 +105,9 @@ resource "aws_network_acl_rule" "public_egress_to_bastion_via_ssh" {
 }
 
 # Allow egress anywhere via HTTP (for downloading the public suffix
-# list), HTTPS (for AWS CLI) and SMTP (for sending emails).  This is
-# so the NAT gateway can relay the corresponding requests from the
-# private subnet.
+# list), HTTPS (for AWS CLI), SMTP (for sending emails), and FTP (for
+# downloading ASN information).  This is so the NAT gateway can relay
+# the corresponding requests from the private subnet.
 resource "aws_network_acl_rule" "public_egress_anywhere" {
   count = "${length(local.bod_docker_egress_anywhere_ports)}"
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -25,6 +25,7 @@ locals {
   # These are the ports on which the BOD Docker security group is
   # allowed to egress anywhere
   bod_docker_egress_anywhere_ports = [
+    21,
     80,
     443,
     587


### PR DESCRIPTION
As part of the incorporation of DMARC information into the Trustworthy Email reports, the BOD Docker host needs to be able to retrieve ASN data via FTP.  These changes allow that to happen.