### PR TITLE
Only create cron jobs in production workspaces

### DIFF
--- a/ansible/roles/bod_docker/tasks/main.yml
+++ b/ansible/roles/bod_docker/tasks/main.yml
@@ -205,6 +205,7 @@
     name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     user: cyhy
+  when: production_workspace
 # This cron job runs at midnight UTC on Saturday mornings, so it
 # should be done by 2PM on Saturday.
 - name: Create a cron job for BOD 18-01 scanning
@@ -215,6 +216,7 @@
     weekday: 6
     user: cyhy
     job: cd /var/cyhy/orchestrator && docker-compose up -d 2>&1 | /usr/bin/logger -t orchestrator
+  when: production_workspace
 # This cron job runs at noon UTC on Mondays.  The BOD reports are long
 # since completed by that time.
 - name: Create a cron job for sending BOD 18-01 reports
@@ -225,6 +227,7 @@
     weekday: 1
     user: cyhy
     job: cd /var/cyhy/cyhy-mailer && docker-compose up -d 2>&1 | /usr/bin/logger -t cyhy-mailer
+  when: production_workspace
 
 
 #

--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -76,8 +76,9 @@
     name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     user: cyhy
+  when: production_workspace
 # This cron job runs at midnight UTC on Sunday mornings.  The BOD
-# scanning is long cince completed by that time.
+# scanning is long since completed by that time.
 - name: Create a cron job for report generation
   cron:
     name: "Snapshot, CyHy report, and CybEx scorecard generation"
@@ -86,6 +87,7 @@
     weekday: 0
     user: cyhy
     job: cd /var/cyhy/reports && ./create_snapshots_reports_scorecard.py --no-dock cyhy scan 2>&1 | /usr/bin/logger -t cyhy-reports
+  when: production_workspace
 
 #
 # Add users to the cyhy group

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -59,7 +59,8 @@ module "bod_docker_ansible_provisioner" {
     "host=${aws_instance.bod_docker.private_ip}",
     "bastion_host=${aws_instance.bod_bastion.public_ip}",
     "host_groups=docker,bod_docker",
-    "mongo_host=${aws_instance.cyhy_mongo.private_ip}"
+    "mongo_host=${aws_instance.cyhy_mongo.private_ip}",
+    "production_workspace=${local.production_workspace}"
   ]
   playbook = "../ansible/playbook.yml"
   dry_run = false

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -63,6 +63,7 @@ module "cyhy_reporter_ansible_provisioner" {
     "host=${aws_instance.cyhy_reporter.private_ip}",
     "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_reporter",
+    "production_workspace=${local.production_workspace}",
     # We want to force ansible to rerun when the instance is recreated
     "instance_arn=${aws_instance.cyhy_reporter.arn}"
   ]


### PR DESCRIPTION
Modify Ansible code to only create CyHy reporter and BOD docker cron jobs for production workspaces.