### PR TITLE
The root filesystem for the BOD Docker instance needs to be larger

### DIFF
--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -33,7 +33,7 @@ resource "aws_instance" "bod_docker" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 10
+    volume_size = 200
     delete_on_termination = true
   }
 


### PR DESCRIPTION
The root filesystem for the BOD Docker instance needs to be large enough to hold all the data that docker creates.

I noticed this because the BOD scanning failed this weekend for this very reason.

I want to revert to a large drive for now, and I created #116 so we can go back later and reduce it to what is necessary.