### PR TITLE
Allow for variable device names

### DIFF
--- a/ansible/roles/bod_docker/tasks/main.yml
+++ b/ansible/roles/bod_docker/tasks/main.yml
@@ -219,15 +219,15 @@
   when: production_workspace
 # This cron job runs at noon UTC on Mondays.  The BOD reports are long
 # since completed by that time.
-- name: Create a cron job for sending BOD 18-01 reports
-  cron:
-    name: "Sending BOD 18-01 reports"
-    minute: 0
-    hour: 12
-    weekday: 1
-    user: cyhy
-    job: cd /var/cyhy/cyhy-mailer && docker-compose up -d 2>&1 | /usr/bin/logger -t cyhy-mailer
-  when: production_workspace
+# - name: Create a cron job for sending BOD 18-01 reports
+#   cron:
+#     name: "Sending BOD 18-01 reports"
+#     minute: 0
+#     hour: 12
+#     weekday: 1
+#     user: cyhy
+#     job: cd /var/cyhy/cyhy-mailer && docker-compose up -d 2>&1 | /usr/bin/logger -t cyhy-mailer
+#   when: production_workspace
 
 
 #

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -83,11 +83,14 @@
     - pip
     - cyhy_commander
 
+# In production, the CyHy reporter instance is a c5 instance type.
+# These instance types expose EBS volumes as NVMe block devices.
 - hosts: cyhy_reporter
   name: Install and configure cyhy-reports
   become: yes
   become_method: sudo
   roles:
+    - nvme
     - xfs
     - pip
     - cyhy_reporter

--- a/packer/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -182,13 +182,6 @@
     path: /var/cyhy/reports/output
     state: directory
 
-# In production, the CyHy reporter instance is a c5 instance type.
-# These instance types expose EBS volumes as NVMe blovck devices.
-- name: Install nvme-cli
-  package:
-    name: nvme-cli
-    state: latest
-
 #
 # Cleanup
 #

--- a/packer/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -165,8 +165,7 @@
 # rsync is required by synchronize
 - name: Install rsync
   package:
-    name:
-      - rsync
+    name: rsync
     state: latest
 
 - name: Copy the cyhy-reports fonts
@@ -182,6 +181,13 @@
   file:
     path: /var/cyhy/reports/output
     state: directory
+
+# In production, the CyHy reporter instance is a c5 instance type.
+# These instance types expose EBS volumes as NVMe blovck devices.
+- name: Install nvme-cli
+  package:
+    name: nvme-cli
+    state: latest
 
 #
 # Cleanup

--- a/packer/ansible/roles/nvme/README.md
+++ b/packer/ansible/roles/nvme/README.md
@@ -1,0 +1,41 @@
+nvme
+====
+
+A role for installing tools to deal with NVMe (Non-volatile memory
+express) devices.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Here's how to use it in a playbook:
+
+    - hosts: nvme-hosts
+      become: yes
+      become_method: sudo
+      roles:
+         - nvme
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Shane Frasier <jeremy.frasier@beta.dhs.gov>

--- a/packer/ansible/roles/nvme/defaults/main.yml
+++ b/packer/ansible/roles/nvme/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for nvme

--- a/packer/ansible/roles/nvme/handlers/main.yml
+++ b/packer/ansible/roles/nvme/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for nvme

--- a/packer/ansible/roles/nvme/meta/main.yml
+++ b/packer/ansible/roles/nvme/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/packer/ansible/roles/nvme/tasks/main.yml
+++ b/packer/ansible/roles/nvme/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+# tasks file for nvme
+
+- name: Install nvme-cli
+  package:
+    name: nvme-cli
+    state: latest

--- a/packer/ansible/roles/nvme/tests/inventory
+++ b/packer/ansible/roles/nvme/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/packer/ansible/roles/nvme/tests/test.yml
+++ b/packer/ansible/roles/nvme/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - nvme

--- a/packer/ansible/roles/nvme/vars/main.yml
+++ b/packer/ansible/roles/nvme/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for nvme

--- a/terraform/reporter_cloud_init.tf
+++ b/terraform/reporter_cloud_init.tf
@@ -2,6 +2,10 @@
 
 data "template_file" "reporter_disk_setup" {
   template = "${file("scripts/reporter_disk_setup.yml")}"
+
+  vars {
+    device = "${local.production_workspace ? "/dev/nvme1n1" : "/dev/xvdb"}"
+  }
 }
 
 data "template_cloudinit_config" "ssh_and_reporter_cloud_init_tasks" {

--- a/terraform/scripts/reporter_disk_setup.yml
+++ b/terraform/scripts/reporter_disk_setup.yml
@@ -3,17 +3,17 @@
 mounts:
   # Add new mount to /etc/fstab, but don't automatically mount it.  We
   # must handle nested mounts in bootcmd section below
-  - [ /dev/xvdb, /var/cyhy/reports/output, xfs, 'defaults,noauto', '0', '2' ]
+  - [ ${device}, /var/cyhy/reports/output, xfs, 'defaults,noauto', '0', '2' ]
 
 bootcmd:
   # Wait for EBS disks to be attached
   - 'while [ `lsblk | grep -c " disk"` -lt 2 ]; do echo Waiting for disks to attach...; sleep 5; done'
   # Format filesystem on each EBS volume (if one was not already there)
   # fs_setup does not honor the overwrite argument.  Always in full-cowboy mode. (v0.7.9)
-  - 'blkid -c /dev/null /dev/xvdb || mkfs.xfs /dev/xvdb -L report_data'
+  - 'blkid -c /dev/null ${device} || mkfs.xfs ${device} -L report_data'
   # Mount report volumes and set ownership.  Due to funky timing of
   # mounts vs. bootcmd, we have to specify the full mount commands.
-  - 'mount --verbose --types xfs /dev/xvdb /var/cyhy/reports/output'
+  - 'mount --verbose --types xfs ${device} /var/cyhy/reports/output'
 
 output:
   - all: '| tee -a /var/log/cloud-init-output.log'


### PR DESCRIPTION
Certain AWS instance types present EBS volumes as NVMe devices, which means that the device name for the EBS volume can change depending on the underlying AWS instance type.  This was biting us with the CyHy reporter instance, since in production is uses a c5 instance type.

This code handles this by using the device name `/dev/xvdb` if we are not in a production workspace and `/dev/nvme1n1` if we are.