### PR TITLE
No more static IPs for the CyHy VPC

### DIFF
--- a/terraform/bod_private_dns.tf
+++ b/terraform/bod_private_dns.tf
@@ -65,9 +65,9 @@ resource "aws_route53_record" "bod_docker_A" {
 resource "aws_route53_zone" "bod_public_zone_reverse" {
   # NOTE:  This assumes that we are using /24 blocks
   name = "${format("%s.%s.%s.in-addr.arpa.",
-    element( split(".", aws_subnet.bod_public_subnet.cidr_block) ,2),
-    element( split(".", aws_subnet.bod_public_subnet.cidr_block) ,1),
-    element( split(".", aws_subnet.bod_public_subnet.cidr_block) ,0),
+    element( split(".", aws_subnet.bod_public_subnet.cidr_block), 2),
+    element( split(".", aws_subnet.bod_public_subnet.cidr_block), 1),
+    element( split(".", aws_subnet.bod_public_subnet.cidr_block), 0),
   )}"
 
   vpc_id = "${aws_vpc.bod_vpc.id}"
@@ -108,10 +108,10 @@ resource "aws_route53_record" "bod_rev_3_PTR" {
 resource "aws_route53_record" "bod_rev_bastion_PTR" {
   zone_id = "${aws_route53_zone.bod_public_zone_reverse.zone_id}"
   name = "${format("%s.%s.%s.%s.in-addr.arpa.",
-    element( split(".", aws_instance.bod_bastion.private_ip) ,3),
-    element( split(".", aws_instance.bod_bastion.private_ip) ,2),
-    element( split(".", aws_instance.bod_bastion.private_ip) ,1),
-    element( split(".", aws_instance.bod_bastion.private_ip) ,0),
+    element( split(".", aws_instance.bod_bastion.private_ip), 3),
+    element( split(".", aws_instance.bod_bastion.private_ip), 2),
+    element( split(".", aws_instance.bod_bastion.private_ip), 1),
+    element( split(".", aws_instance.bod_bastion.private_ip), 0),
   )}"
   type = "PTR"
   ttl = 300
@@ -127,9 +127,9 @@ resource "aws_route53_record" "bod_rev_bastion_PTR" {
 resource "aws_route53_zone" "bod_private_zone_reverse" {
   # NOTE:  This assumes that we are using /24 blocks
   name = "${format("%s.%s.%s.in-addr.arpa.",
-    element( split(".", aws_subnet.bod_private_subnet.cidr_block) ,2),
-    element( split(".", aws_subnet.bod_private_subnet.cidr_block) ,1),
-    element( split(".", aws_subnet.bod_private_subnet.cidr_block) ,0),
+    element( split(".", aws_subnet.bod_private_subnet.cidr_block), 2),
+    element( split(".", aws_subnet.bod_private_subnet.cidr_block), 1),
+    element( split(".", aws_subnet.bod_private_subnet.cidr_block), 0),
   )}"
 
   vpc_id = "${aws_vpc.bod_vpc.id}"
@@ -140,10 +140,10 @@ resource "aws_route53_zone" "bod_private_zone_reverse" {
 resource "aws_route53_record" "bod_rev_docker_PTR" {
   zone_id = "${aws_route53_zone.bod_private_zone_reverse.zone_id}"
   name = "${format("%s.%s.%s.%s.in-addr.arpa.",
-    element( split(".", aws_instance.bod_docker.private_ip) ,3),
-    element( split(".", aws_instance.bod_docker.private_ip) ,2),
-    element( split(".", aws_instance.bod_docker.private_ip) ,1),
-    element( split(".", aws_instance.bod_docker.private_ip) ,0),
+    element( split(".", aws_instance.bod_docker.private_ip), 3),
+    element( split(".", aws_instance.bod_docker.private_ip), 2),
+    element( split(".", aws_instance.bod_docker.private_ip), 1),
+    element( split(".", aws_instance.bod_docker.private_ip), 0),
   )}"
   type = "PTR"
   ttl = 300

--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -7,7 +7,6 @@ resource "aws_instance" "cyhy_bastion" {
 
   # This is the public subnet
   subnet_id = "${aws_subnet.cyhy_scanner_subnet.id}"
-  private_ip = "${cidrhost(aws_subnet.cyhy_scanner_subnet.cidr_block, local.the_bastion)}"
   associate_public_ip_address = true
 
   root_block_device {

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -21,9 +21,9 @@ data "aws_ami" "cyhy_mongo" {
 }
 
 resource "aws_instance" "cyhy_mongo" {
+  count = "${local.mongo_instance_count}"
   ami = "${data.aws_ami.cyhy_mongo.id}"
   instance_type = "${local.production_workspace ? "m4.10xlarge" : "t2.micro"}"
-  #count = "${local.mongo_instance_count}"
   ebs_optimized = "${local.production_workspace}"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   subnet_id = "${aws_subnet.cyhy_private_subnet.id}"

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -26,13 +26,8 @@ resource "aws_instance" "cyhy_mongo" {
   #count = "${local.mongo_instance_count}"
   ebs_optimized = "${local.production_workspace}"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-
   subnet_id = "${aws_subnet.cyhy_private_subnet.id}"
-  # TODO when we start using multiple mongo, change private_ip calculation below
-  #private_ip = "${cidrhost(aws_subnet.cyhy_private_subnet.cidr_block, count.index + local.first_database)}"
-  private_ip = "${cidrhost(aws_subnet.cyhy_private_subnet.cidr_block, local.first_database)}"
-
-  # associate_public_ip_address = true
+  associate_public_ip_address = false
 
   root_block_device {
     volume_type = "gp2"

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -28,7 +28,6 @@ resource "aws_instance" "cyhy_nessus" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   subnet_id = "${aws_subnet.cyhy_scanner_subnet.id}"
-  private_ip = "${cidrhost(aws_subnet.cyhy_scanner_subnet.cidr_block, count.index + local.first_vuln_scanner)}"
   associate_public_ip_address = true
 
   root_block_device {

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -32,7 +32,6 @@ resource "aws_instance" "cyhy_nmap" {
   # availability_zone = "${element(data.aws_availability_zones.all.names, count.index)}"
 
   subnet_id = "${aws_subnet.cyhy_scanner_subnet.id}"
-  private_ip = "${cidrhost(aws_subnet.cyhy_scanner_subnet.cidr_block, count.index + local.first_port_scanner)}"
 
   associate_public_ip_address = true
 

--- a/terraform/cyhy_private_dns.tf
+++ b/terraform/cyhy_private_dns.tf
@@ -188,6 +188,7 @@ resource "aws_route53_record" "cyhy_rev_reporter_PTR" {
 }
 
 resource "aws_route53_record" "cyhy_rev_database_PTR" {
+  count = "${local.count_database}"
   zone_id = "${aws_route53_zone.cyhy_private_zone_reverse.zone_id}"
   name    = "${format("%s.%s.%s.%s.in-addr.arpa.",
     element(split(".", aws_instance.cyhy_mongo.private_ip), 3),
@@ -197,5 +198,5 @@ resource "aws_route53_record" "cyhy_rev_database_PTR" {
   )}"
   type    = "PTR"
   ttl     = 300
-  records = [ "database1.${local.cyhy_private_domain}." ]
+  records = [ "database${count.index + 1}.${local.cyhy_private_domain}." ]
 }

--- a/terraform/cyhy_private_dns.tf
+++ b/terraform/cyhy_private_dns.tf
@@ -82,9 +82,9 @@ resource "aws_route53_record" "cyhy_vulnscan_A" {
 resource "aws_route53_zone" "cyhy_scanner_zone_reverse" {
   # NOTE:  This assumes that we are using /24 blocks
   name = "${format("%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_subnet.cyhy_scanner_subnet.cidr_block) ,2),
-    element(split(".", aws_subnet.cyhy_scanner_subnet.cidr_block) ,1),
-    element(split(".", aws_subnet.cyhy_scanner_subnet.cidr_block) ,0),
+    element(split(".", aws_subnet.cyhy_scanner_subnet.cidr_block), 2),
+    element(split(".", aws_subnet.cyhy_scanner_subnet.cidr_block), 1),
+    element(split(".", aws_subnet.cyhy_scanner_subnet.cidr_block), 0),
   )}"
 
   vpc_id = "${aws_vpc.cyhy_vpc.id}"
@@ -119,10 +119,10 @@ resource "aws_route53_record" "cyhy_rev_3_PTR" {
 resource "aws_route53_record" "cyhy_rev_bastion_PTR" {
   zone_id = "${aws_route53_zone.cyhy_scanner_zone_reverse.zone_id}"
   name    = "${format("%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.cyhy_bastion.private_ip) ,3),
-    element(split(".", aws_instance.cyhy_bastion.private_ip) ,2),
-    element(split(".", aws_instance.cyhy_bastion.private_ip) ,1),
-    element(split(".", aws_instance.cyhy_bastion.private_ip) ,0),
+    element(split(".", aws_instance.cyhy_bastion.private_ip), 3),
+    element(split(".", aws_instance.cyhy_bastion.private_ip), 2),
+    element(split(".", aws_instance.cyhy_bastion.private_ip), 1),
+    element(split(".", aws_instance.cyhy_bastion.private_ip), 0),
   )}"
   type    = "PTR"
   ttl     = 300
@@ -133,10 +133,10 @@ resource "aws_route53_record" "cyhy_rev_portscan_PTR" {
   count = "${local.count_port_scanner}"
   zone_id = "${aws_route53_zone.cyhy_scanner_zone_reverse.zone_id}"
   name    = "${format("%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)) ,3),
-    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)) ,2),
-    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)) ,1),
-    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)) ,0),
+    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)), 3),
+    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)), 2),
+    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)), 1),
+    element(split(".", element(aws_instance.cyhy_nmap.*.private_ip, count.index)), 0),
   )}"
   type    = "PTR"
   ttl     = 300
@@ -147,10 +147,10 @@ resource "aws_route53_record" "cyhy_rev_vulnscan_PTR" {
   count = "${local.count_vuln_scanner}"
   zone_id = "${aws_route53_zone.cyhy_scanner_zone_reverse.zone_id}"
   name    = "${format("%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)) ,3),
-    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)) ,2),
-    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)) ,1),
-    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)) ,0),
+    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)), 3),
+    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)), 2),
+    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)), 1),
+    element(split(".", element(aws_instance.cyhy_nessus.*.private_ip, count.index)), 0),
   )}"
   type    = "PTR"
   ttl     = 300
@@ -164,9 +164,9 @@ resource "aws_route53_record" "cyhy_rev_vulnscan_PTR" {
 resource "aws_route53_zone" "cyhy_private_zone_reverse" {
   # NOTE:  This assumes that we are using /24 blocks
   name = "${format("%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_subnet.cyhy_private_subnet.cidr_block) ,2),
-    element(split(".", aws_subnet.cyhy_private_subnet.cidr_block) ,1),
-    element(split(".", aws_subnet.cyhy_private_subnet.cidr_block) ,0),
+    element(split(".", aws_subnet.cyhy_private_subnet.cidr_block), 2),
+    element(split(".", aws_subnet.cyhy_private_subnet.cidr_block), 1),
+    element(split(".", aws_subnet.cyhy_private_subnet.cidr_block), 0),
   )}"
 
   vpc_id = "${aws_vpc.cyhy_vpc.id}"
@@ -177,10 +177,10 @@ resource "aws_route53_zone" "cyhy_private_zone_reverse" {
 resource "aws_route53_record" "cyhy_rev_reporter_PTR" {
   zone_id = "${aws_route53_zone.cyhy_private_zone_reverse.zone_id}"
   name    = "${format("%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.cyhy_reporter.private_ip) ,3),
-    element(split(".", aws_instance.cyhy_reporter.private_ip) ,2),
-    element(split(".", aws_instance.cyhy_reporter.private_ip) ,1),
-    element(split(".", aws_instance.cyhy_reporter.private_ip) ,0),
+    element(split(".", aws_instance.cyhy_reporter.private_ip), 3),
+    element(split(".", aws_instance.cyhy_reporter.private_ip), 2),
+    element(split(".", aws_instance.cyhy_reporter.private_ip), 1),
+    element(split(".", aws_instance.cyhy_reporter.private_ip), 0),
   )}"
   type    = "PTR"
   ttl     = 300
@@ -190,10 +190,10 @@ resource "aws_route53_record" "cyhy_rev_reporter_PTR" {
 resource "aws_route53_record" "cyhy_rev_database_PTR" {
   zone_id = "${aws_route53_zone.cyhy_private_zone_reverse.zone_id}"
   name    = "${format("%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.cyhy_mongo.private_ip) ,3),
-    element(split(".", aws_instance.cyhy_mongo.private_ip) ,2),
-    element(split(".", aws_instance.cyhy_mongo.private_ip) ,1),
-    element(split(".", aws_instance.cyhy_mongo.private_ip) ,0),
+    element(split(".", aws_instance.cyhy_mongo.private_ip), 3),
+    element(split(".", aws_instance.cyhy_mongo.private_ip), 2),
+    element(split(".", aws_instance.cyhy_mongo.private_ip), 1),
+    element(split(".", aws_instance.cyhy_mongo.private_ip), 0),
   )}"
   type    = "PTR"
   ttl     = 300

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -29,7 +29,6 @@ resource "aws_instance" "cyhy_reporter" {
 
   # This is the private subnet
   subnet_id = "${aws_subnet.cyhy_private_subnet.id}"
-  private_ip = "${cidrhost(aws_subnet.cyhy_private_subnet.cidr_block, local.the_reporter)}"
   associate_public_ip_address = false
 
   root_block_device {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -63,24 +63,18 @@ locals {
   # otherwise it must end in a period
   bod_public_subdomain = "bod."
 
-  # DNS zone calculations based on requested instances
-  # The numbers represent the count of IP addresses in a subnet
-  # and are used by the cidrhost() function.
-  # NOTE: there is an assumption that subnets are /24 in the reverse zone names
+  # DNS zone calculations based on requested instances.  The numbers
+  # represent the count of IP addresses in a subnet.
+  #
+  # NOTE: there is an assumption that subnets are /24 in the reverse
+  # zone names.
 
   # Port Scanners DNS entries
-  first_port_scanner = 11
   count_port_scanner = "${local.nmap_instance_count}"
 
   # Vulnerability Scanners DNS entries
-  first_vuln_scanner = 201
   count_vuln_scanner = "${local.nessus_instance_count}"
 
   # Database DNS entries
-  first_database = 11
   count_database = "${local.mongo_instance_count}"
-
-  # Singleton DNS entries
-  the_reporter = 6  # there can be only one
-  the_bastion = 254 # there can be only one
 }


### PR DESCRIPTION
I deployed this to the `jsf9k` workspace and it appears to be working fine.  I particularly want @felddy to review this pull request in case there is a good reason to stick with static IPs that I'm missing.