### PR TITLE
Persist journald logs across reboots

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -1,12 +1,13 @@
 ---
 - hosts: all
-  name: Update the base image, install python, add banner
+  name: Update the base image, install python, add banner, persist journald
   become: yes
   become_method: sudo
   roles:
     - upgrade
     - python
     - banner
+    - journald
 
 # The bastion should have as little installed as possible, since it's
 # exposed to the cruel world

--- a/packer/ansible/roles/journald/README.md
+++ b/packer/ansible/roles/journald/README.md
@@ -1,0 +1,40 @@
+journald
+========
+
+A role for configuring journald to persist logs across reboots.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Here's how to use it in a playbook:
+
+    - hosts: all
+      become: yes
+      become_method: sudo
+      roles:
+         - journald
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Shane Frasier <jeremy.frasier@beta.dhs.gov>

--- a/packer/ansible/roles/journald/defaults/main.yml
+++ b/packer/ansible/roles/journald/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for journald

--- a/packer/ansible/roles/journald/handlers/main.yml
+++ b/packer/ansible/roles/journald/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for journald

--- a/packer/ansible/roles/journald/meta/main.yml
+++ b/packer/ansible/roles/journald/meta/main.yml
@@ -1,0 +1,60 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/packer/ansible/roles/journald/tasks/main.yml
+++ b/packer/ansible/roles/journald/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for journald
+
+- name: Configure journald to persist storage
+  lineinfile:
+    dest: /etc/systemd/journald.conf
+    regexp: ^#Storage=
+    state: present
+    line: Storage=persistent

--- a/packer/ansible/roles/journald/tests/inventory
+++ b/packer/ansible/roles/journald/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/packer/ansible/roles/journald/tests/test.yml
+++ b/packer/ansible/roles/journald/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - journald

--- a/packer/ansible/roles/journald/vars/main.yml
+++ b/packer/ansible/roles/journald/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for journald


### PR DESCRIPTION
* Add ansible role to persist journald storage across reboots
* Apply above ansible role to all AMIs

I'll rebuild all the AMIs once this is approved and merged.  I tested it with the bastion hosts in the `jsf9k` workspace.