### PR TITLE
Don't apply journald tweak to the Nessus instance

### DIFF
--- a/packer/ansible/roles/journald/tasks/main.yml
+++ b/packer/ansible/roles/journald/tasks/main.yml
@@ -7,3 +7,5 @@
     regexp: ^#Storage=
     state: present
     line: Storage=persistent
+  when:
+    - ansible_service_mgr == "systemd"


### PR DESCRIPTION
Only apply the changes that persist the `journald` logs to systems that actually run `journald`.