### PR TITLE
Increase root volume sizes

### DIFF
--- a/terraform/bod_bastion_ec2.tf
+++ b/terraform/bod_bastion_ec2.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "bod_bastion" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 8
+    volume_size = 20
     delete_on_termination = true
   }
 

--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "cyhy_bastion" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 8
+    volume_size = 20
     delete_on_termination = true
   }
 

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "cyhy_mongo" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 8
+    volume_size = 10
     delete_on_termination = true
   }
 

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "cyhy_mongo" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 10
+    volume_size = 20
     delete_on_termination = true
   }
 

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -37,7 +37,7 @@ resource "aws_instance" "cyhy_nmap" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = "${local.production_workspace ? 16 : 8}"
+    volume_size = "${local.production_workspace ? 20 : 8}"
     delete_on_termination = true
   }
 

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -33,7 +33,7 @@ resource "aws_instance" "cyhy_reporter" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 8
+    volume_size = 12
     delete_on_termination = true
   }
 

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -33,7 +33,7 @@ resource "aws_instance" "cyhy_reporter" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 12
+    volume_size = 20
     delete_on_termination = true
   }
 


### PR DESCRIPTION
Bump up the size of some root volumes now that we are writing `journald` logs there.

The CyHy Mongo and CyHy reporter root volumes were fullish, so I decided to increase them a little bit.  The other instances appear fine for now.

I'm not against bumping *everyone* up to a 16GB or 20GB root volume, either.  **What do @felddy, @dav3r, and @KyleEvers think makes sense?**