### PR TITLE
Break out cyhy-core install and retrieval of GitHub OAuth token into roles

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -24,7 +24,6 @@
   become_method: sudo
   roles:
     - pip
-    - github_oauth
     - cyhy_runner
     - nmap
     - more_ephemeral_ports
@@ -53,7 +52,6 @@
   become_method: sudo
   roles:
     - pip
-    - github_oauth
     - cyhy_runner
     - more_ephemeral_ports
 
@@ -86,7 +84,6 @@
   become_method: sudo
   roles:
     - pip
-    - github_oauth
     - cyhy_core
     - cyhy_commander
 
@@ -100,7 +97,6 @@
     - nvme
     - xfs
     - pip
-    - github_oauth
     - cyhy_core
     - cyhy_reporter
     - cyhy_mailer
@@ -111,7 +107,6 @@
   become_method: sudo
   roles:
     - pip
-    - github_oauth
     - cyhy_core
     - cyhy_feeds
 
@@ -120,5 +115,4 @@
   become: yes
   become_method: sudo
   roles:
-    - github_oauth
     - cyhy_archive

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -24,6 +24,7 @@
   become_method: sudo
   roles:
     - pip
+    - github_oauth
     - cyhy_runner
     - nmap
     - more_ephemeral_ports
@@ -52,6 +53,7 @@
   become_method: sudo
   roles:
     - pip
+    - github_oauth
     - cyhy_runner
     - more_ephemeral_ports
 
@@ -84,6 +86,8 @@
   become_method: sudo
   roles:
     - pip
+    - github_oauth
+    - cyhy_core
     - cyhy_commander
 
 # In production, the CyHy reporter instance is a c5 instance type.
@@ -96,6 +100,8 @@
     - nvme
     - xfs
     - pip
+    - github_oauth
+    - cyhy_core
     - cyhy_reporter
     - cyhy_mailer
 
@@ -105,6 +111,8 @@
   become_method: sudo
   roles:
     - pip
+    - github_oauth
+    - cyhy_core
     - cyhy_feeds
 
 - hosts: cyhy_archive
@@ -112,4 +120,5 @@
   become: yes
   become_method: sudo
   roles:
+    - github_oauth
     - cyhy_archive

--- a/packer/ansible/roles/cyhy_archive/README.md
+++ b/packer/ansible/roles/cyhy_archive/README.md
@@ -1,31 +1,34 @@
-Role Name
-=========
+cyhy_archive
+============
 
-A brief description of the role goes here.
+A role for installing cyhy-archive.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+None
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+None
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+- github_oauth
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+Here's how to use it in a playbook:
 
-    - hosts: servers
+    - hosts: archivers
+      become: yes
+      become_method: sudo
       roles:
-         - { role: username.rolename, x: 42 }
+        - github_oauth
+        - cyhy_archive
 
 License
 -------
@@ -35,4 +38,4 @@ BSD
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+David Redmin <david.redmin@beta.dhs.gov>

--- a/packer/ansible/roles/cyhy_archive/meta/main.yml
+++ b/packer/ansible/roles/cyhy_archive/meta/main.yml
@@ -52,6 +52,5 @@ galaxy_info:
     # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
     #       Maximum 20 tags per role.
 
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+dependencies:
+  - {role: github_oauth}

--- a/packer/ansible/roles/cyhy_archive/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_archive/tasks/main.yml
@@ -1,21 +1,6 @@
 ---
 # tasks file for cyhy_archive
 
-- name: Grab GitHub OAuth token from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: github_oauth_token.yml
-    dest: /tmp/github_oauth_token.yml
-    mode: get
-  become: no
-
-- name: Load GitHub OAuth token from YML file
-  local_action:
-    module: include_vars
-    file: /tmp/github_oauth_token.yml
-  become: no
-
 - name: Create the /var/cyhy/scripts directory
   file:
     path: /var/cyhy/scripts
@@ -28,11 +13,3 @@
       Authorization: "token {{ github_oauth_token }}"
     dest: /var/cyhy/scripts/cyhy_archive.sh
     mode: 0755
-
-# Clean up
-- name: Delete local copy of GitHub OAuth token
-  local_action:
-    module: file
-    path: /tmp/github_oauth_token.yml
-    state: absent
-  become: no

--- a/packer/ansible/roles/cyhy_commander/README.md
+++ b/packer/ansible/roles/cyhy_commander/README.md
@@ -16,7 +16,8 @@ None
 Dependencies
 ------------
 
-None
+- github_oauth
+- cyhy_core
 
 Example Playbook
 ----------------
@@ -24,9 +25,11 @@ Example Playbook
 Here's how to use it in a playbook:
 
      - hosts: cyhy_commander
-      become: yes
-      become_method: sudo
-      roles:
+       become: yes
+       become_method: sudo
+       roles:
+         - github_oauth
+         - cyhy_core
          - cyhy_commander
 License
 -------

--- a/packer/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_commander/tasks/main.yml
@@ -11,45 +11,6 @@
       - unzip
     state: latest
 
-- name: Grab GitHub OAuth token from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: github_oauth_token.yml
-    dest: /tmp/github_oauth_token.yml
-    mode: get
-  become: no
-
-- name: Load GitHub OAuth token from YML file
-  local_action:
-    module: include_vars
-    file: /tmp/github_oauth_token.yml
-  become: no
-
-#
-# Grab the cyhy-core code
-#
-- name: Create the /tmp/cyhy-core directory
-  file:
-    path: /tmp/cyhy-core
-    state: directory
-
-- name: Download and untar the cyhy-core tarball
-  unarchive:
-    src: "https://api.github.com/repos/jsf9k/cyhy-core/tarball/develop?access_token={{ github_oauth_token }}"
-    dest: /tmp/cyhy-core
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-# Thanks to https://github.com/ansible/ansible/issues/37912 I have to
-# do some chicanery here instead of just using pip
-# - name: Install cyhy-core
-#   pip:
-#     name: file:///tmp/cyhy-core
-- name: Install cyhy-core
-  command: pip install /tmp/cyhy-core
-
 #
 # Grab the cyhy-commander code
 #
@@ -108,19 +69,7 @@
 #
 # Cleanup
 #
-- name: Delete /tmp/cyhy-core
-  file:
-    path: /tmp/cyhy-core
-    state: absent
-
 - name: Delete /tmp/cyhy-commander
   file:
     path: /tmp/cyhy-commander
     state: absent
-
-- name: Delete local copy of GitHub OAuth token
-  local_action:
-    module: file
-    path: /tmp/github_oauth_token.yml
-    state: absent
-  become: no

--- a/packer/ansible/roles/cyhy_core/README.md
+++ b/packer/ansible/roles/cyhy_core/README.md
@@ -1,7 +1,7 @@
-cyhy_feeds
-=====
+cyhy_core
+=========
 
-A role for installing and configuring cyhy_feeds servers.
+A role for installing cyhy-core.
 
 Requirements
 ------------
@@ -17,20 +17,18 @@ Dependencies
 ------------
 
 - github_oauth
-- cyhy_core
 
 Example Playbook
 ----------------
 
 Here's how to use it in a playbook:
 
-    - hosts: cyhy_feeds
+    - hosts: reporters
       become: yes
       become_method: sudo
       roles:
         - github_oauth
         - cyhy_core
-        - cyhy_feeds
 
 License
 -------
@@ -40,4 +38,4 @@ BSD
 Author Information
 ------------------
 
-Kyle Evers <kyle.evers@beta.dhs.gov>
+Shane Frasier <jeremy.frasier@beta.dhs.gov>

--- a/packer/ansible/roles/cyhy_core/defaults/main.yml
+++ b/packer/ansible/roles/cyhy_core/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for cyhy_core

--- a/packer/ansible/roles/cyhy_core/handlers/main.yml
+++ b/packer/ansible/roles/cyhy_core/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for cyhy_core

--- a/packer/ansible/roles/cyhy_core/meta/main.yml
+++ b/packer/ansible/roles/cyhy_core/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/packer/ansible/roles/cyhy_core/meta/main.yml
+++ b/packer/ansible/roles/cyhy_core/meta/main.yml
@@ -52,6 +52,5 @@ galaxy_info:
     # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
     #       Maximum 20 tags per role.
 
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+dependencies:
+  - {role: github_oauth}

--- a/packer/ansible/roles/cyhy_core/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_core/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# tasks file for cyhy_core
+
+#
+# Grab the cyhy-core code
+#
+- name: Create the /tmp/cyhy-core directory
+  file:
+    path: /tmp/cyhy-core
+    state: directory
+
+- name: Download and untar the cyhy-core tarball
+  unarchive:
+    src: "https://api.github.com/repos/jsf9k/cyhy-core/tarball/develop?access_token={{ github_oauth_token }}"
+    dest: /tmp/cyhy-core
+    remote_src: yes
+    extra_opts:
+      - "--strip-components=1"
+
+#
+# Install cyhy-core
+#
+
+# Thanks to https://github.com/ansible/ansible/issues/37912 I have to
+# do some chicanery here instead of just using pip
+# - name: Install cyhy-core
+#   pip:
+#     name: file:///var/cyhy/cyhy-core
+- name: Install cyhy-core
+  command: pip install /tmp/cyhy-core
+
+#
+# Cleanup
+#
+- name: Delete /tmp/cyhy-core
+  file:
+    path: /tmp/cyhy-core
+    state: absent

--- a/packer/ansible/roles/cyhy_core/tests/inventory
+++ b/packer/ansible/roles/cyhy_core/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/packer/ansible/roles/cyhy_core/tests/test.yml
+++ b/packer/ansible/roles/cyhy_core/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - cyhy_core

--- a/packer/ansible/roles/cyhy_core/vars/main.yml
+++ b/packer/ansible/roles/cyhy_core/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for cyhy_core

--- a/packer/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -5,45 +5,6 @@
     name: unzip
     state: latest
 
-- name: Grab GitHub OAuth token from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: github_oauth_token.yml
-    dest: /tmp/github_oauth_token.yml
-    mode: get
-
-
-- name: Load GitHub OAuth token from YML file
-  local_action:
-    module: include_vars
-    file: /tmp/github_oauth_token.yml
-
-
-#
-# Grab the cyhy-core code
-#
-- name: Create the /tmp/cyhy-core directory
-  file:
-    path: /tmp/cyhy-core
-    state: directory
-
-- name: Download and untar the cyhy-core tarball
-  unarchive:
-    src: "https://api.github.com/repos/jsf9k/cyhy-core/tarball/develop?access_token={{ github_oauth_token }}"
-    dest: /tmp/cyhy-core
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-# Thanks to https://github.com/ansible/ansible/issues/37912 I have to
-# do some chicanery here instead of just using pip
-# - name: Install cyhy-core
-#   pip:
-#     name: file:///tmp/cyhy-core
-- name: Install cyhy-core
-  command: pip install /tmp/cyhy-core
-
 - name: Install boto3
   pip:
     name:
@@ -67,17 +28,3 @@
   pip:
     name:
       - requests
-
-#
-# Cleanup
-#
-- name: Delete /tmp/cyhy-core
-  file:
-    path: /tmp/cyhy-core
-    state: absent
-
-- name: Delete local copy of GitHub OAuth token
-  local_action:
-    module: file
-    path: /tmp/github_oauth_token.yml
-    state: absent

--- a/packer/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -1,49 +1,6 @@
 ---
 # tasks file for cyhy_reporter
 
-- name: Grab GitHub OAuth token from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: github_oauth_token.yml
-    dest: /tmp/github_oauth_token.yml
-    mode: get
-  become: no
-
-- name: Load GitHub OAuth token from YML file
-  local_action:
-    module: include_vars
-    file: /tmp/github_oauth_token.yml
-  become: no
-
-#
-# Grab the cyhy-core code
-#
-- name: Create the /tmp/cyhy-core directory
-  file:
-    path: /tmp/cyhy-core
-    state: directory
-
-- name: Download and untar the cyhy-core tarball
-  unarchive:
-    src: "https://api.github.com/repos/jsf9k/cyhy-core/tarball/develop?access_token={{ github_oauth_token }}"
-    dest: /tmp/cyhy-core
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-#
-# Install cyhy-core
-#
-
-# Thanks to https://github.com/ansible/ansible/issues/37912 I have to
-# do some chicanery here instead of just using pip
-# - name: Install cyhy-core
-#   pip:
-#     name: file:///var/cyhy/cyhy-core
-- name: Install cyhy-core
-  command: pip install /tmp/cyhy-core
-
 #
 # Grab the ncats-webd code
 #
@@ -185,19 +142,7 @@
 #
 # Cleanup
 #
-- name: Delete /tmp/cyhy-core
-  file:
-    path: /tmp/cyhy-core
-    state: absent
-
 - name: Delete /tmp/cyhy-reports
   file:
     path: /tmp/cyhy-reports
     state: absent
-
-- name: Delete local copy of GitHub OAuth token
-  local_action:
-    module: file
-    path: /tmp/github_oauth_token.yml
-    state: absent
-  become: no

--- a/packer/ansible/roles/cyhy_runner/README.md
+++ b/packer/ansible/roles/cyhy_runner/README.md
@@ -16,18 +16,19 @@ None
 Dependencies
 ------------
 
-None
+- github_oauth
 
 Example Playbook
 ----------------
 
 Here's how to use it in a playbook:
 
-    - hosts: cyhy_runner
+    - hosts: runners
       become: yes
       become_method: sudo
       roles:
-         - cyhy_runner
+        - github_oauth
+        - cyhy_runner
 
 License
 -------

--- a/packer/ansible/roles/cyhy_runner/meta/main.yml
+++ b/packer/ansible/roles/cyhy_runner/meta/main.yml
@@ -52,6 +52,5 @@ galaxy_info:
     # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
     #       Maximum 20 tags per role.
 
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+dependencies:
+  - {role: github_oauth}

--- a/packer/ansible/roles/cyhy_runner/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_runner/tasks/main.yml
@@ -1,21 +1,6 @@
 ---
 # tasks file for cyhy_runner
 
-- name: Grab GitHub OAuth token from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: github_oauth_token.yml
-    dest: /tmp/github_oauth_token.yml
-    mode: get
-  become: no
-
-- name: Load GitHub OAuth token from YML file
-  local_action:
-    module: include_vars
-    file: /tmp/github_oauth_token.yml
-  become: no
-
 - name: Create the /tmp/cyhy-runner directory
   file:
     path: /tmp/cyhy-runner
@@ -98,10 +83,3 @@
   file:
     path: /tmp/cyhy-runner
     state: absent
-
-- name: Delete local copy of GitHub OAuth token
-  local_action:
-    module: file
-    path: /tmp/github_oauth_token.yml
-    state: absent
-  become: no

--- a/packer/ansible/roles/github_oauth/README.md
+++ b/packer/ansible/roles/github_oauth/README.md
@@ -1,7 +1,9 @@
-cyhy_reporter
-=============
+github_oauth
+============
 
-A role for installing cyhy-reports.
+A role for retrieving the GitHub OAuth token and making it available
+to ansible as the variable github_oauth_token.  This token is needed
+to check out some repositories that are currently private.
 
 Requirements
 ------------
@@ -16,8 +18,7 @@ None
 Dependencies
 ------------
 
-- github_oauth
-- cyhy_core
+None
 
 Example Playbook
 ----------------
@@ -28,9 +29,7 @@ Here's how to use it in a playbook:
       become: yes
       become_method: sudo
       roles:
-        - github_oauth
-        - cyhy_core
-        - cyhy_reporter
+         - github_oauth
 
 License
 -------

--- a/packer/ansible/roles/github_oauth/defaults/main.yml
+++ b/packer/ansible/roles/github_oauth/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for github_oauth

--- a/packer/ansible/roles/github_oauth/handlers/main.yml
+++ b/packer/ansible/roles/github_oauth/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for github_oauth

--- a/packer/ansible/roles/github_oauth/meta/main.yml
+++ b/packer/ansible/roles/github_oauth/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/packer/ansible/roles/github_oauth/tasks/main.yml
+++ b/packer/ansible/roles/github_oauth/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# tasks file for github_oauth
+
+- name: Grab GitHub OAuth token from S3
+  local_action:
+    module: aws_s3
+    bucket: ncats-cyhy-secrets
+    object: github_oauth_token.yml
+    dest: /tmp/github_oauth_token.yml
+    mode: get
+  become: no
+
+- name: Load GitHub OAuth token from YML file
+  local_action:
+    module: include_vars
+    file: /tmp/github_oauth_token.yml
+  become: no
+
+- name: Delete local copy of GitHub OAuth token
+  local_action:
+    module: file
+    path: /tmp/github_oauth_token.yml
+    state: absent
+  become: no

--- a/packer/ansible/roles/github_oauth/tests/inventory
+++ b/packer/ansible/roles/github_oauth/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/packer/ansible/roles/github_oauth/tests/test.yml
+++ b/packer/ansible/roles/github_oauth/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - github_oauth

--- a/packer/ansible/roles/github_oauth/vars/main.yml
+++ b/packer/ansible/roles/github_oauth/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for github_oauth


### PR DESCRIPTION
Both these tasks are repeated in the Ansible code, so it makes sense to break them out into their own roles.