### PR TITLE
Move some stuff around between cyhy-feeds Ansibles

### DIFF
--- a/ansible/roles/cyhy_feeds/meta/main.yml
+++ b/ansible/roles/cyhy_feeds/meta/main.yml
@@ -53,4 +53,4 @@ galaxy_info:
     #       Maximum 20 tags per role.
 
 dependencies:
-  - role: chown_cyhy_dirs
+  - chown_cyhy_dirs

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -1,19 +1,76 @@
 ---
 # tasks file for cyhy_feeds
-- name: Grab GitHub OAuth token from S3
+
+#
+# Grab and copy some secrets from S3
+#
+- name: Grab secrets from S3
   local_action:
     module: aws_s3
     bucket: ncats-cyhy-secrets
-    object: github_oauth_token.yml
-    dest: /tmp/github_oauth_token.yml
+    object: "{{ item }}"
+    dest: "/tmp/{{ item }}"
     mode: get
   become: no
+  loop:
+    - cyhy-data-extract.cfg
+    - ncats_lab_public_gpg.key
+    - ncats_lab_private_gpg.key
+    - nsd_cyhy_daily_extract_public.key
+    - gpg_keys.trust
 
-- name: Load GitHub OAuth token from YML file
+- name: Copy secrets
+  copy:
+    src: "/tmp/{{ item }}"
+    dest: "/var/cyhy/scripts/cyhy-feeds/{{ item }}"
+    mode: 0444
+    owner: cyhy
+    group: cyhy
+  loop:
+    - cyhy-data-extract.cfg
+    - ncats_lab_public_gpg.key
+    - ncats_lab_private_gpg.key
+    - nsd_cyhy_daily_extract_public.key
+    - gpg_keys.trust
+
+#
+# Import keys and trust
+#
+- name: Import gpg keys
+  shell: "gpg2 --trustdb-name /var/cyhy/.gnupg/trustdb.gpg --import --batch /var/cyhy/scripts/cyhy-feeds/{{ item }}"
+  become_user: cyhy
+  vars:
+    ansible_ssh_pipelining: yes
+  loop:
+    - ncats_lab_public_gpg.key
+    - ncats_lab_private_gpg.key
+    - nsd_cyhy_daily_extract_public.key
+
+- name: Import gpg trust
+  shell: "gpg2 --import-ownertrust --batch /var/cyhy/scripts/cyhy-feeds/gpg_keys.trust"
+  become_user: cyhy
+  vars:
+    ansible_ssh_pipelining: yes
+
+#
+# Cleanup
+#
+- name: Delete local copies of secrets
   local_action:
-    module: include_vars
-    file: /tmp/github_oauth_token.yml
+    module: file
+    path: "/tmp/{{ item }}"
+    state: absent
+  become: no
+  loop:
+    - cyhy-data-extract.cfg
+    - ncats_lab_public_gpg.key
+    - ncats_lab_private_gpg.key
+    - nsd_cyhy_daily_extract_public.key
+    - gpg_keys.trust
 
+#
+# Create /etc/cyhy/cyhy.conf file
+#
 - name: Grab mongo users from S3
   local_action:
     module: aws_s3
@@ -29,198 +86,10 @@
     file: /tmp/mongo_users.yml
     name: mongo_users
 
-- name: Create the /var/cyhy/scripts/cyhy-feeds/
-  file:
-    path: /var/cyhy/scripts/cyhy-feeds/
-    state: directory
-    owner: cyhy
-    group: cyhy
-
-- name: Create the /var/cyhy/scripts/cyhy-feeds/extracts
-  file:
-    path: /var/cyhy/scripts/cyhy-feeds/cyhy_extracts
-    state: directory
-    owner: cyhy
-    group: cyhy
-
-- name: Create /etc/cyhy dir
+- name: Create /etc/cyhy directory
   file:
     path: /etc/cyhy
     state: directory
-
-- name: Download cyhy extract from GitHub
-  get_url:
-    url: "https://raw.githubusercontent.com/jsf9k/cyhy-feeds/develop/aws_jobs/cyhy-data-extract.py"
-    headers:
-      Authorization: "token {{ github_oauth_token }}"
-    dest: /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py
-    mode: 0755
-    owner: cyhy
-    group: cyhy
-
-- name: Download dmarc extract from GitHub
-  get_url:
-    url: "https://raw.githubusercontent.com/jsf9k/cyhy-feeds/develop/aws_jobs/dmarc.py"
-    headers:
-      Authorization: "token {{ github_oauth_token }}"
-    dest: /var/cyhy/scripts/cyhy-feeds/dmarc.py
-    mode: 0755
-    owner: cyhy
-    group: cyhy
-
-- name: Grab cyhy extract config file from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: cyhy-data-extract.cfg
-    dest: /tmp/cyhy-data-extract.cfg
-    mode: get
-  become: no
-
-- name: Grab gpg public key from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: ncats_lab_public_gpg.key
-    dest: /tmp/ncats_lab_public_gpg.key
-    mode: get
-  become: no
-
-- name: Grab cyhy private key from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: ncats_lab_private_gpg.key
-    dest: /tmp/ncats_lab_private_gpg.key
-    mode: get
-  become: no
-
-- name: Grab cyhy nsd public key from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: nsd_cyhy_daily_extract_public.key
-    dest: /tmp/nsd_cyhy_daily_extract_public.key
-    mode: get
-  become: no
-
-- name: Grab gpg trust keys from S3
-  local_action:
-    module: aws_s3
-    bucket: ncats-cyhy-secrets
-    object: gpg_keys.trust
-    dest: /tmp/gpg_keys.trust
-    mode: get
-  become: no
-
-#
-# Copy extract config to new instance
-#
-- name: Copy config file for moe data extractor
-  copy:
-    src: /tmp/cyhy-data-extract.cfg
-    dest: /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg
-    mode: 0644
-    owner: cyhy
-    group: cyhy
-
-- name: Copy gpg public key for moe data extract
-  copy:
-    src: /tmp/ncats_lab_public_gpg.key
-    dest: /var/cyhy/scripts/cyhy-feeds/ncats_lab_public_gpg.key
-    mode: 0644
-    owner: cyhy
-    group: cyhy
-
-- name: Copy nsd_cyhy_daily public key for moe data extract
-  copy:
-    src: /tmp/nsd_cyhy_daily_extract_public.key
-    dest: /var/cyhy/scripts/cyhy-feeds/nsd_cyhy_daily_extract_public.key
-    mode: 0644
-    owner: cyhy
-    group: cyhy
-
-- name: Copy gpg private key for moe data extract
-  copy:
-    src: /tmp/ncats_lab_private_gpg.key
-    dest: /var/cyhy/scripts/cyhy-feeds/ncats_lab_private_gpg.key
-    mode: 0444
-    owner: cyhy
-    group: cyhy
-
-- name: Copy gpg trust file
-  copy:
-    src: /tmp/gpg_keys.trust
-    dest: /var/cyhy/scripts/cyhy-feeds/gpg_keys.trust
-    mode: 0644
-    owner: cyhy
-    group: cyhy
-
-- name: Create the /var/cyhy/scripts/cyhy-feeds/cyhy_extracts directory
-  file:
-    path: /var/cyhy/scripts/cyhy-feeds/cyhy_extracts
-    state: directory
-    owner: cyhy
-    group: cyhy
-
-- name: import lab public key
-  shell: "gpg2 --trustdb-name /var/cyhy/.gnupg/trustdb.gpg --import /var/cyhy/scripts/cyhy-feeds/ncats_lab_public_gpg.key"
-  become_user: cyhy
-  vars:
-    ansible_ssh_pipelining: yes
-
-- name: import nsd daily public key
-  shell: "gpg2 --trustdb-name /var/cyhy/.gnupg/trustdb.gpg --import /var/cyhy/scripts/cyhy-feeds/nsd_cyhy_daily_extract_public.key"
-  become_user: cyhy
-  vars:
-    ansible_ssh_pipelining: yes
-
-- name: import lab private key
-  shell: "gpg2 --batch --import /var/cyhy/scripts/cyhy-feeds/ncats_lab_private_gpg.key"
-  become_user: cyhy
-  vars:
-    ansible_ssh_pipelining: yes
-
-- name: Add trust
-  shell: "gpg2 --import-ownertrust /var/cyhy/scripts/cyhy-feeds/gpg_keys.trust"
-  become_user: cyhy
-  vars:
-    ansible_ssh_pipelining: yes
-
-- name: Delete nsd public key
-  local_action:
-    module: file
-    path: /tmp/nsd_cyhy_daily_extract_public.key
-    state: absent
-  become: no
-
-- name: Delete local copy config file for moe data extractor
-  local_action:
-    module: file
-    path: /tmp/cyhy-data-extract.cfg
-    state: absent
-  become: no
-
-- name: Delete local copy gpg public key for moe data extract
-  local_action:
-    module: file
-    path: /tmp/ncats_lab_public_gpg.key
-    state: absent
-  become: no
-
-- name: Delete local copy gpg public key for moe data extract
-  local_action:
-    module: file
-    path: /tmp/ncats_lab_private_gpg.key
-    state: absent
-  become: no
-
-- name: Delete gpg trust file
-  local_action:
-    module: file
-    path: /tmp/gpg_keys.trust
-    state: absent
-  become: no
 
 - name: Create /etc/cyhy/cyhy.conf with commander credentials
   copy:
@@ -239,9 +108,10 @@
       database-name = cyhy
 
 #
-# Run nightly at 0815 (UTC) as cyhy
+# Create a cron job to run the extract script nightly at 0815 (UTC) as
+# cyhy
 #
-- name: Set up nightly cron job to sync NSD data for moe extract
+- name: Set up nightly cron job to sync NSD data for MOE extract
   cron:
     name: Nightly cyhy extract
     hour: 08

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -36,6 +36,9 @@
 #
 # Import keys and trust
 #
+
+# The --batch flag makes sure that gpg2 doesn't attempt to do anything
+# interactive.
 - name: Import gpg keys
   shell: "gpg2 --trustdb-name /var/cyhy/.gnupg/trustdb.gpg --import --batch /var/cyhy/scripts/cyhy-feeds/{{ item }}"
   become_user: cyhy

--- a/packer/ansible/roles/cyhy_feeds/meta/main.yml
+++ b/packer/ansible/roles/cyhy_feeds/meta/main.yml
@@ -53,4 +53,6 @@ galaxy_info:
     #       Maximum 20 tags per role.
 
 dependencies:
-  - role: cyhy_core
+  - pip
+  - github_oauth
+  - cyhy_core

--- a/packer/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -1,6 +1,22 @@
 ---
 # tasks file for cyhy_feeds
 
+- name: Create the /var/cyhy/scripts/cyhy-feeds/cyhy_extracts directory
+  file:
+    path: /var/cyhy/scripts/cyhy-feeds/cyhy_extracts
+    state: directory
+
+- name: Download cyhy extract scripts from GitHub
+  get_url:
+    url: "https://raw.githubusercontent.com/jsf9k/cyhy-feeds/develop/aws_jobs/{{ item }}"
+    headers:
+      Authorization: "token {{ github_oauth_token }}"
+    dest: "/var/cyhy/scripts/cyhy-feeds/{{ item }}"
+    mode: 0755
+  loop:
+    - cyhy-data-extract.py
+    - dmarc.py
+
 - name: Install dependencies
   package:
     name:

--- a/packer/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -23,6 +23,9 @@
       - gnupg2
       - unzip
 
+# We want to install boto3 and requests via pip but older versions may
+# have already been installed via the package manager.  Let's force
+# pip to upgrade in case those versions aren't the latest.
 - name: Install pip dependencies
   pip:
     name:
@@ -30,3 +33,4 @@
       - python-gnupg
       - requests
       - requests_aws4auth
+    extra_args: --upgrade

--- a/terraform/cyhy_private_dns.tf
+++ b/terraform/cyhy_private_dns.tf
@@ -75,6 +75,14 @@ resource "aws_route53_record" "cyhy_vulnscan_A" {
   records = [ "${aws_instance.cyhy_nessus.*.private_ip[count.index]}" ]
 }
 
+resource "aws_route53_record" "cyhy_feeds_A" {
+  zone_id = "${aws_route53_zone.cyhy_private_zone.zone_id}"
+  name    = "feeds.${aws_route53_zone.cyhy_private_zone.name}"
+  type    = "A"
+  ttl     = 300
+  records = [ "${aws_instance.cyhy_feeds.private_ip}"]
+}
+
 ##################################
 # Reverse records - scanner subnet
 ##################################
@@ -199,4 +207,17 @@ resource "aws_route53_record" "cyhy_rev_database_PTR" {
   type    = "PTR"
   ttl     = 300
   records = [ "database${count.index + 1}.${local.cyhy_private_domain}." ]
+}
+
+resource "aws_route53_record" "cyhy_rev_feeds_PTR" {
+  zone_id = "${aws_route53_zone.cyhy_private_zone_reverse.zone_id}"
+  name    = "${format("%s.%s.%s.%s.in-addr.arpa.",
+    element(split(".", aws_instance.cyhy_feeds.private_ip), 3),
+    element(split(".", aws_instance.cyhy_feeds.private_ip), 2),
+    element(split(".", aws_instance.cyhy_feeds.private_ip), 1),
+    element(split(".", aws_instance.cyhy_feeds.private_ip), 0),
+  )}"
+  type    = "PTR"
+  ttl     = 300
+  records = [ "feeds.${local.cyhy_private_domain}." ]
 }


### PR DESCRIPTION
I didn't like that scripts were being installed in the Terraform Ansible, so I fixed that.  I took the opportunity to reduce the amount of code using Ansible `loop`s in several places.

I also ran into [this problem with `gpg2`](https://discuss.circleci.com/t/error-sending-to-agent-inappropriate-ioctl-for-device/17465), perhaps because I have `gpg-agent` running locally.  In any event, adding the `--batch` option to the `gpg2` commands gets rid of the issue and otherwise changes nothing.