### PR TITLE
Add TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: python
 
+env:
+  global:
+    - AWS_DEFAULT_REGION=us-east-1
+    - AWS_ACCESS_KEY_ID=AAAAAAAAAAAAAAAAAAAA
+    - AWS_SECRET_ACCESS_KEY=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
 matrix:
   include:
     - python: 3.7
@@ -8,6 +14,7 @@ matrix:
 
 # Install terraform, packer, and ansible
 before_install:
+  - echo $(which packer)
   - wget https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip -O terraform.zip
   - sudo unzip terraform.zip -d /opt/terraform
   - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
@@ -28,6 +35,6 @@ before_install:
 # We don't check Terraform variables because we don't have a tfvars
 # file to use.
 script:
-  - for f in $(ls packer/*.json); do packer validate -syntax-only $f; done
+  - for f in $(ls packer/*.json); do packer validate $f; done
   - cd terraform && ./configure.py && cd ..
   - for d in terraform terraform_egress_pub terraform_nessus_only terraform_route_53; do terraform init -backend=false $d; terraform validate -check-variables=false $d; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: minimal
 
 # This doesn't work yet on trusty, so we have to use matrix below
 # python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: minimal
-
-# This doesn't work yet on trusty, so we have to use matrix below
-# python:
-#   - '3.7'
+language: python
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+language: python
+
+python:
+  - '3.7'
+
 # Install terraform, packer, and ansible
 before_install:
   - wget https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip -O terraform.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: python
 
-python:
-  - '3.7'
+# This doesn't work yet on trusty, so we have to use matrix below
+# python:
+#   - '3.7'
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 # Install terraform, packer, and ansible
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ before_install:
 # We don't check Terraform variables because we don't have a tfvars
 # file to use.
 script:
-  - for f in $(ls packer/*.json); do packer validate --syntax-only $f; done
+  - for f in $(ls packer/*.json); do packer validate -syntax-only $f; done
   - cd terraform && ./configure.py && cd ..
   - for d in terraform terraform_egress_pub terraform_nessus_only terraform_route_53; do terraform init -backend=false $d; terraform validate -check-variables=false $d; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,18 @@
 language: python
 
-env:
-  global:
-    - AWS_DEFAULT_REGION=us-east-1
-    - AWS_ACCESS_KEY_ID=AAAAAAAAAAAAAAAAAAAA
-    - AWS_SECRET_ACCESS_KEY=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-
 matrix:
   include:
     - python: 3.7
       dist: xenial
       sudo: true
 
-# Install terraform, packer, and ansible
+# Install terraform and ansible
 before_install:
   - echo $(which packer)
   - wget https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip -O terraform.zip
   - sudo unzip terraform.zip -d /opt/terraform
   - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
   - rm -f terraform.zip
-  - wget https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_amd64.zip -O packer.zip
-  - sudo unzip packer.zip -d /opt/packer
-  - sudo ln -s /opt/packer/packer /usr/bin/packer
-  - rm -f packer.zip
   - sudo apt-get install ansible
 
 # Travis' Xenial builds run on GCE and do not have any AWS
@@ -35,6 +25,6 @@ before_install:
 # We don't check Terraform variables because we don't have a tfvars
 # file to use.
 script:
-  - for f in $(ls packer/*.json); do packer validate $f; done
+  - for f in $(ls packer/*.json); do packer validate -syntax-only $f; done
   - cd terraform && ./configure.py && cd ..
   - for d in terraform terraform_egress_pub terraform_nessus_only terraform_route_53; do terraform init -backend=false $d; terraform validate -check-variables=false $d; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# Install terraform, packer, and ansible
+before_install:
+  - wget https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip -O terraform.zip
+  - sudo unzip terraform.zip -d /opt/terraform
+  - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+  - rm -f terraform.zip
+  - wget https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_amd64.zip -O packer.zip
+  - sudo unzip packer.zip -d /opt/packer
+  - sudo ln -s /opt/packer/packer /usr/bin/packer
+  - rm -f packer.zip
+  - sudo apt-get install ansible
+
+# We don't initialize the Terraform backend because Travis doesn't
+# have credentials to connect to our AWS S3 bucket where the Terraform
+# state is stored.
+#
+# We don't check Terraform variables because we don't have a tfvars
+# file to use.
+script:
+  - for f in $(ls packer/*.json); do packer validate $f; done
+  - for d in terraform terraform_egress_pub terraform_nessus_only terraform_route_53; do terraform init -backend=false $d; terraform validate -check-variables=false $d; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_install:
   - rm -f packer.zip
   - sudo apt-get install ansible
 
+# Travis' Xenial builds run on GCE and do not have any AWS
+# credentials.  Therefore our packer tests use --syntax-only.
+#
 # We don't initialize the Terraform backend because Travis doesn't
 # have credentials to connect to our AWS S3 bucket where the Terraform
 # state is stored.
@@ -25,6 +28,6 @@ before_install:
 # We don't check Terraform variables because we don't have a tfvars
 # file to use.
 script:
-  - for f in $(ls packer/*.json); do packer validate $f; done
+  - for f in $(ls packer/*.json); do packer validate --syntax-only $f; done
   - cd terraform && ./configure.py && cd ..
   - for d in terraform terraform_egress_pub terraform_nessus_only terraform_route_53; do terraform init -backend=false $d; terraform validate -check-variables=false $d; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ before_install:
 # file to use.
 script:
   - for f in $(ls packer/*.json); do packer validate $f; done
+  - cd terraform && ./configure.py && cd ..
   - for d in terraform terraform_egress_pub terraform_nessus_only terraform_route_53; do terraform init -backend=false $d; terraform validate -check-variables=false $d; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 matrix:
   include:
+    # We need python 3.7 in order to run the configure.py script, and
+    # only the xenial TravisCI images have python 3.7 available.
     - python: 3.7
       dist: xenial
       sudo: true
@@ -16,7 +18,7 @@ before_install:
   - sudo apt-get install ansible
 
 # Travis' Xenial builds run on GCE and do not have any AWS
-# credentials.  Therefore our packer tests use --syntax-only.
+# credentials.  Therefore our packer tests must use --syntax-only.
 #
 # We don't initialize the Terraform backend because Travis doesn't
 # have credentials to connect to our AWS S3 bucket where the Terraform


### PR DESCRIPTION
This took a few iterations to get right.  One problem is that Python 3.7 (required for `terraform/configure.py`) isn't supported in TravisCI unless you specifically request a Xenial VM.  Once I did that, I realized that `packer validate` can't completely validate our Packer code because the Xenial VMs run in GCE.  (On the Trusty VMs, which run in EC2, `packer validate` works just fine.) Therefore I had to add the `-syntax-only` flag to `packer validate`, and that command isn't validating as much as it could.

I could fix the issue by adding (encrypted) AWS credentials to the TravisCI configuration, but it seems hokey to create a user just for that.

The TravisCI situation would be improved if we split the AMI generation code into its own repository, since then I could run `packer validate` in TravisCI's Trusty environment.  In one sense the complication of testing both Packer and Terraform code in the same repository is due to TravisCI's deficiencies.  To my mind, though, it is another indication that this repo contains _too much stuff_ and should be broken up.  That's my $0.02.