### PR TITLE
Improvement/remove nat gateways

### DIFF
--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-default-section = purge-production
+default-section = production
 database-uri = mongodb://commander:PASSWORD@mongodb.host.flood:27017/cyhy
 jobs-per-nmap-host = 8
 jobs-per-nessus-host = 16
@@ -15,7 +15,7 @@ nessus-hosts = vulnscan1
 
 [production]
 database-name = cyhy
-jobs-per-nmap-host = 384
+jobs-per-nmap-host = 768
 jobs-per-nessus-host = 16
 nmap-hosts = portscan1
 nessus-hosts = vulnscan1,vulnscan2,vulnscan3

--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-default-section = production
+default-section = purge-production
 database-uri = mongodb://commander:PASSWORD@mongodb.host.flood:27017/cyhy
 jobs-per-nmap-host = 8
 jobs-per-nessus-host = 16
@@ -15,9 +15,9 @@ nessus-hosts = vulnscan1
 
 [production]
 database-name = cyhy
-jobs-per-nmap-host = 12
+jobs-per-nmap-host = 384
 jobs-per-nessus-host = 16
-nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8, portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64
+nmap-hosts = portscan1
 nessus-hosts = vulnscan1,vulnscan2,vulnscan3
 
 [purge]
@@ -26,6 +26,15 @@ jobs-per-nmap-host = 0
 jobs-per-nessus-host = 0
 shutdown-when-idle = true
 database-name = cyhy
+
+[purge-production]
+# use to collect remaining jobs without creating new ones
+database-name = cyhy
+jobs-per-nmap-host = 0
+jobs-per-nessus-host = 0
+shutdown-when-idle = false
+nmap-hosts = portscan1
+nessus-hosts = vulnscan1,vulnscan2,vulnscan3
 
 [purge-trash]
 # purge jobs from scanners

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -27,7 +27,7 @@ assert sys.version_info >= (3,7), 'This script requires Python version 3.7 or ne
 # for each workspace, set the number of instances to create for each template
 WORKSPACE_CONFIGS = {
                         'production':   {'nmap':64, 'nessus':3, 'mongo':1},
-                        'prod-b':       {'nmap':64, 'nessus':3, 'mongo':1},
+                        'prod-b':       {'nmap':1, 'nessus':3, 'mongo':1},
                         'felddy':       {'nmap':4, 'nessus':1, 'mongo':1},
                         'jsf9k':        {'nmap':0, 'nessus':0, 'mongo':1},
                     }

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -64,7 +64,7 @@ data "aws_eip" "cyhy_nessus_eips" {
 resource "aws_eip" "cyhy_nessus_random_eips" {
   count = "${local.production_workspace ? 0 : local.nessus_instance_count}"
   vpc = true
-  tags = "${merge(var.tags, map("Name", "CyHy Nmap EIP", "Publish Egress", "True"))}"
+  tags = "${merge(var.tags, map("Name", format("CyHy Nessus EIP %d", count.index+1), "Publish Egress", "True"))}"
 }
 
 # Associate the appropriate Elastic IPs above with the CyHy Nessus

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -85,7 +85,7 @@ resource "aws_eip" "cyhy_nessus_random_eips" {
 resource "aws_eip_association" "cyhy_nessus_eip_assocs" {
   count = "${local.nessus_instance_count}"
   instance_id = "${element(aws_instance.cyhy_nessus.*.id, count.index)}"
-  allocation_id = "${element(coalescelist(data.aws_eip.cyhy_nmap_eips.*.id, aws_eip.cyhy_nmap_random_eips.*.id), count.index)}"
+  allocation_id = "${element(coalescelist(data.aws_eip.cyhy_nessus_eips.*.id, aws_eip.cyhy_nessus_random_eips.*.id), count.index)}"
 }
 
 # Note that the EBS volume contains production data. Therefore we need

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -28,7 +28,6 @@ resource "aws_instance" "cyhy_nessus" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   subnet_id = "${aws_subnet.cyhy_vulnscanner_subnet.id}"
-  associate_public_ip_address = false
 
   root_block_device {
     volume_type = "gp2"
@@ -49,6 +48,44 @@ resource "aws_instance" "cyhy_nessus" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+# The Elastic IPs for the *production* CyHy Nessus instances.  These
+# EIPs can be created via dhs-ncats/elastic-ips-terraform or manually,
+# and are intended to be a public IP address that rarely changes.
+data "aws_eip" "cyhy_nessus_eips" {
+  count = "${local.production_workspace ? local.nessus_instance_count : 0}"
+  public_ip = "${element(var.cyhy_vulnscan_elastic_ips, count.index)}"
+}
+
+# The Elastic IP for the *non-production* CyHy Nessus instances.
+# These EIPs are only created in *non-production* workspaces and are
+# randomly-assigned public IP address for temporary use.
+resource "aws_eip" "cyhy_nessus_random_eips" {
+  count = "${local.production_workspace ? 0 : local.nessus_instance_count}"
+  vpc = true
+  tags = "${merge(var.tags, map("Name", "CyHy Nmap EIP", "Publish Egress", "True"))}"
+}
+
+# Associate the appropriate Elastic IPs above with the CyHy Nessus
+# instances.  Since our elastic IPs are handled differently in
+# production vs. non-production workspaces, their corresponding
+# terraform resources (data.aws_eip.cyhy_nessus_eips,
+# data.aws_eip.cyhy_nessus_random_eips) may or may not be created.  To
+# handle that, we use "splat syntax" (the *), which resolves to either
+# an empty list (if the resource is not present in the current
+# workspace) or a valid list (if the resource is present).  Then we
+# use coalescelist() to choose the (non-empty) list containing the
+# valid eip.id. Finally, we use element() to choose the appropriate
+# element in that non-empty list, which is the allocation_id of our
+# elastic IP.  See
+# https://github.com/hashicorp/terraform/issues/11566#issuecomment-289417805
+#
+# VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
+resource "aws_eip_association" "cyhy_nessus_eip_assocs" {
+  count = "${local.nessus_instance_count}"
+  instance_id = "${element(aws_instance.cyhy_nessus.*.id, count.index)}"
+  allocation_id = "${element(coalescelist(data.aws_eip.cyhy_nmap_eips.*.id, aws_eip.cyhy_nmap_random_eips.*.id), count.index)}"
 }
 
 # Note that the EBS volume contains production data. Therefore we need

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -55,7 +55,7 @@ resource "aws_instance" "cyhy_nmap" {
 # changes.
 data "aws_eip" "cyhy_nmap_eips" {
   count = "${local.production_workspace ? local.nmap_instance_count : 0}"
-  public_ip = "${element(var.cyhy_nmap_elastic_ips, count.index)}"
+  public_ip = "${element(var.cyhy_portscan_elastic_ips, count.index)}"
 }
 
 # The Elastic IPs for the *non-production* CyHy nmap scanner

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -22,7 +22,7 @@ data "aws_ami" "nmap" {
 
 resource "aws_instance" "cyhy_nmap" {
   ami = "${data.aws_ami.nmap.id}"
-  instance_type = "${local.production_workspace ? "r5.12xlarge" : "t3.micro"}"
+  instance_type = "${local.production_workspace ? "r5.24xlarge" : "t3.micro"}"
   count = "${local.nmap_instance_count}"
 
   ebs_optimized = "${local.production_workspace}"
@@ -35,7 +35,7 @@ resource "aws_instance" "cyhy_nmap" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = "${local.production_workspace ? 200 : 8}"
+    volume_size = "${local.production_workspace ? 100 : 8}"
     delete_on_termination = true
   }
 

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -65,7 +65,7 @@ data "aws_eip" "cyhy_nmap_eips" {
 resource "aws_eip" "cyhy_nmap_random_eips" {
   count = "${local.production_workspace ? 0 : local.nmap_instance_count}"
   vpc = true
-  tags = "${merge(var.tags, map("Name", "CyHy Nmap EIP", "Publish Egress", "True"))}"
+  tags = "${merge(var.tags, map("Name", format("CyHy Nmap EIP %d", count.index+1), "Publish Egress", "True"))}"
 }
 
 # Associate the appropriate Elastic IP above with the CyHy nmap

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -25,7 +25,7 @@ resource "aws_instance" "cyhy_nmap" {
   instance_type = "${local.production_workspace ? "r5.12xlarge" : "t3.micro"}"
   count = "${local.nmap_instance_count}"
 
-  # ebs_optimized = true
+  ebs_optimized = "${local.production_workspace}"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   # We may want to spread instances across all availability zones, however
   # this will also require creating a scanner subnet in each availability zone
@@ -49,38 +49,44 @@ resource "aws_instance" "cyhy_nmap" {
   volume_tags = "${merge(var.tags, map("Name", format("CyHy Nmap - portscan%d", count.index+1)))}"
 }
 
-# The Elastic IP for the *Production* CyHy nmap scanner instance
-# Can be created via dhs-ncats/elastic-ips-terraform or manually
-# Intended to be a public IP address that rarely changes
-data "aws_eip" "cyhy_nmap_eip" {
-  count = "${local.production_workspace ? 1 : 0}"
-  public_ip = "${var.cyhy_nmap_elastic_ip}"
+# The Elastic IPs for the *production* CyHy nmap scanner instances.
+# These EIPs can be created via dhs-ncats/elastic-ips-terraform or
+# manually and are intended to be a public IP address that rarely
+# changes.
+data "aws_eip" "cyhy_nmap_eips" {
+  count = "${local.production_workspace ? local.nmap_instance_count : 0}"
+  public_ip = "${element(var.cyhy_nmap_elastic_ips, count.index)}"
 }
 
-# The Elastic IP for the *Non-Production* CyHy nmap scanner instance
-# Only created in *non-production* workspaces
-# This is a randomly-assigned public IP address for temporary use
-resource "aws_eip" "cyhy_nmap_random_eip" {
-  count = "${local.production_workspace ? 0 : 1}"
+# The Elastic IPs for the *non-production* CyHy nmap scanner
+# instances.  These EIPs are only created in *non-production*
+# workspaces and are randomly-assigned public IP address for temporary
+# use.
+resource "aws_eip" "cyhy_nmap_random_eips" {
+  count = "${local.production_workspace ? 0 : local.nmap_instance_count}"
   vpc = true
   tags = "${merge(var.tags, map("Name", "CyHy Nmap EIP", "Publish Egress", "True"))}"
 }
 
-# Associate the appropriate Elastic IP above with the CyHy nmap instance
-# Since our elastic IPs are handled differently in production vs.
-# non-production workspaces, their corresponding terraform resources
-# (data.aws_eip.cyhy_nmap_eip, data.aws_eip.cyhy_nmap_random_eip)
-# may or may not be created.  To handle that, we use "splat syntax" (the *),
-# which resolves to either an empty list (if the resource is not present in
-# the current workspace) or a valid list (if the resource is present).  Then
-# we use coalescelist() to choose the (non-empty) list containing the valid
-# eip.id. Finally, we use element() to choose the first element in that
-# non-empty list, which is the allocation_id of our elastic IP.
-# See https://github.com/hashicorp/terraform/issues/11566#issuecomment-289417805
+# Associate the appropriate Elastic IP above with the CyHy nmap
+# instances.  Since our elastic IPs are handled differently in
+# production vs.  non-production workspaces, their corresponding
+# terraform resources (data.aws_eip.cyhy_nmap_eips,
+# data.aws_eip.cyhy_nmap_random_eips) may or may not be created.  To
+# handle that, we use "splat syntax" (the *), which resolves to either
+# an empty list (if the resource is not present in the current
+# workspace) or a valid list (if the resource is present).  Then we
+# use coalescelist() to choose the (non-empty) list containing the
+# valid eip.id. Finally, we use element() to choose the first element
+# in that non-empty list, which is the allocation_id of our elastic
+# IP.  See
+# https://github.com/hashicorp/terraform/issues/11566#issuecomment-289417805
+#
 # VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
-resource "aws_eip_association" "cyhy_nmap_eip_assoc" {
-  instance_id   = "${aws_instance.cyhy_nmap.id}"
-  allocation_id = "${element(coalescelist(data.aws_eip.cyhy_nmap_eip.*.id, aws_eip.cyhy_nmap_random_eip.*.id), 0)}"
+resource "aws_eip_association" "cyhy_nmap_eip_assocs" {
+  count = "${local.nmap_instance_count}"
+  instance_id = "${element(aws_instance.cyhy_nmap.*.id, count.index)}"
+  allocation_id = "${element(coalescelist(data.aws_eip.cyhy_nmap_eips.*.id, aws_eip.cyhy_nmap_random_eips.*.id), count.index)}"
 }
 
 # Note that the EBS volume contains production data. Therefore we need

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -22,7 +22,7 @@ data "aws_ami" "nmap" {
 
 resource "aws_instance" "cyhy_nmap" {
   ami = "${data.aws_ami.nmap.id}"
-  instance_type = "${local.production_workspace ? "t2.micro" : "t2.micro"}"
+  instance_type = "${local.production_workspace ? "r5.12xlarge" : "t3.micro"}"
   count = "${local.nmap_instance_count}"
 
   # ebs_optimized = true
@@ -36,7 +36,7 @@ resource "aws_instance" "cyhy_nmap" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = "${local.production_workspace ? 20 : 8}"
+    volume_size = "${local.production_workspace ? 200 : 8}"
     delete_on_termination = true
   }
 
@@ -65,7 +65,7 @@ resource "aws_ebs_volume" "nmap_cyhy_runner_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   # availability_zone = "${element(data.aws_availability_zones.all.names, count.index)}"
   type = "gp2"
-  size = "${local.production_workspace ? 2 : 1}"
+  size = "${local.production_workspace ? 128 : 1}"
   encrypted = true
 
   tags = "${merge(var.tags, map("Name", format("CyHy Nmap - portscan%d", count.index+1)))}"

--- a/terraform/cyhy_vpc.tf
+++ b/terraform/cyhy_vpc.tf
@@ -51,8 +51,8 @@ resource "aws_subnet" "cyhy_vulnscanner_subnet" {
 }
 
 # Public subnet of the VPC
-# All traffic from portscanner, vulnscanner, and private subnets will
-# route through here
+#
+# All traffic from private subnet will route through here
 resource "aws_subnet" "cyhy_public_subnet" {
   vpc_id = "${aws_vpc.cyhy_vpc.id}"
   # TODO: Maybe make this subnet smaller?
@@ -66,74 +66,27 @@ resource "aws_subnet" "cyhy_public_subnet" {
   tags = "${merge(var.tags, map("Name", "CyHy Public"))}"
 }
 
-# The Elastic IPs for the *Production* CyHy Port/Vuln Scanner NAT gateways
-# Can be created via dhs-ncats/elastic-ips-terraform or manually
-# Intended to be public IP addresses that rarely change
-data "aws_eip" "cyhy_portscan_nat_gw_eip" {
-  count = "${local.production_workspace ? 1 : 0}"
-  public_ip = "${var.cyhy_portscan_nat_gw_elastic_ip}"
-}
-
-data "aws_eip" "cyhy_vulnscan_nat_gw_eip" {
-  count = "${local.production_workspace ? 1 : 0}"
-  public_ip = "${var.cyhy_vulnscan_nat_gw_elastic_ip}"
-}
-
-# The Elastic IPs for the *Non-Production* CyHy Port/Vuln Scanner NAT gateways
-# Only created in *non-production* workspaces
-# This are randomly-assigned public IP addresses for temporary use
-resource "aws_eip" "cyhy_portscan_nat_gw_random_eip" {
-  count = "${local.production_workspace ? 0 : 1}"
+# Elastic IP for the NAT gateway
+resource "aws_eip" "cyhy_eip" {
   vpc = true
-  tags = "${merge(var.tags, map("Name", "CyHy Port Scanner NATGW EIP", "Publish Egress", "True"))}"
+
+  depends_on = [
+    "aws_internet_gateway.cyhy_igw"
+  ]
+
+  tags = "${merge(var.tags, map("Name", "CyHy NAT GW IP"))}"
 }
 
-resource "aws_eip" "cyhy_vulnscan_nat_gw_random_eip" {
-  count = "${local.production_workspace ? 0 : 1}"
-  vpc = true
-  tags = "${merge(var.tags, map("Name", "CyHy Vuln Scanner NATGW EIP", "Publish Egress", "True"))}"
-}
-
-# The Port Scanner NAT gateway for the VPC
-# Resides in public subnet; used by portscanner and private subnets
-resource "aws_nat_gateway" "cyhy_portscanner_nat_gw" {
-  # Since our elastic IPs are handled differently in production vs.
-  # non-production workspaces, their corresponding terraform resources
-  # (data.aws_eip.cyhy_portscan_nat_gw_eip,
-  #  data.aws_eip.cyhy_vulnscan_nat_gw_eip,
-  #  aws_eip.cyhy_portscan_nat_gw_random_eip,
-  #  aws_eip.cyhy_vulncan_nat_gw_random_eip)
-  # may or may not be created.  To handle that, we use "splat syntax" (the *),
-  # which resolves to either an empty list (if the resource is not present in
-  # the current workspace) or a valid list (if the resource is present).  Then
-  # we use coalescelist() to choose the (non-empty) list containing the valid
-  # eip.id. Finally, we use element() to choose the first element in that
-  # non-empty list, which is the allocation_id of our elastic IP.
-  # See https://github.com/hashicorp/terraform/issues/11566#issuecomment-289417805
-  # VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
-  allocation_id = "${element(coalescelist(data.aws_eip.cyhy_portscan_nat_gw_eip.*.id, aws_eip.cyhy_portscan_nat_gw_random_eip.*.id), 0)}"
+# The NAT gateway for the VPC
+resource "aws_nat_gateway" "cyhy_nat_gw" {
+  allocation_id = "${aws_eip.cyhy_eip.id}"
   subnet_id = "${aws_subnet.cyhy_public_subnet.id}"
 
   depends_on = [
     "aws_internet_gateway.cyhy_igw"
   ]
 
-  tags = "${merge(var.tags, map("Name", "CyHy Port Scanner NATGW"))}"
-}
-
-# The Vuln Scanner NAT gateway for the VPC
-# Resides in public subnet; used by vulnscanner subnet
-resource "aws_nat_gateway" "cyhy_vulnscanner_nat_gw" {
-  # See comment above (aws_nat_gateway.cyhy_portscanner_nat_gw) explaining
-  # the next trainwreck of a line
-  allocation_id = "${element(coalescelist(data.aws_eip.cyhy_vulnscan_nat_gw_eip.*.id, aws_eip.cyhy_vulnscan_nat_gw_random_eip.*.id), 0)}"
-  subnet_id = "${aws_subnet.cyhy_public_subnet.id}"
-
-  depends_on = [
-    "aws_internet_gateway.cyhy_igw"
-  ]
-
-  tags = "${merge(var.tags, map("Name", "CyHy Vuln Scanner NATGW"))}"
+  tags = "${merge(var.tags, map("Name", "CyHy NAT GW"))}"
 }
 
 # The internet gateway for the VPC
@@ -143,91 +96,51 @@ resource "aws_internet_gateway" "cyhy_igw" {
   tags = "${merge(var.tags, map("Name", "CyHy IGW"))}"
 }
 
-# Default route table for VPC, which routes all external traffic through the
-# Port Scanner NAT gateway
+# Default route table for VPC, which routes all external traffic
+# through the internet gateway
 resource "aws_default_route_table" "cyhy_default_route_table" {
   default_route_table_id = "${aws_vpc.cyhy_vpc.default_route_table_id}"
 
   tags = "${merge(var.tags, map("Name", "CyHy Port Scanners"))}"
 }
 
-# Default route: Route all external traffic through the Port Scanner NAT gateway
-resource "aws_route" "cyhy_default_route_external_traffic_through_portscanner_nat_gateway" {
+# Default route: Route all external traffic through the internet
+# gateway
+resource "aws_route" "cyhy_default_route_external_traffic_through_internet_gateway" {
   route_table_id = "${aws_default_route_table.cyhy_default_route_table.id}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id = "${aws_nat_gateway.cyhy_portscanner_nat_gw.id}"
-}
-
-# Route table for our vulnscanner subnet, which routes all external traffic
-# through the Vuln Scanner NAT gateway
-resource "aws_route_table" "cyhy_vulnscanner_route_table" {
-  vpc_id = "${aws_vpc.cyhy_vpc.id}"
-
-  tags = "${merge(var.tags, map("Name", "CyHy Vuln Scanners"))}"
-}
-
-# Vulnscanner route: Route all external traffic through the Vuln Scanner NAT gateway
-resource "aws_route" "cyhy_vulnscanner_route_external_traffic_through_vulnscanner_nat_gateway" {
-  route_table_id = "${aws_route_table.cyhy_vulnscanner_route_table.id}"
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id = "${aws_nat_gateway.cyhy_vulnscanner_nat_gw.id}"
-}
-
-# Associate the route table with the vulnscanner subnet
-resource "aws_route_table_association" "cyhy_vulnscanner_association" {
-  subnet_id = "${aws_subnet.cyhy_vulnscanner_subnet.id}"
-  route_table_id = "${aws_route_table.cyhy_vulnscanner_route_table.id}"
+  gateway_id = "${aws_internet_gateway.cyhy_igw.id}"
 }
 
 # Route table for our private subnet, which routes:
 # - all BOD traffic through the VPC peering connection
-# - all other external traffic through the Port Scanner NAT gateway
+# - all other external traffic through the NAT gateway
 resource "aws_route_table" "cyhy_private_route_table" {
   vpc_id = "${aws_vpc.cyhy_vpc.id}"
 
   tags = "${merge(var.tags, map("Name", "CyHy Private"))}"
 }
 
-# Private route: Route all BOD traffic through the VPC peering connection
+# Private route: Route all BOD traffic through the VPC peering
+# connection
 resource "aws_route" "cyhy_private_route_external_traffic_through_vpc_peering_connection" {
   route_table_id = "${aws_route_table.cyhy_private_route_table.id}"
   destination_cidr_block = "${aws_vpc.bod_vpc.cidr_block}"
   vpc_peering_connection_id = "${aws_vpc_peering_connection.peering_connection.id}"
 }
 
-# Private route: Route all (non-BOD) external traffic through the
-# Port Scanner NAT gateway
-resource "aws_route" "cyhy_private_route_external_traffic_through_portscanner_nat_gateway" {
+# Private route: Route all (non-BOD) external traffic through the NAT
+# gateway
+resource "aws_route" "cyhy_private_route_external_traffic_through_nat_gateway" {
   route_table_id = "${aws_route_table.cyhy_private_route_table.id}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id = "${aws_nat_gateway.cyhy_portscanner_nat_gw.id}"
+  nat_gateway_id = "${aws_nat_gateway.cyhy_nat_gw.id}"
 }
 
 # Associate the route table with the private subnet
 resource "aws_route_table_association" "cyhy_private_association" {
   subnet_id = "${aws_subnet.cyhy_private_subnet.id}"
   route_table_id = "${aws_route_table.cyhy_private_route_table.id}"
-}
-
-# Route table for our public subnet, which routes all external traffic
-# through the internet gateway
-resource "aws_route_table" "cyhy_public_route_table" {
-  vpc_id = "${aws_vpc.cyhy_vpc.id}"
-
-  tags = "${merge(var.tags, map("Name", "CyHy Public"))}"
-}
-
-# Public route: Route all external traffic through the internet gateway
-resource "aws_route" "cyhy_public_route_external_traffic_through_internet_gateway" {
-  route_table_id = "${aws_route_table.cyhy_public_route_table.id}"
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.cyhy_igw.id}"
-}
-
-# Associate the route table with the public subnet
-resource "aws_route_table_association" "cyhy_public_association" {
-  subnet_id = "${aws_subnet.cyhy_public_subnet.id}"
-  route_table_id = "${aws_route_table.cyhy_public_route_table.id}"
 }
 
 # ACL for the private subnet of the VPC

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,12 +66,14 @@ variable "cyhy_archive_bucket_name" {
   default = "ncats-cyhy-archive"
 }
 
-variable "cyhy_nmap_elastic_ip" {
-  description = "The IP address of the elastic IP to be assigned to the CyHy nmap instance"
-  default = ""
+variable "cyhy_nmap_elastic_ips" {
+  type = "list"
+  description = "The IP addresses of the elastic IPs to be assigned to the CyHy nmap instances.  These values are only used in a production workspace, and in that case the number of elements in the list should equal the number of nmap instances being created."
+  default = []
 }
 
-variable "cyhy_vulnscan_nat_gw_elastic_ip" {
-  description = "The IP address of the elastic IP to be assigned to the CyHy Vulnscan NAT gateway"
-  default = ""
+variable "cyhy_vulnscan_elastic_ips" {
+  type = "list"
+  description = "The IP addresses of the elastic IPs to be assigned to the CyHy vulnscan instances.  These values are only used in a production workspace, and in that case the number of elements in the list should equal the number of Nessus instances being created."
+  default = []
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,8 +66,8 @@ variable "cyhy_archive_bucket_name" {
   default = "ncats-cyhy-archive"
 }
 
-variable "cyhy_portscan_nat_gw_elastic_ip" {
-  description = "The IP address of the elastic IP to be assigned to the CyHy Portscan NAT gateway"
+variable "cyhy_nmap_elastic_ip" {
+  description = "The IP address of the elastic IP to be assigned to the CyHy nmap instance"
   default = ""
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,14 +66,14 @@ variable "cyhy_archive_bucket_name" {
   default = "ncats-cyhy-archive"
 }
 
-variable "cyhy_nmap_elastic_ips" {
+variable "cyhy_portscan_elastic_ips" {
   type = "list"
-  description = "The IP addresses of the elastic IPs to be assigned to the CyHy nmap instances.  These values are only used in a production workspace, and in that case the number of elements in the list should equal the number of nmap instances being created."
+  description = "The IP addresses of the elastic IPs to be assigned to the CyHy portscan instances.  These values are only used in a production workspace, and in that case the number of elements in the list should equal the number of portscan (nmap) instances being created."
   default = []
 }
 
 variable "cyhy_vulnscan_elastic_ips" {
   type = "list"
-  description = "The IP addresses of the elastic IPs to be assigned to the CyHy vulnscan instances.  These values are only used in a production workspace, and in that case the number of elements in the list should equal the number of Nessus instances being created."
+  description = "The IP addresses of the elastic IPs to be assigned to the CyHy vulnscan instances.  These values are only used in a production workspace, and in that case the number of elements in the list should equal the number of vulnscan (Nessus) instances being created."
   default = []
 }


### PR DESCRIPTION
Since the NAT gateways did not give us the throughput that we needed, we removed them.  To keep our public IP footprint to the 4 elastic IPs that we have already publicized, we switch from many small nmap instances to one large nmap instance (until a better solution can be achieved).