### PR TITLE
Remove stray mode line

### DIFF
--- a/ansible/roles/cyhy_dashboard/tasks/main.yml
+++ b/ansible/roles/cyhy_dashboard/tasks/main.yml
@@ -42,7 +42,6 @@
 
 - name: Create random secret key for webd
   shell: touch /var/cyhy/web/secret_key
-  mode: 0664
   become_user: cyhy
   vars:
     ansible_ssh_pipelining: yes


### PR DESCRIPTION
A mode line makes no sense next to a shell command.  And it makes Ansible fail (at least Ansible version 2.7.4).