### PR TITLE
add cd to directory of script because the script expects the output d…

### DIFF
--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -120,4 +120,4 @@
     hour: 08
     minute: 15
     user: cyhy
-    job: python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --section production --aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg
+    job: cd /var/cyhy/scripts/cyhy-feeds && python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --section production --aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg


### PR DESCRIPTION
…irectory to be in the same directory