### PR TITLE
Upgrade mongo instance type

### DIFF
--- a/packer/ansible/roles/cyhy_commander/files/cyhy-commander.service
+++ b/packer/ansible/roles/cyhy_commander/files/cyhy-commander.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=cyhy-commander service
-After=network.target
+After=network.target mongod.service
 
 [Service]
 Type=simple

--- a/packer/ansible/roles/cyhy_runner/files/cyhy-runner.service
+++ b/packer/ansible/roles/cyhy_runner/files/cyhy-runner.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=cyhy-runner service
 After=network.target
+RequiresMountsFor=/var/cyhy/runner
 
 [Service]
 Type=simple

--- a/packer/ansible/roles/mongo/tasks/main.yml
+++ b/packer/ansible/roles/mongo/tasks/main.yml
@@ -48,6 +48,15 @@
     state: present
     line: ExecStart=/usr/bin/numactl --interleave=all /usr/bin/mongod --config /etc/mongod.conf
 
+- name: Make sure all mongo file systems are mounted before starting
+  lineinfile:
+    dest: /lib/systemd/system/mongod.service
+    firstmatch: yes
+    regexp: ^RequiresMountsFor=/var/lib/mongodb /var/lib/mongodb/journal /var/log/mongodb
+    insertafter: ^After=
+    state: present
+    line: RequiresMountsFor=/var/lib/mongodb /var/lib/mongodb/journal /var/log/mongodb
+
 # pymongo is needed for ansible mongodb_user module
 - name: Install pymongo via pip
   pip:

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -13,7 +13,7 @@
             ],
             "most_recent": true
         },
-        "instance_type": "t2.micro",
+        "instance_type": "t3.micro",
         "ssh_username": "admin",
         "ami_name": "cyhy-mongo-hvm-{{timestamp}}-x86_64-ebs",
         "ami_regions": [

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -23,8 +23,7 @@ data "aws_ami" "cyhy_mongo" {
 resource "aws_instance" "cyhy_mongo" {
   count = "${local.mongo_instance_count}"
   ami = "${data.aws_ami.cyhy_mongo.id}"
-  instance_type = "${local.production_workspace ? "m4.10xlarge" : "t2.micro"}"
-  ebs_optimized = "${local.production_workspace}"
+  instance_type = "${local.production_workspace ? "m5.10xlarge" : "t3.micro"}"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   subnet_id = "${aws_subnet.cyhy_private_subnet.id}"
   associate_public_ip_address = false

--- a/terraform/docker_cloud_init.tf
+++ b/terraform/docker_cloud_init.tf
@@ -9,6 +9,7 @@ data "template_file" "docker_disk_setup" {
     mount_point = "/var/cyhy/orchestrator/output"
     label = "report_data"
     fs_type = "xfs"
+    mount_options = "defaults"
   }
 }
 

--- a/terraform/mongo_cloud_init.tf
+++ b/terraform/mongo_cloud_init.tf
@@ -1,13 +1,52 @@
 # cloud-init commands for configuring ssh and mongo
 
-data "template_file" "mongo_disk_setup" {
-  template = "${file("scripts/mongo_disk_setup.yml")}"
+data "template_file" "mongo_data_disk_setup" {
+  template = "${file("${path.module}/scripts/disk_setup.sh")}"
 
   vars {
-    mongo_disk_data = "${var.mongo_disks["data"]}"
-    mongo_disk_journal = "${var.mongo_disks["journal"]}"
-    mongo_disk_log = "${var.mongo_disks["log"]}"
+    num_disks = 4
+    device_name = "${var.mongo_disks["data"]}"
+    mount_point = "/var/lib/mongodb"
+    label = "mongo_data"
+    fs_type = "xfs"
+    mount_options = "defaults"
   }
+}
+
+data "template_file" "mongo_journal_disk_setup" {
+  template = "${file("${path.module}/scripts/disk_setup.sh")}"
+
+  vars {
+    num_disks = 4
+    device_name = "${var.mongo_disks["journal"]}"
+    mount_point = "/var/lib/mongodb/journal"
+    label = "mongo_journal"
+    fs_type = "ext4"
+    # The x-systemd.requires bit forces the Mongo data disk to be
+    # mounted before this one
+    mount_options = "defaults,x-systemd.requires=/var/lib/mongodb"
+  }
+}
+
+data "template_file" "mongo_log_disk_setup" {
+  template = "${file("${path.module}/scripts/disk_setup.sh")}"
+
+  vars {
+    num_disks = 4
+    device_name = "${var.mongo_disks["log"]}"
+    mount_point = "/var/log/mongodb"
+    label = "mongo_log"
+    fs_type = "ext4"
+    mount_options = "defaults"
+  }
+}
+
+data "template_file" "mongo_journal_mountpoint_setup" {
+  template = "${file("${path.module}/scripts/mongo_journal_mountpoint_setup.sh")}"
+}
+
+data "template_file" "mongo_dir_setup" {
+  template = "${file("${path.module}/scripts/mongo_dir_setup.sh")}"
 }
 
 data "template_cloudinit_config" "ssh_and_mongo_cloud_init_tasks" {
@@ -15,22 +54,40 @@ data "template_cloudinit_config" "ssh_and_mongo_cloud_init_tasks" {
   base64_encode = true
 
   part {
-    filename     = "mongo_disk_setup.yml"
+    filename = "user_ssh_setup.yml"
     content_type = "text/cloud-config"
-    content      = "${data.template_file.mongo_disk_setup.rendered}"
+    content = "${data.template_file.user_ssh_setup.rendered}"
   }
 
   part {
-    filename     = "user_ssh_setup.yml"
+    filename = "cyhy_user_ssh_setup.yml"
     content_type = "text/cloud-config"
-    content      = "${data.template_file.user_ssh_setup.rendered}"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
+    content = "${data.template_file.cyhy_user_ssh_setup.rendered}"
+    merge_type = "list(append)+dict(recurse_array)+str()"
   }
 
   part {
-    filename     = "cyhy_user_ssh_setup.yml"
-    content_type = "text/cloud-config"
-    content      = "${data.template_file.cyhy_user_ssh_setup.rendered}"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.mongo_data_disk_setup.rendered}"
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.mongo_journal_mountpoint_setup.rendered}"
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.mongo_journal_disk_setup.rendered}"
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.mongo_log_disk_setup.rendered}"
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.mongo_dir_setup.rendered}"
   }
 }

--- a/terraform/nessus_cyhy_runner_cloud_init.tf
+++ b/terraform/nessus_cyhy_runner_cloud_init.tf
@@ -9,6 +9,7 @@ data "template_file" "nessus_disk_setup" {
     mount_point = "/var/cyhy/runner"
     label = "cyhy_runner"
     fs_type = "ext4"
+    mount_options = "defaults"
   }
 }
 

--- a/terraform/nmap_cyhy_runner_cloud_init.tf
+++ b/terraform/nmap_cyhy_runner_cloud_init.tf
@@ -9,6 +9,7 @@ data "template_file" "nmap_disk_setup" {
     mount_point = "/var/cyhy/runner"
     label = "cyhy_runner"
     fs_type = "ext4"
+    mount_options = "defaults"
   }
 }
 

--- a/terraform/reporter_cloud_init.tf
+++ b/terraform/reporter_cloud_init.tf
@@ -9,6 +9,7 @@ data "template_file" "reporter_disk_setup" {
     mount_point = "/var/cyhy/reports/output"
     label = "report_data"
     fs_type = "xfs"
+    mount_options = "defaults"
   }
 }
 

--- a/terraform/scripts/mongo_dir_setup.sh
+++ b/terraform/scripts/mongo_dir_setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Create the mongodb keyFile (if it's not already there)
+stat /var/lib/mongodb/keyFile || openssl rand -base64 741 > /var/lib/mongodb/keyFile
+chmod 600 /var/lib/mongodb/keyFile
+
+# Make the mongodb user the owner of the mongodb directories
+chown --verbose --recursive mongodb:mongodb /var/log/mongodb
+chown --verbose --recursive mongodb:mongodb /var/lib/mongodb

--- a/terraform/scripts/mongo_journal_mountpoint_setup.sh
+++ b/terraform/scripts/mongo_journal_mountpoint_setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Create the mongo journal mount point
+mkdir --verbose --parents /var/lib/mongodb/journal

--- a/terraform/scripts/non_nvme_disk_setup.sh
+++ b/terraform/scripts/non_nvme_disk_setup.sh
@@ -10,6 +10,8 @@
 # file system
 # fs_type - the file system type to use if it is necessary to create a
 # file system
+# mount_options - a comma-separated list of options to pass when
+# mounting (defaults or defaults,noauto, for example)
 
 set -o nounset
 set -o errexit
@@ -28,9 +30,9 @@ blkid -c /dev/null ${device_name} || mkfs -t ${fs_type} -L ${label} ${device_nam
 uuid=$(blkid -s UUID -o value ${device_name})
 
 # Mount the file system
-mount UUID="$uuid" ${mount_point}
+mount UUID="$uuid" -o ${mount_options} ${mount_point}
 
 # Save the mount point in fstab, so the file system is remounted if
 # the instance is rebooted
 echo "# ${label}" >> /etc/fstab
-echo "UUID=$uuid ${mount_point} ${fs_type} defaults 0 2" >> /etc/fstab
+echo "UUID=$uuid ${mount_point} ${fs_type} ${mount_options} 0 2" >> /etc/fstab


### PR DESCRIPTION
The mongo EC2 instance now uses latest-generation hardware that supports NVMe volumes.  This necessitated some minor changes to cloud-init scripts for other instances that have additional volumes as well.

In addition, the mongo EC2 instance as well as EC2 instances that involve cyhy-runner will now wait until all additional filesystems are mounted before starting the relevant services (`mongod` and `cyhy-runner`).

Finally, this pull request includes a minor change to ensure that `mongod` is started before `cyhy-commander`.  The lack of such a dependency was occasionally causing a failure when `cyhy-commander` started up due to the race condition.

This code has been tested via deployment to a test Terraform workspace (`jsf9k2`).