### PR TITLE
Move creation of the Mongo run directory from the second Ansible to the Mongo unit file

### DIFF
--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -86,15 +86,6 @@
     state: absent
   become: no
 
-# /var/run/mongodb is used to store a file containing the mongod pid
-- name: Create the /var/run/mongodb directory
-  file:
-    path: /var/run/mongodb
-    state: directory
-    owner: mongodb
-    group: mongodb
-    mode: 0744
-
 - name: Copy mongo configuration file
   template:
     src: mongod.conf

--- a/packer/ansible/roles/mongo/tasks/main.yml
+++ b/packer/ansible/roles/mongo/tasks/main.yml
@@ -94,6 +94,26 @@
     state: present
     line: AssertPathIsMountPoint=/var/log/mongodb
 
+# /run/mongodb (AKA /var/run/mnogodb) is used to store a file
+# containing the mongod pid.  We shouldn't start up until that
+# directory exists and has teh correct permissions.
+- name: Make sure /run/mongodb is created before starting
+  lineinfile:
+    dest: /lib/systemd/system/mongod.service
+    firstmatch: yes
+    regexp: ^RuntimeDirectory=mongodb
+    insertafter: ^Group=mongodb
+    state: present
+    line: RuntimeDirectory=mongodb
+- name: Make sure /run/mongodb has the correct permissions before starting
+  lineinfile:
+    dest: /lib/systemd/system/mongod.service
+    firstmatch: yes
+    regexp: ^RuntimeDirectoryMode=0744
+    insertafter: ^RuntimeDirectory=mongodb
+    state: present
+    line: RuntimeDirectoryMode=0744
+
 # pymongo is needed for ansible mongodb_user module
 - name: Install pymongo via pip
   pip:


### PR DESCRIPTION
The second Ansible does not run on a reboot, so on a reboot the run directory does not get created and the MongoDB service cannot start.  `systemd` provides the `RuntimeDirectory` directive for the unit file for exactly this situation, so it makes sense to use it here.

I tested in the jsf9k Terraform workspace that this works and MongoDB automatically restarts after a reboot.