### PR TITLE
Change public zones from cyber.dhs.gov to ncats.cyber.dhs.gov.

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -48,10 +48,10 @@ locals {
   bod_private_domain = "local"
 
   # zone to use for public DNS
-  cyhy_public_zone  = "cyber.dhs.gov"
+  cyhy_public_zone  = "ncats.cyber.dhs.gov"
 
   # zone to use for public DNS
-  bod_public_zone  = "cyber.dhs.gov"
+  bod_public_zone  = "ncats.cyber.dhs.gov"
 
   # subdomains to use in the public_zone.
   # to create records directly in the public_zone set to ""


### PR DESCRIPTION
This is a change that @felddy asked for.  The analogous change has already been made in the [dhs-ncats/pca-teamserver-aws](https://github.com/dhs-ncats/pca-teamserver-aws) repository.

This change is simple, but it will likely break folks' local ssh configs.  It will also likely break the CyHy team's access to the Mongo DB in AWS.  Some coordination will be required before deployment.