### PR TITLE
Pull Lambda zips from an S3 bucket instead of from the local filesystem

### DIFF
--- a/terraform/bod_lambdas.tf
+++ b/terraform/bod_lambdas.tf
@@ -90,8 +90,11 @@ resource "aws_iam_role_policy" "lambda_ec2_policies" {
 resource "aws_lambda_function" "lambdas" {
   count = "${length(var.scan_types)}"
 
-  filename = "${var.lambda_function_zip_files[var.scan_types[count.index]]}"
-  source_code_hash = "${base64sha256(file(var.lambda_function_zip_files[var.scan_types[count.index]]))}"
+  # Terraform cannot access buckets that are not in the provider's
+  # region.  This limitation means that we have to create
+  # region-specific buckets.
+  s3_bucket = "${var.lambda_function_bucket}-${var.aws_region}"
+  s3_key = "${var.lambda_function_keys[var.scan_types[count.index]]}"
   function_name = "${var.lambda_function_names[var.scan_types[count.index]]}"
   role = "${aws_iam_role.lambda_roles.*.arn[count.index]}"
   handler = "lambda_handler.handler"

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -1,5 +1,5 @@
 # The reporter EC2 instance
-data "aws_ami" "cyhy_reporter" {
+data "aws_ami" "reporter" {
   filter {
     name = "name"
     values = [

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -39,16 +39,6 @@ locals {
     465,
     587
   ]
-
-  # These are the ports on which the BOD Lambda security group is
-  # allowed to egress anywhere
-  bod_lambda_egress_anywhere_ports = [
-    25,
-    80,
-    443,
-    465,
-    587
-  ]
   
   # These are the ports via which trusted networks are allowed to
   # access the Management hosts on the private subnet

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -111,9 +111,14 @@ variable "lambda_function_names" {
   description = "The names to use for the Lambda functions.  The keys are the values in scan_types."
 }
 
-variable "lambda_function_zip_files" {
+variable "lambda_function_bucket" {
+  type = "string"
+  description = "The name of the S3 bucket where the Lambda function zip files reside.  Terraform cannot access buckets that are not in the provider's region, so the region name will be appended to the bucket name to obtain the actual bucket where the zips are stored.  So if we are working in region us-west-1 and this variable has the value buckethead, then the zips will be looked for in the bucket buckethead-us-west-1."
+}
+
+variable "lambda_function_keys" {
   type = "map"
-  description = "The locations of the zip files for the Lambda functions.  The keys are the values in scan_types."
+  description = "The keys (names) of the zip files for the Lambda functions inside the S3 bucket.  The keys for the map are the values in scan_types."
 }
 
 variable "dmarc_import_aws_region" {


### PR DESCRIPTION
I am making this enhancement because then I can upload the correct zips to the appropriate bucket.  Then other users need not worry about generating the zips themselves in another repo, or making sure that the zips end up in the correct location.  This makes life easier for everyone.

Note that Terraform cannot access buckets that are not in the provider's region.  This limitation means that we have to create region-specific buckets.

This PR is also a bugfix since it corrects a couple of minor issues that somehow made it through #153 and/or #154.