### PR TITLE
Remove explicit touch command

### DIFF
--- a/ansible/roles/cyhy_dashboard/tasks/main.yml
+++ b/ansible/roles/cyhy_dashboard/tasks/main.yml
@@ -40,19 +40,13 @@
     group: cyhy
     mode: 0750
 
-- name: Create random secret key for webd
-  shell: touch /var/cyhy/web/secret_key
-  become_user: cyhy
-  vars:
-    ansible_ssh_pipelining: yes
-
-- name: create secret key file
+- name: Create secret key file for webd
   file:
     path: /var/cyhy/web/secret_key
     owner: cyhy
     group: cyhy
     mode: 0664
-  become_user: cyhy
+    state: touch
   vars:
     ansible_ssh_pipelining: yes
 


### PR DESCRIPTION
We can instead use the `file` Ansible module and set the state parameter equal to `touch`.

When we use the `command` Ansible module to run `touch` it generates a warning, which has been slowly driving me mad.  Today I finally got around to fixing this.