### PR TITLE
Allow the user to specify docker-compose override files

### DIFF
--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -66,6 +66,20 @@
       [default]
       region = {{ ses_aws_region }}
 
+# docker-compose will automatically use docker-compose.yml and
+# docker-compose.override.yml, so this is a way for us to tune
+# docker-compose's behavior to the particular machine.
+#
+# In our case we want to send the BOD 18-01 reports on the BOD docker
+# instance and the CyHy-related reports on the reporter instance.
+- name: Create a symlink for the docker-compose override file
+  file:
+    src: /var/cyhy/cyhy-mailer/{{ docker_compose_override_file_for_mailer }}
+    path: /var/cyhy/cyhy-mailer/docker-compose.override.yml
+    state: link
+    owner: cyhy
+    group: cyhy
+    mode: 0664
 
 #
 # Create a cron job for the sending of reports
@@ -77,8 +91,7 @@
 #     value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 #     user: cyhy
 #   when: production_workspace
-# This cron job runs at noon UTC on Mondays.  The BOD reports are long
-# since completed by that time.
+#
 # - name: Create a cron job for sending BOD 18-01 reports
 #   cron:
 #     name: "Sending BOD 18-01 reports"

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -161,7 +161,10 @@ module "bod_docker_ansible_provisioner" {
     "production_workspace=${local.production_workspace}",
     "aws_region=${var.aws_region}",
     "dmarc_import_aws_region=${var.dmarc_import_aws_region}",
-    "ses_aws_region=${var.ses_aws_region}"
+    "ses_aws_region=${var.ses_aws_region}",
+    # This file will be used to add/override any settings in
+    # docker-compose.yml (for cyhy-mailer).
+    "docker_compose_override_file_for_mailer=${var.docker_mailer_override_filename}"
   ]
   playbook = "../ansible/playbook.yml"
   dry_run = false

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -111,6 +111,9 @@ module "cyhy_reporter_ansible_provisioner" {
     "mongo_host=${aws_instance.cyhy_mongo.private_ip}",
     "production_workspace=${local.production_workspace}",
     "ses_aws_region=${var.ses_aws_region}",
+    # This file will be used to add/override any settings in
+    # docker-compose.yml (for cyhy-mailer).
+    "docker_compose_override_file_for_mailer=${var.reporter_mailer_override_filename}"
   ]
   playbook = "../ansible/playbook.yml"
   dry_run = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -135,6 +135,16 @@ variable "ses_aws_region" {
   default = "us-east-1"
 }
 
+variable "reporter_mailer_override_filename" {
+  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
+  default = "docker-compose.cyhy.yml"
+}
+
+variable "docker_mailer_override_filename" {
+  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the docker EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
+  default = "docker-compose.bod.yml"
+}
+
 # If additional VPCs are added in the future:
 #  - Ensure that they include security groups and ACLs that allow complete
 #    access by the vulnscanner in the management VPC


### PR DESCRIPTION
`docker-compose` by default reads in the `docker-compose.yml` and `docker-compose.override.yml` files.  By symlinking the proper YML file to `docker-compose.override.yml` in the second Ansible, we can install the proper configuration for the docker and reporter EC2 instances.  In particular, the docker instance will send the BOD 18-01 reports and the reporter instance will send the Cyber Hygiene reports and the Cyber Exposure scorecard.

See also cisagov/cyhy-mailer#42, where I created the override files specific to the cyhy and docker EC2 instances.