### PR TITLE
Improvement/more dynamic mgmt vpc

### DIFF
--- a/terraform/bod_bastion_security_group_rules.tf
+++ b/terraform/bod_bastion_security_group_rules.tf
@@ -38,7 +38,7 @@ resource "aws_security_group_rule" "bastion_ssh_to_docker" {
 # Allow all ICMP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_bastion_ingress_all_icmp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_bastion_sg.id}"
   type = "ingress"
@@ -53,7 +53,7 @@ resource "aws_security_group_rule" "bod_bastion_ingress_all_icmp_from_mgmt_vulns
 # Allow all TCP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_bastion_ingress_all_tcp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_bastion_sg.id}"
   type = "ingress"
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "bod_bastion_ingress_all_tcp_from_mgmt_vulnsc
 # Allow all UDP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_bastion_ingress_all_udp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_bastion_sg.id}"
   type = "ingress"
@@ -83,7 +83,7 @@ resource "aws_security_group_rule" "bod_bastion_ingress_all_udp_from_mgmt_vulnsc
 # Allow all ICMP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_bastion_egress_all_icmp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_bastion_sg.id}"
   type = "egress"
@@ -98,7 +98,7 @@ resource "aws_security_group_rule" "bod_bastion_egress_all_icmp_to_mgmt_vulnscan
 # Allow all TCP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_bastion_egress_all_tcp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_bastion_sg.id}"
   type = "egress"
@@ -113,7 +113,7 @@ resource "aws_security_group_rule" "bod_bastion_egress_all_tcp_to_mgmt_vulnscan"
 # Allow all UDP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_bastion_egress_all_udp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_bastion_sg.id}"
   type = "egress"

--- a/terraform/bod_docker_acl_rules.tf
+++ b/terraform/bod_docker_acl_rules.tf
@@ -56,7 +56,7 @@ resource "aws_network_acl_rule" "docker_egress_to_public_via_ephemeral_ports" {
 # Allow all ports and protocols from Management private subnet to ingress,
 # for internal scanning
 resource "aws_network_acl_rule" "bod_private_ingress_all_from_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.bod_docker_acl.id}"
   egress = false
@@ -71,7 +71,7 @@ resource "aws_network_acl_rule" "bod_private_ingress_all_from_mgmt_private" {
 # Allow all ports and protocols to egress to Management private subnet,
 # for internal scanning
 resource "aws_network_acl_rule" "bod_private_egress_all_to_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.bod_docker_acl.id}"
   egress = true

--- a/terraform/bod_docker_security_group_rules.tf
+++ b/terraform/bod_docker_security_group_rules.tf
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "docker_egress_to_cyhy_private_via_mongodb" {
 # Allow all ICMP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_docker_ingress_all_icmp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_docker_sg.id}"
   type = "ingress"
@@ -64,7 +64,7 @@ resource "aws_security_group_rule" "bod_docker_ingress_all_icmp_from_mgmt_vulnsc
 # Allow all TCP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_docker_ingress_all_tcp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_docker_sg.id}"
   type = "ingress"
@@ -79,7 +79,7 @@ resource "aws_security_group_rule" "bod_docker_ingress_all_tcp_from_mgmt_vulnsca
 # Allow all UDP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_docker_ingress_all_udp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_docker_sg.id}"
   type = "ingress"
@@ -94,7 +94,7 @@ resource "aws_security_group_rule" "bod_docker_ingress_all_udp_from_mgmt_vulnsca
 # Allow all ICMP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_docker_egress_all_icmp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_docker_sg.id}"
   type = "egress"
@@ -109,7 +109,7 @@ resource "aws_security_group_rule" "bod_docker_egress_all_icmp_to_mgmt_vulnscan"
 # Allow all TCP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_docker_egress_all_tcp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_docker_sg.id}"
   type = "egress"
@@ -124,7 +124,7 @@ resource "aws_security_group_rule" "bod_docker_egress_all_tcp_to_mgmt_vulnscan" 
 # Allow all UDP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "bod_docker_egress_all_udp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.bod_docker_sg.id}"
   type = "egress"

--- a/terraform/bod_public_acl_rules.tf
+++ b/terraform/bod_public_acl_rules.tf
@@ -117,7 +117,7 @@ resource "aws_network_acl_rule" "bod_public_egress_to_anywhere_via_ephemeral_por
 # Allow all ports and protocols from Management private subnet to ingress,
 # for internal scanning
 resource "aws_network_acl_rule" "bod_public_ingress_all_from_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.bod_public_acl.id}"
   egress = false
@@ -132,7 +132,7 @@ resource "aws_network_acl_rule" "bod_public_ingress_all_from_mgmt_private" {
 # Allow all ports and protocols to egress to Management private subnet,
 # for internal scanning
 resource "aws_network_acl_rule" "bod_public_egress_all_to_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.bod_public_acl.id}"
   egress = true

--- a/terraform/bod_vpc.tf
+++ b/terraform/bod_vpc.tf
@@ -128,7 +128,7 @@ resource "aws_route" "bod_route_cyhy_traffic_through_peering_connection" {
 
 # Route all Management VPC traffic through the VPC peering connection
 resource "aws_route" "bod_route_mgmt_traffic_through_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   route_table_id = "${aws_default_route_table.bod_default_route_table.id}"
   destination_cidr_block = "${aws_vpc.mgmt_vpc.cidr_block}"
@@ -151,7 +151,7 @@ resource "aws_route_table" "bod_public_route_table" {
 
 # Route all Management VPC traffic through the VPC peering connection
 resource "aws_route" "bod_public_route_mgmt_traffic_through_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   route_table_id = "${aws_route_table.bod_public_route_table.id}"
   destination_cidr_block = "${aws_vpc.mgmt_vpc.cidr_block}"

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -25,6 +25,7 @@ import sys
 assert sys.version_info >= (3,7), 'This script requires Python version 3.7 or newer'
 
 # for each workspace, set the number of instances to create for each template
+# NOTE: mgmt_bastion should only be set to 0 or 1
 WORKSPACE_CONFIGS = {
     'production': {
         'nmap': 64, 'nessus': 3, 'mongo': 1,

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -26,21 +26,35 @@ assert sys.version_info >= (3,7), 'This script requires Python version 3.7 or ne
 
 # for each workspace, set the number of instances to create for each template
 WORKSPACE_CONFIGS = {
-                        'production':   {'nmap':64, 'nessus':3, 'mongo':1},
-                        'prod-a':       {'nmap':64, 'nessus':3, 'mongo':1},
-                        'prod-b':       {'nmap':64, 'nessus':3, 'mongo':1},
-                        'felddy':       {'nmap':4, 'nessus':1, 'mongo':1},
-                        'jsf9k':        {'nmap':0, 'nessus':0, 'mongo':1},
-                    }
+    'production': {
+        'nmap': 64, 'nessus': 3, 'mongo': 1,
+        'mgmt_bastion': 0, 'mgmt_nessus': 0},
+    'prod-a': {
+        'nmap': 64, 'nessus': 3, 'mongo': 1,
+        'mgmt_bastion': 0, 'mgmt_nessus': 0},
+    'prod-b': {
+        'nmap': 64, 'nessus': 3, 'mongo': 1,
+        'mgmt_bastion': 0, 'mgmt_nessus': 0},
+    'felddy': {
+        'nmap': 4, 'nessus': 1, 'mongo': 1,
+        'mgmt_bastion': 0, 'mgmt_nessus': 0},
+    'jsf9k': {
+        'nmap': 0, 'nessus': 0, 'mongo': 1,
+        'mgmt_bastion': 0, 'mgmt_nessus': 0}
+    }
 
 # the default configuration if a workspace is not defined above
-DEFAULT_CONFIG =    {'nmap':1, 'nessus':1, 'mongo':1}
+DEFAULT_CONFIG = {
+        'nmap': 1, 'nessus': 1, 'mongo': 1,
+        'mgmt_bastion': 0, 'mgmt_nessus': 0}
 
 # variables to be defined in a dynamic locals file
 LOCAL_DEFS = {
-    'nmap':     'nmap_instance_count',
-    'nessus':   'nessus_instance_count',
-    'mongo':    'mongo_instance_count'
+    'nmap':          'nmap_instance_count',
+    'nessus':        'nessus_instance_count',
+    'mongo':         'mongo_instance_count',
+    'mgmt_bastion':  'mgmt_bastion_instance_count',
+    'mgmt_nessus':   'mgmt_nessus_instance_count'
     }
 
 # filename constant definitions

--- a/terraform/cyhy_bastion_security_group_rules.tf
+++ b/terraform/cyhy_bastion_security_group_rules.tf
@@ -100,7 +100,7 @@ resource "aws_security_group_rule" "bastion_egress_for_webd" {
 # Allow all ICMP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "cyhy_bastion_ingress_all_icmp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
   type = "ingress"
@@ -115,7 +115,7 @@ resource "aws_security_group_rule" "cyhy_bastion_ingress_all_icmp_from_mgmt_vuln
 # Allow all TCP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "cyhy_bastion_ingress_all_tcp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
   type = "ingress"
@@ -130,7 +130,7 @@ resource "aws_security_group_rule" "cyhy_bastion_ingress_all_tcp_from_mgmt_vulns
 # Allow all UDP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "cyhy_bastion_ingress_all_udp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
   type = "ingress"
@@ -145,7 +145,7 @@ resource "aws_security_group_rule" "cyhy_bastion_ingress_all_udp_from_mgmt_vulns
 # Allow all ICMP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "cyhy_bastion_egress_all_icmp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
   type = "egress"
@@ -160,7 +160,7 @@ resource "aws_security_group_rule" "cyhy_bastion_egress_all_icmp_to_mgmt_vulnsca
 # Allow all TCP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "cyhy_bastion_egress_all_tcp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
   type = "egress"
@@ -175,7 +175,7 @@ resource "aws_security_group_rule" "cyhy_bastion_egress_all_tcp_to_mgmt_vulnscan
 # Allow all UDP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "cyhy_bastion_egress_all_udp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_bastion_sg.id}"
   type = "egress"

--- a/terraform/cyhy_portscanner_acl_rules.tf
+++ b/terraform/cyhy_portscanner_acl_rules.tf
@@ -65,7 +65,7 @@ resource "aws_network_acl_rule" "portscanner_egress_to_anywhere_via_any_port" {
 # Allow all ports and protocols from Management private subnet to ingress,
 # for internal scanning
 resource "aws_network_acl_rule" "portscanner_ingress_all_from_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.cyhy_portscanner_acl.id}"
   egress = false

--- a/terraform/cyhy_private_acl_rules.tf
+++ b/terraform/cyhy_private_acl_rules.tf
@@ -98,7 +98,7 @@ resource "aws_network_acl_rule" "private_egress_to_bod_docker_via_ephemeral_port
 # Allow all ports and protocols from Management private subnet to ingress,
 # for internal scanning
 resource "aws_network_acl_rule" "cyhy_private_ingress_all_from_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
   egress = false
@@ -113,7 +113,7 @@ resource "aws_network_acl_rule" "cyhy_private_ingress_all_from_mgmt_private" {
 # Allow all ports and protocols to egress to Management private subnet,
 # for internal scanning
 resource "aws_network_acl_rule" "cyhy_private_egress_all_to_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.cyhy_private_acl.id}"
   egress = true

--- a/terraform/cyhy_private_security_group_rules.tf
+++ b/terraform/cyhy_private_security_group_rules.tf
@@ -109,7 +109,7 @@ resource "aws_security_group_rule" "private_webd_egress_to_webui" {
 # Allow all ICMP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "private_ingress_all_icmp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"
   type = "ingress"
@@ -124,7 +124,7 @@ resource "aws_security_group_rule" "private_ingress_all_icmp_from_mgmt_vulnscan"
 # Allow all TCP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "private_ingress_all_tcp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"
   type = "ingress"
@@ -139,7 +139,7 @@ resource "aws_security_group_rule" "private_ingress_all_tcp_from_mgmt_vulnscan" 
 # Allow all UDP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "private_ingress_all_udp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"
   type = "ingress"
@@ -154,7 +154,7 @@ resource "aws_security_group_rule" "private_ingress_all_udp_from_mgmt_vulnscan" 
 # Allow all ICMP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "private_egress_all_icmp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"
   type = "egress"
@@ -169,7 +169,7 @@ resource "aws_security_group_rule" "private_egress_all_icmp_to_mgmt_vulnscan" {
 # Allow all TCP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "private_egress_all_tcp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"
   type = "egress"
@@ -184,7 +184,7 @@ resource "aws_security_group_rule" "private_egress_all_tcp_to_mgmt_vulnscan" {
 # Allow all UDP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "private_egress_all_udp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"
   type = "egress"

--- a/terraform/cyhy_public_acl_rules.tf
+++ b/terraform/cyhy_public_acl_rules.tf
@@ -91,7 +91,7 @@ resource "aws_network_acl_rule" "public_ingress_from_vulncanner_via_any_port" {
 # Allow all ports and protocols from Management private subnet to ingress,
 # for internal scanning
 resource "aws_network_acl_rule" "public_ingress_all_from_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.cyhy_public_acl.id}"
   egress = false

--- a/terraform/cyhy_vpc.tf
+++ b/terraform/cyhy_vpc.tf
@@ -115,7 +115,7 @@ resource "aws_route" "cyhy_default_route_external_traffic_through_internet_gatew
 # Default route: Route all Management traffic through the VPC peering
 # connection
 resource "aws_route" "cyhy_default_route_mgmt_traffic_through_mgmt_vpc_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   route_table_id = "${aws_default_route_table.cyhy_default_route_table.id}"
   destination_cidr_block = "${aws_vpc.mgmt_vpc.cidr_block}"
@@ -143,7 +143,7 @@ resource "aws_route" "cyhy_private_route_external_traffic_through_bod_vpc_peerin
 # Private route: Route all Management traffic through the VPC peering
 # connection
 resource "aws_route" "cyhy_private_route_external_traffic_through_mgmt_vpc_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
   
   route_table_id = "${aws_route_table.cyhy_private_route_table.id}"
   destination_cidr_block = "${aws_vpc.mgmt_vpc.cidr_block}"

--- a/terraform/cyhy_vulnscanner_acl_rules.tf
+++ b/terraform/cyhy_vulnscanner_acl_rules.tf
@@ -67,7 +67,7 @@ resource "aws_network_acl_rule" "vulnscanner_egress_to_anywhere_via_any_port" {
 # Allow all ports and protocols from Management private subnet to ingress,
 # for internal scanning
 resource "aws_network_acl_rule" "vulnscanner_ingress_all_from_mgmt_vpc" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.cyhy_vulnscanner_acl.id}"
   egress = false

--- a/terraform/dyn_mgmt_bastion/mgmt_bastion.template
+++ b/terraform/dyn_mgmt_bastion/mgmt_bastion.template
@@ -1,0 +1,15 @@
+# Provision a Management Bastion EC2 instance via Ansible
+module "mgmt_bastion_ansible_provisioner_$index" {
+  source = "github.com/cloudposse/tf_ansible"
+
+  arguments = [
+    "--user=$${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no'"
+  ]
+  envs = [
+    "host=$${var.mgmt_bastion_public_ip}",
+    "host_groups=mgmt_bastion"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}

--- a/terraform/dyn_mgmt_bastion/variables.tf
+++ b/terraform/dyn_mgmt_bastion/variables.tf
@@ -1,0 +1,2 @@
+variable "mgmt_bastion_public_ip" {}
+variable "remote_ssh_user" {}

--- a/terraform/dyn_mgmt_nessus/mgmt_nessus.template
+++ b/terraform/dyn_mgmt_nessus/mgmt_nessus.template
@@ -1,0 +1,17 @@
+# Provision a Management Nessus EC2 instance via Ansible
+module "mgmt_nessus_ansible_provisioner_$index" {
+  source = "github.com/cloudposse/tf_ansible"
+
+  arguments = [
+    "--user=$${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q $${var.remote_ssh_user}@$${var.mgmt_bastion_public_ip}\"'"
+  ]
+  envs = [
+    "host=$${element(var.mgmt_nessus_private_ips, $index)}",
+    "bastion_host=$${var.mgmt_bastion_public_ip}",
+    "host_groups=nessus",
+    "nessus_activation_code=$${var.mgmt_nessus_activation_codes[$index]}"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}

--- a/terraform/dyn_mgmt_nessus/variables.tf
+++ b/terraform/dyn_mgmt_nessus/variables.tf
@@ -1,0 +1,4 @@
+variable "mgmt_bastion_public_ip" {}
+variable "mgmt_nessus_private_ips" { type = "list" }
+variable "mgmt_nessus_activation_codes" { type = "list" }
+variable "remote_ssh_user" {}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -101,3 +101,4 @@ locals {
 
   # Management Vulnerability Scanner DNS entries
   count_mgmt_vuln_scanner = "${local.mgmt_nessus_instance_count}"
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -39,7 +39,7 @@ locals {
     465,
     587
   ]
-  
+
   # These are the ports via which trusted networks are allowed to
   # access the Management hosts on the private subnet
   mgmt_trusted_ingress_ports = [
@@ -98,4 +98,6 @@ locals {
 
   # Database DNS entries
   count_database = "${local.mongo_instance_count}"
-}
+
+  # Management Vulnerability Scanner DNS entries
+  count_mgmt_vuln_scanner = "${local.mgmt_nessus_instance_count}"

--- a/terraform/mgmt_bastion_ec2.tf
+++ b/terraform/mgmt_bastion_ec2.tf
@@ -20,8 +20,7 @@ resource "aws_instance" "mgmt_bastion" {
     "${aws_security_group.mgmt_bastion_sg.id}"
   ]
 
-  #TODO: Make this user_data_base64
-  user_data = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
+  user_data_base64 = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
 
   tags = "${merge(var.tags, map("Name", "Management Bastion"))}"
   volume_tags = "${merge(var.tags, map("Name", "Management Bastion"))}"

--- a/terraform/mgmt_bastion_ec2.tf
+++ b/terraform/mgmt_bastion_ec2.tf
@@ -1,5 +1,7 @@
 # The bastion EC2 instance
 resource "aws_instance" "mgmt_bastion" {
+  count = "${var.enable_mgmt_vpc}"
+
   ami = "${data.aws_ami.bastion.id}"
   instance_type = "t3.micro"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
@@ -18,24 +20,16 @@ resource "aws_instance" "mgmt_bastion" {
     "${aws_security_group.mgmt_bastion_sg.id}"
   ]
 
+  #TODO: Make this user_data_base64
   user_data = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
 
   tags = "${merge(var.tags, map("Name", "Management Bastion"))}"
   volume_tags = "${merge(var.tags, map("Name", "Management Bastion"))}"
 }
 
-# Provision the bastion EC2 instance via Ansible
-module "mgmt_bastion_ansible_provisioner" {
-  source = "github.com/cloudposse/tf_ansible"
-
-  arguments = [
-    "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no'"
-  ]
-  envs = [
-    "host=${aws_instance.mgmt_bastion.public_ip}",
-    "host_groups=mgmt_bastion"
-  ]
-  playbook = "../ansible/playbook.yml"
-  dry_run = false
+# load in the dynamically created provisioner modules
+module "dyn_mgmt_bastion" {
+  source = "./dyn_mgmt_bastion"
+  mgmt_bastion_public_ip = "${aws_instance.mgmt_bastion.public_ip}"
+  remote_ssh_user = "${var.remote_ssh_user}"
 }

--- a/terraform/mgmt_bastion_security_group_rules.tf
+++ b/terraform/mgmt_bastion_security_group_rules.tf
@@ -1,5 +1,7 @@
 # Allow ingress from trusted networks via ssh
 resource "aws_security_group_rule" "mgmt_bastion_ingress_from_trusted_via_ssh" {
+  count = "${var.enable_mgmt_vpc}"
+
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "ingress"
   protocol = "tcp"
@@ -14,6 +16,8 @@ resource "aws_security_group_rule" "mgmt_bastion_ingress_from_trusted_via_ssh" {
 # We need this because Ansible uses the ssh proxy even when connecting
 # to the bastion.
 resource "aws_security_group_rule" "mgmt_bastion_self_ingress" {
+  count = "${var.enable_mgmt_vpc}"
+
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "ingress"
   protocol = "tcp"
@@ -29,6 +33,8 @@ resource "aws_security_group_rule" "mgmt_bastion_self_ingress" {
 # We need this because Ansible uses the ssh proxy even when connecting
 # to the bastion.
 resource "aws_security_group_rule" "mgmt_bastion_self_egress" {
+  count = "${var.enable_mgmt_vpc}"
+
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "egress"
   protocol = "tcp"
@@ -41,7 +47,7 @@ resource "aws_security_group_rule" "mgmt_bastion_self_egress" {
 
 # Allow egress via ssh and Nessus to the scanner security group
 resource "aws_security_group_rule" "mgmt_bastion_egress_to_scanner_sg_via_trusted_ports" {
-  count = "${length(local.mgmt_trusted_ingress_ports)}"
+  count = "${var.enable_mgmt_vpc * length(local.mgmt_trusted_ingress_ports)}"
 
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "egress"
@@ -54,7 +60,7 @@ resource "aws_security_group_rule" "mgmt_bastion_egress_to_scanner_sg_via_truste
 # Allow all ICMP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_bastion_ingress_all_icmp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "ingress"
@@ -69,7 +75,7 @@ resource "aws_security_group_rule" "mgmt_bastion_ingress_all_icmp_from_mgmt_vuln
 # Allow all TCP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_bastion_ingress_all_tcp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "ingress"
@@ -84,7 +90,7 @@ resource "aws_security_group_rule" "mgmt_bastion_ingress_all_tcp_from_mgmt_vulns
 # Allow all UDP from vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_bastion_ingress_all_udp_from_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "ingress"
@@ -99,7 +105,7 @@ resource "aws_security_group_rule" "mgmt_bastion_ingress_all_udp_from_mgmt_vulns
 # Allow all ICMP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_bastion_egress_all_icmp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "egress"
@@ -114,7 +120,7 @@ resource "aws_security_group_rule" "mgmt_bastion_egress_all_icmp_to_mgmt_vulnsca
 # Allow all TCP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_bastion_egress_all_tcp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "egress"
@@ -129,7 +135,7 @@ resource "aws_security_group_rule" "mgmt_bastion_egress_all_tcp_to_mgmt_vulnscan
 # Allow all UDP to vulnscanner instance in Management VPC,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_bastion_egress_all_udp_to_mgmt_vulnscan" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_bastion_sg.id}"
   type = "egress"

--- a/terraform/mgmt_nessus_ec2.tf
+++ b/terraform/mgmt_nessus_ec2.tf
@@ -1,4 +1,6 @@
 resource "aws_instance" "mgmt_nessus" {
+  count = "${var.enable_mgmt_vpc}"
+  
   ami = "${data.aws_ami.nessus.id}"
   instance_type = "m5.large"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
@@ -15,6 +17,7 @@ resource "aws_instance" "mgmt_nessus" {
     "${aws_security_group.mgmt_scanner_sg.id}"
   ]
 
+  #TODO: Make this user_data_base64
   user_data = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
 
   tags = "${merge(var.tags, map("Name", "Management Nessus - vulnscan1"))}"
@@ -26,20 +29,11 @@ resource "aws_instance" "mgmt_nessus" {
   }
 }
 
-# Provision a Nessus EC2 instance via Ansible
-module "mgmt_nessus_ansible_provisioner" {
-  source = "github.com/cloudposse/tf_ansible"
-
-  arguments = [
-    "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.mgmt_bastion.public_ip}\"'"
-  ]
-  envs = [
-    "host=${aws_instance.mgmt_nessus.private_ip}",
-    "bastion_host=${aws_instance.mgmt_bastion.public_ip}",
-    "host_groups=nessus",
-    "nessus_activation_code=${var.mgmt_nessus_activation_code}"
-  ]
-  playbook = "../ansible/playbook.yml"
-  dry_run = false
+# load in the dynamically created provisioner modules
+module "dyn_mgmt_nessus" {
+  source = "./dyn_mgmt_nessus"
+  mgmt_bastion_public_ip = "${aws_instance.mgmt_bastion.public_ip}"
+  mgmt_nessus_private_ips = "${aws_instance.mgmt_nessus.*.private_ip}"
+  mgmt_nessus_activation_codes = "${var.mgmt_nessus_activation_codes}"
+  remote_ssh_user = "${var.remote_ssh_user}"
 }

--- a/terraform/mgmt_nessus_ec2.tf
+++ b/terraform/mgmt_nessus_ec2.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "mgmt_nessus" {
-  count = "${var.enable_mgmt_vpc}"
+  count = "${var.enable_mgmt_vpc * local.mgmt_nessus_instance_count}"
 
   ami = "${data.aws_ami.nessus.id}"
   instance_type = "m5.large"
@@ -19,8 +19,8 @@ resource "aws_instance" "mgmt_nessus" {
 
   user_data_base64 = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
 
-  tags = "${merge(var.tags, map("Name", "Management Nessus - vulnscan1"))}"
-  volume_tags = "${merge(var.tags, map("Name", "Management Nessus - vulnscan1"))}"
+  tags = "${merge(var.tags, map("Name", format("Management Nessus - vulnscan%d", count.index+1)))}"
+  volume_tags = "${merge(var.tags, map("Name", format("Management Nessus - vulnscan%d", count.index+1)))}"
 
   # If the instance is destroyed we will have to reset the license to nessus
   lifecycle {

--- a/terraform/mgmt_nessus_ec2.tf
+++ b/terraform/mgmt_nessus_ec2.tf
@@ -1,6 +1,6 @@
 resource "aws_instance" "mgmt_nessus" {
   count = "${var.enable_mgmt_vpc}"
-  
+
   ami = "${data.aws_ami.nessus.id}"
   instance_type = "m5.large"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
@@ -17,8 +17,7 @@ resource "aws_instance" "mgmt_nessus" {
     "${aws_security_group.mgmt_scanner_sg.id}"
   ]
 
-  #TODO: Make this user_data_base64
-  user_data = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
+  user_data_base64 = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
 
   tags = "${merge(var.tags, map("Name", "Management Nessus - vulnscan1"))}"
   volume_tags = "${merge(var.tags, map("Name", "Management Nessus - vulnscan1"))}"

--- a/terraform/mgmt_private_acl_rules.tf
+++ b/terraform/mgmt_private_acl_rules.tf
@@ -1,6 +1,6 @@
 # Allow ingress from public mgmt subnet (bastion) via the Nessus UI and ssh ports
 resource "aws_network_acl_rule" "mgmt_private_ingress_from_public_via_nessus_and_ssh" {
-  count = "${length(local.mgmt_trusted_ingress_ports)}"
+  count = "${var.enable_mgmt_vpc * length(local.mgmt_trusted_ingress_ports)}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = false
@@ -14,7 +14,7 @@ resource "aws_network_acl_rule" "mgmt_private_ingress_from_public_via_nessus_and
 
 # Allow ingress from anywhere via ephemeral ports
 resource "aws_network_acl_rule" "mgmt_private_ingress_from_anywhere_via_ephemeral_ports" {
-  count = "${length(local.tcp_and_udp)}"
+  count = "${var.enable_mgmt_vpc * length(local.tcp_and_udp)}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = false
@@ -29,7 +29,7 @@ resource "aws_network_acl_rule" "mgmt_private_ingress_from_anywhere_via_ephemera
 # Allow ICMP traffic from CyHy VPC to ingress, since we're scanning and will
 # want ping responses, etc.
 resource "aws_network_acl_rule" "mgmt_private_ingress_from_cyhy_vpc_via_icmp" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = false
@@ -44,7 +44,7 @@ resource "aws_network_acl_rule" "mgmt_private_ingress_from_cyhy_vpc_via_icmp" {
 # Allow ICMP traffic from BOD 18-01 VPC to ingress, since we're scanning and
 # will want ping responses, etc.
 resource "aws_network_acl_rule" "mgmt_private_ingress_from_bod_vpc_via_icmp" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = false
@@ -59,7 +59,7 @@ resource "aws_network_acl_rule" "mgmt_private_ingress_from_bod_vpc_via_icmp" {
 # Allow ICMP traffic from Management public subnet to ingress, since we're
 # scanning and will want ping responses, etc.
 resource "aws_network_acl_rule" "mgmt_private_ingress_from_mgmt_public_via_icmp" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = false
@@ -74,6 +74,8 @@ resource "aws_network_acl_rule" "mgmt_private_ingress_from_mgmt_public_via_icmp"
 # Allow egress anywhere via https
 # Needed for Nessus plugin updates
 resource "aws_network_acl_rule" "mgmt_private_egress_anywhere_via_https" {
+  count = "${var.enable_mgmt_vpc}"
+
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = true
   protocol = "tcp"
@@ -87,7 +89,7 @@ resource "aws_network_acl_rule" "mgmt_private_egress_anywhere_via_https" {
 # Allow egress to CyHy VPC via any protocol and port
 # Needed for vulnerability scanning of the CyHy VPC
 resource "aws_network_acl_rule" "mgmt_private_egress_to_cyhy_vpc_via_any_port" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = true
@@ -102,7 +104,7 @@ resource "aws_network_acl_rule" "mgmt_private_egress_to_cyhy_vpc_via_any_port" {
 # Allow egress to BOD 18-01 VPC via any protocol and port
 # Needed for vulnerability scanning of the BOD 18-01 VPC
 resource "aws_network_acl_rule" "mgmt_private_egress_to_bod_vpc_via_any_port" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = true
@@ -117,7 +119,7 @@ resource "aws_network_acl_rule" "mgmt_private_egress_to_bod_vpc_via_any_port" {
 # Allow egress to Management public subnet via any protocol and port
 # Needed for vulnerability scanning of the Management public subnet
 resource "aws_network_acl_rule" "mgmt_private_egress_to_mgmt_public_via_any_port" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = true
@@ -131,6 +133,8 @@ resource "aws_network_acl_rule" "mgmt_private_egress_to_mgmt_public_via_any_port
 
 # Allow egress to the bastion via ephemeral ports
 resource "aws_network_acl_rule" "mgmt_private_egress_to_bastion_via_ephemeral_ports" {
+  count = "${var.enable_mgmt_vpc}"
+
   network_acl_id = "${aws_network_acl.mgmt_private_acl.id}"
   egress = true
   protocol = "tcp"

--- a/terraform/mgmt_private_dns.tf
+++ b/terraform/mgmt_private_dns.tf
@@ -1,4 +1,6 @@
 resource "aws_route53_zone" "mgmt_private_zone" {
+  count = "${var.enable_mgmt_vpc}"
+
   name = "${local.mgmt_private_domain}."
   vpc {
     vpc_id = "${aws_vpc.mgmt_vpc.id}"
@@ -8,6 +10,8 @@ resource "aws_route53_zone" "mgmt_private_zone" {
 }
 
 resource "aws_route53_record" "mgmt_router_A" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_private_zone.zone_id}"
   name = "router.${aws_route53_zone.mgmt_private_zone.name}"
   type = "A"
@@ -19,6 +23,8 @@ resource "aws_route53_record" "mgmt_router_A" {
 }
 
 resource "aws_route53_record" "mgmt_ns_A" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_private_zone.zone_id}"
   name = "ns.${aws_route53_zone.mgmt_private_zone.name}"
   type = "A"
@@ -30,6 +36,8 @@ resource "aws_route53_record" "mgmt_ns_A" {
 }
 
 resource "aws_route53_record" "mgmt_reserved_A" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_private_zone.zone_id}"
   name = "reserved.${aws_route53_zone.mgmt_private_zone.name}"
   type = "A"
@@ -41,6 +49,8 @@ resource "aws_route53_record" "mgmt_reserved_A" {
 }
 
 resource "aws_route53_record" "mgmt_bastion_A" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_private_zone.zone_id}"
   name = "bastion.${aws_route53_zone.mgmt_private_zone.name}"
   type = "A"
@@ -51,6 +61,8 @@ resource "aws_route53_record" "mgmt_bastion_A" {
 }
 
 resource "aws_route53_record" "mgmt_vulnscan_A" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_private_zone.zone_id}"
   name = "vulnscan1.${aws_route53_zone.mgmt_private_zone.name}"
   type = "A"
@@ -65,6 +77,8 @@ resource "aws_route53_record" "mgmt_vulnscan_A" {
 ##################################
 
 resource "aws_route53_zone" "mgmt_public_zone_reverse" {
+  count = "${var.enable_mgmt_vpc}"
+
   # NOTE:  This assumes that we are using /24 blocks
   name = "${format("%s.%s.%s.in-addr.arpa.",
     element( split(".", aws_subnet.mgmt_public_subnet.cidr_block), 2),
@@ -80,6 +94,8 @@ resource "aws_route53_zone" "mgmt_public_zone_reverse" {
 }
 
 resource "aws_route53_record" "mgmt_rev_1_PTR" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_public_zone_reverse.zone_id}"
   name = "1.${aws_route53_zone.mgmt_public_zone_reverse.name}"
   type = "PTR"
@@ -90,6 +106,8 @@ resource "aws_route53_record" "mgmt_rev_1_PTR" {
 }
 
 resource "aws_route53_record" "mgmt_rev_2_PTR" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_public_zone_reverse.zone_id}"
   name = "2.${aws_route53_zone.mgmt_public_zone_reverse.name}"
   type = "PTR"
@@ -100,6 +118,8 @@ resource "aws_route53_record" "mgmt_rev_2_PTR" {
 }
 
 resource "aws_route53_record" "mgmt_rev_3_PTR" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_public_zone_reverse.zone_id}"
   name = "3.${aws_route53_zone.mgmt_public_zone_reverse.name}"
   type = "PTR"
@@ -110,6 +130,8 @@ resource "aws_route53_record" "mgmt_rev_3_PTR" {
 }
 
 resource "aws_route53_record" "mgmt_rev_bastion_PTR" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_public_zone_reverse.zone_id}"
   name = "${format("%s.%s.%s.%s.in-addr.arpa.",
     element( split(".", aws_instance.mgmt_bastion.private_ip), 3),
@@ -129,6 +151,8 @@ resource "aws_route53_record" "mgmt_rev_bastion_PTR" {
 ##################################
 
 resource "aws_route53_zone" "mgmt_private_zone_reverse" {
+  count = "${var.enable_mgmt_vpc}"
+
   # NOTE:  This assumes that we are using /24 blocks
   name = "${format("%s.%s.%s.in-addr.arpa.",
     element( split(".", aws_subnet.mgmt_private_subnet.cidr_block), 2),
@@ -144,6 +168,8 @@ resource "aws_route53_zone" "mgmt_private_zone_reverse" {
 }
 
 resource "aws_route53_record" "mgmt_rev_nessus_PTR" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${aws_route53_zone.mgmt_private_zone_reverse.zone_id}"
   name = "${format("%s.%s.%s.%s.in-addr.arpa.",
     element( split(".", aws_instance.mgmt_nessus.private_ip), 3),

--- a/terraform/mgmt_private_dns.tf
+++ b/terraform/mgmt_private_dns.tf
@@ -61,16 +61,15 @@ resource "aws_route53_record" "mgmt_bastion_A" {
 }
 
 resource "aws_route53_record" "mgmt_vulnscan_A" {
-  count = "${var.enable_mgmt_vpc}"
+  count = "${var.enable_mgmt_vpc * local.count_mgmt_vuln_scanner}"
 
   zone_id = "${aws_route53_zone.mgmt_private_zone.zone_id}"
-  name = "vulnscan1.${aws_route53_zone.mgmt_private_zone.name}"
+  name = "vulnscan${count.index + 1}.${aws_route53_zone.mgmt_private_zone.name}"
   type = "A"
   ttl = 300
   records = [
-    "${aws_instance.mgmt_nessus.private_ip}"
+    "${aws_instance.mgmt_nessus.*.private_ip[count.index]}"
   ]
-}
 
 ##################################
 # Reverse records - public subnet
@@ -168,7 +167,7 @@ resource "aws_route53_zone" "mgmt_private_zone_reverse" {
 }
 
 resource "aws_route53_record" "mgmt_rev_nessus_PTR" {
-  count = "${var.enable_mgmt_vpc}"
+  count = "${var.enable_mgmt_vpc * local.count_mgmt_vuln_scanner}"
 
   zone_id = "${aws_route53_zone.mgmt_private_zone_reverse.zone_id}"
   name = "${format("%s.%s.%s.%s.in-addr.arpa.",
@@ -180,6 +179,6 @@ resource "aws_route53_record" "mgmt_rev_nessus_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "vulnscan1.${local.mgmt_private_domain}."
+    "vulnscan${count.index + 1}.${local.mgmt_private_domain}."
   ]
 }

--- a/terraform/mgmt_private_dns.tf
+++ b/terraform/mgmt_private_dns.tf
@@ -70,6 +70,7 @@ resource "aws_route53_record" "mgmt_vulnscan_A" {
   records = [
     "${aws_instance.mgmt_nessus.*.private_ip[count.index]}"
   ]
+}
 
 ##################################
 # Reverse records - public subnet

--- a/terraform/mgmt_public_acl_rules.tf
+++ b/terraform/mgmt_public_acl_rules.tf
@@ -4,7 +4,7 @@
 # they want via the NAT gateway, subject to their own security group
 # and network ACL restrictions.
 resource "aws_network_acl_rule" "mgmt_public_ingress_from_private" {
-  count = "${length(local.mgmt_scanner_egress_anywhere_ports)}"
+  count = "${var.enable_mgmt_vpc * length(local.mgmt_scanner_egress_anywhere_ports)}"
 
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = false
@@ -16,7 +16,7 @@ resource "aws_network_acl_rule" "mgmt_public_ingress_from_private" {
   to_port = "${local.mgmt_scanner_egress_anywhere_ports[count.index]}"
 }
 resource "aws_network_acl_rule" "mgmt_public_ingress_from_private_via_port_53" {
-  count = "${length(local.tcp_and_udp)}"
+  count = "${var.enable_mgmt_vpc * length(local.tcp_and_udp)}"
 
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = false
@@ -32,6 +32,8 @@ resource "aws_network_acl_rule" "mgmt_public_ingress_from_private_via_port_53" {
 # necessary because the return traffic to the NAT gateway has to enter
 # here before it is relayed to the private subnet.
 resource "aws_network_acl_rule" "mgmt_public_ingress_from_anywhere_via_ephemeral_ports_tcp" {
+  count = "${var.enable_mgmt_vpc}"
+
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = false
   protocol = "tcp"
@@ -44,6 +46,8 @@ resource "aws_network_acl_rule" "mgmt_public_ingress_from_anywhere_via_ephemeral
 
 # Allow ingress from anywhere via ssh
 resource "aws_network_acl_rule" "mgmt_public_ingress_from_anywhere_via_ssh" {
+  count = "${var.enable_mgmt_vpc}"
+
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = false
   protocol = "tcp"
@@ -56,6 +60,8 @@ resource "aws_network_acl_rule" "mgmt_public_ingress_from_anywhere_via_ssh" {
 
 # Allow egress to the private subnet via ssh
 resource "aws_network_acl_rule" "mgmt_public_egress_to_private_via_ssh" {
+  count = "${var.enable_mgmt_vpc}"
+
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = true
   protocol = "tcp"
@@ -69,6 +75,8 @@ resource "aws_network_acl_rule" "mgmt_public_egress_to_private_via_ssh" {
 # Allow egress to the bastion via ssh.  This is necessary because
 # Ansible applies the ssh proxy even when sshing to the bastion.
 resource "aws_network_acl_rule" "mgmt_public_egress_to_bastion_via_ssh" {
+  count = "${var.enable_mgmt_vpc}"
+
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = true
   protocol = "tcp"
@@ -83,7 +91,7 @@ resource "aws_network_acl_rule" "mgmt_public_egress_to_bastion_via_ssh" {
 # This is so the NAT gateway can relay the corresponding requests
 # from the private subnet.
 resource "aws_network_acl_rule" "mgmt_public_egress_anywhere" {
-  count = "${length(local.mgmt_scanner_egress_anywhere_ports)}"
+  count = "${var.enable_mgmt_vpc * length(local.mgmt_scanner_egress_anywhere_ports)}"
 
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = true
@@ -97,6 +105,8 @@ resource "aws_network_acl_rule" "mgmt_public_egress_anywhere" {
 
 # Allow egress to anywhere via TCP ephemeral ports
 resource "aws_network_acl_rule" "mgmt_public_egress_to_anywhere_via_tcp_ephemeral_ports" {
+  count = "${var.enable_mgmt_vpc}"
+
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = true
   protocol = "tcp"
@@ -110,7 +120,7 @@ resource "aws_network_acl_rule" "mgmt_public_egress_to_anywhere_via_tcp_ephemera
 # Allow all ports and protocols from Management private subnet to ingress,
 # for internal scanning
 resource "aws_network_acl_rule" "mgmt_public_ingress_all_from_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = false
@@ -125,7 +135,7 @@ resource "aws_network_acl_rule" "mgmt_public_ingress_all_from_mgmt_private" {
 # Allow all ports and protocols to egress to Management private subnet,
 # for internal scanning
 resource "aws_network_acl_rule" "mgmt_public_egress_all_to_mgmt_private" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   network_acl_id = "${aws_network_acl.mgmt_public_acl.id}"
   egress = true

--- a/terraform/mgmt_public_dns.tf
+++ b/terraform/mgmt_public_dns.tf
@@ -1,8 +1,12 @@
 data "aws_route53_zone" "mgmt_public_zone" {
+  count = "${var.enable_mgmt_vpc}"
+
   name = "${local.mgmt_public_zone}"
 }
 
 resource "aws_route53_record" "mgmt_bastion_pub_A" {
+  count = "${var.enable_mgmt_vpc}"
+
   zone_id = "${data.aws_route53_zone.mgmt_public_zone.zone_id}"
   name    = "bastion.${terraform.workspace}.${local.mgmt_public_subdomain}${data.aws_route53_zone.mgmt_public_zone.name}"
   type    = "A"

--- a/terraform/mgmt_scanner_security_group_rules.tf
+++ b/terraform/mgmt_scanner_security_group_rules.tf
@@ -1,6 +1,6 @@
 # Allow ingress from the bastion security group via the ssh and Nessus ports
 resource "aws_security_group_rule" "mgmt_scanner_ingress_from_bastion_sg" {
-  count = "${length(local.mgmt_trusted_ingress_ports)}"
+  count = "${var.enable_mgmt_vpc * length(local.mgmt_trusted_ingress_ports)}"
 
   security_group_id = "${aws_security_group.mgmt_scanner_sg.id}"
   type = "ingress"
@@ -13,7 +13,7 @@ resource "aws_security_group_rule" "mgmt_scanner_ingress_from_bastion_sg" {
 # Allow ingress from Management, CyHy, and BOD VPCs via all ephemeral tcp ports,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_scanner_ingress_tcp_from_cyhy_and_bod_vpc" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_scanner_sg.id}"
   type = "ingress"
@@ -30,7 +30,7 @@ resource "aws_security_group_rule" "mgmt_scanner_ingress_tcp_from_cyhy_and_bod_v
 # Allow ingress from Management, CyHy, and BOD VPCs via all ephemeral udp ports,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_scanner_ingress_udp_from_cyhy_and_bod_vpc" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_scanner_sg.id}"
   type = "ingress"
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "mgmt_scanner_ingress_udp_from_cyhy_and_bod_v
 # Allow ingress from Management, CyHy, and BOD VPCs via all icmp ports,
 # for internal scanning
 resource "aws_security_group_rule" "mgmt_scanner_ingress_icmp_from_cyhy_and_bod_vpc" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_scanner_sg.id}"
   type = "ingress"
@@ -64,7 +64,7 @@ resource "aws_security_group_rule" "mgmt_scanner_ingress_icmp_from_cyhy_and_bod_
 # Allow egress to Management, CyHy, and BOD 18-01 VPCs via all ports and
 # protocols, for internal scanning
 resource "aws_security_group_rule" "mgmt_scanner_egress_to_cyhy_and_bod_vpc" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   security_group_id = "${aws_security_group.mgmt_scanner_sg.id}"
   type = "egress"
@@ -80,7 +80,7 @@ resource "aws_security_group_rule" "mgmt_scanner_egress_to_cyhy_and_bod_vpc" {
 
 # Allow HTTPS egress anywhere; needed for Nessus plugin updates
 resource "aws_security_group_rule" "mgmt_scanner_https_egress_to_anywhere" {
-  count = "${length(local.mgmt_scanner_egress_anywhere_ports)}"
+  count = "${var.enable_mgmt_vpc * length(local.mgmt_scanner_egress_anywhere_ports)}"
 
   security_group_id = "${aws_security_group.mgmt_scanner_sg.id}"
   type = "egress"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,9 +56,9 @@ variable "nessus_activation_codes" {
   description = "A list of strings containing Nessus activation codes"
 }
 
-variable "mgmt_nessus_activation_code" {
-  description = "The Nessus activation code used in the management VPC"
-  default = ""
+variable "mgmt_nessus_activation_codes" {
+  type = "list"
+  description = "A list of strings containing Nessus activation codes used in the management VPC"
 }
 
 variable "create_cyhy_flow_logs" {
@@ -154,7 +154,7 @@ variable "docker_mailer_override_filename" {
 # For some examples of this, refer to the rules in these files:
 #  - cyhy_private_security_group_rules.tf
 #  - cyhy_private_acl_rules.tf
-variable "enable_mgmt_vpc_access_to_all_vpcs" {
+variable "enable_mgmt_vpc" {
   description = "Whether or not to enable unfettered access from the vulnerability scanner in the Management VPC to other VPCs (CyHy, BOD).  This should only be enabled while running security scans from the Management VPC.  Zero means access is disabled and one means access is enabled."
   default = 0
 }

--- a/terraform/vpc_peering.tf
+++ b/terraform/vpc_peering.tf
@@ -19,7 +19,7 @@ resource "aws_vpc_peering_connection_options" "cyhy_bod_peering_connection" {
 }
 
 resource "aws_vpc_peering_connection" "cyhy_mgmt_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   vpc_id = "${aws_vpc.mgmt_vpc.id}"
   peer_vpc_id = "${aws_vpc.cyhy_vpc.id}"
@@ -29,7 +29,7 @@ resource "aws_vpc_peering_connection" "cyhy_mgmt_peering_connection" {
 }
 
 resource "aws_vpc_peering_connection_options" "cyhy_mgmt_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection.cyhy_mgmt_peering_connection.id}"
 
@@ -43,7 +43,7 @@ resource "aws_vpc_peering_connection_options" "cyhy_mgmt_peering_connection" {
 }
 
 resource "aws_vpc_peering_connection" "bod_mgmt_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   vpc_id = "${aws_vpc.mgmt_vpc.id}"
   peer_vpc_id = "${aws_vpc.bod_vpc.id}"
@@ -53,7 +53,7 @@ resource "aws_vpc_peering_connection" "bod_mgmt_peering_connection" {
 }
 
 resource "aws_vpc_peering_connection_options" "bod_mgmt_peering_connection" {
-  count = "${var.enable_mgmt_vpc_access_to_all_vpcs}"
+  count = "${var.enable_mgmt_vpc}"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection.bod_mgmt_peering_connection.id}"
 


### PR DESCRIPTION
This PR gives us better control over the management VPC.  The bastion and vulnscanner are now handled dynamically, similar to how we support a dynamic number of scanners in the CyHy VPC.

Even though the management bastion is created dynamically, **do not** create more than one in the management VPC; the management bastion is only created dynamically so that it can be removed when the management VPC is not needed.

To completely remove the management VPC and all of its resources, do the following:
1. Set the `enable_mgmt_vpc` variable (previously known as `enable_mgmt_vpc_access_to_all_vpcs`) in your `.tfvars` file to 0
1. Update `configure.py` so that your terraform workspace is configured with:
 `'mgmt_bastion': 0, 'mgmt_nessus': 0`
1. Run `configure.py` to update your local configuration
1. Terraform away!

To create (enable) the management VPC and all of its resources, do the following:
1. Set the `enable_mgmt_vpc` variable (previously known as `enable_mgmt_vpc_access_to_all_vpcs`) in your `.tfvars` file to 1
1. Update `configure.py` so that your terraform workspace is configured with:
 `'mgmt_bastion': 1, 'mgmt_nessus': 1` (if desired, you can increase the number of `mgmt_nessus` instances, but the number `mgmt_bastion` instances should **never be more than 1**)
1. Run `configure.py` to update your local configuration
1. Ensure that the `mgmt_nessus_activation_codes` variable in your `.tfvars` file has a valid activation code for each `mgmt_nessus` instance
1. Terraform away!