### PR TITLE
Allow Amazon certs in CAA record

### DIFF
--- a/terraform_route_53/cyber.dhs.gov.tf
+++ b/terraform_route_53/cyber.dhs.gov.tf
@@ -36,6 +36,7 @@ resource "aws_route53_record" "root_CAA" {
   type    = "CAA"
   ttl     = 300
   records = [ "0 issue \"letsencrypt.org\"",
+              "0 issue \"amazon.com\"",
               "0 issuewild \";\"",
               "0 iodef \"mailto:NCATSSecurity@hq.dhs.gov\""
             ]

--- a/terraform_route_53/cyber.dhs.gov.tf
+++ b/terraform_route_53/cyber.dhs.gov.tf
@@ -42,6 +42,18 @@ resource "aws_route53_record" "root_CAA" {
             ]
 }
 
+# This DNS record gives Amazon Certificate Manager permission to
+# generate certificates for rules.ncats.cyber.dhs.gov
+resource "aws_route53_record" "root_acm_rules_CNAME" {
+  zone_id = "${aws_route53_zone.cyber_zone.zone_id}"
+  name = "_724d852f42d6b10ed1c6ab4135301ef6.rules.ncats.${aws_route53_zone.cyber_zone.name}"
+  type = "CNAME"
+  ttl = 60
+  records = [
+    "_548e9cb4a195b3c2a5410a9ff88fcda3.acm-validations.aws"
+  ]
+}
+
 resource "aws_route53_record" "root_MX" {
   zone_id = "${aws_route53_zone.cyber_zone.zone_id}"
   name    = "${aws_route53_zone.cyber_zone.name}"


### PR DESCRIPTION
I am giving Amazon certs a try for `rules.ncats.cyber.dhs.gov` instead of Let's Encrypt.  I suspect this will make certificate renewal easier.

I had to add two records to our Route53 configuration in order to accomplish this.