### PR TITLE
Add code-gov-update to BOD Docker instance

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -44,6 +44,7 @@
   roles:
     - orchestrator
     - cyhy_mailer
+    - code_gov_update
 
 - hosts: cyhy_commander
   name: Configure cyhy-commander hosts

--- a/ansible/roles/code_gov_update/README.md
+++ b/ansible/roles/code_gov_update/README.md
@@ -1,0 +1,41 @@
+code_gov_updater
+================
+
+An Ansible role for configuring a host to generate updated code.gov
+JSON files and email them.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Here's how to use it in a playbook:
+
+    - hosts: bod_docker
+      become: yes
+      become_method: sudo
+      roles:
+         - code_gov_updater
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Shane Frasier <jeremy.frasier@trio.dhs.gov>

--- a/ansible/roles/code_gov_update/defaults/main.yml
+++ b/ansible/roles/code_gov_update/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for bod_docker

--- a/ansible/roles/code_gov_update/handlers/main.yml
+++ b/ansible/roles/code_gov_update/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for bod_docker

--- a/ansible/roles/code_gov_update/meta/main.yml
+++ b/ansible/roles/code_gov_update/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies:
+  - chown_cyhy_dirs
+  - github_oauth

--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -54,7 +54,7 @@
     mode: 0440
     content: |
       [default]
-      region = {{ aws_region }}
+      region = {{ ses_aws_region }}
 
 
 #

--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+# tasks file for code_gov_update
+
+#
+# code_gov_update secrets
+#
+- name: Create the secrets directory
+  file:
+    path: /var/cyhy/code-gov-update/secrets
+    owner: cyhy
+    group: cyhy
+    state: directory
+
+- name: Create the llnl-scraper config
+  copy:
+    dest: /var/cyhy/code-gov-update/secrets/scraper.json
+    owner: cyhy
+    group: cyhy
+    mode: 0440
+    content: |
+      {
+          "agency": "DHS",
+          "organization": "Department of Homeland Security",
+          "contact_email": "do_not_email_just_use_github@dhs.gov",
+
+          "permissions": {
+            "usageType": "openSource",
+            "exemptionText": "Code in agency repositories follow the license provided in the repository."
+          },
+
+          "GitHub": [{
+             "url": "https://github.com",
+             "token": "{{ github_oauth_token }}",
+             "public_only": true,
+
+             "orgs": [
+                "cisagov",
+                "dhs-nccic",
+                "US-CBP",
+                "usdhs"
+              ],
+              "repos": [
+              ],
+              "exclude": [
+              ]
+          }]
+      }
+
+- name: Create the AWS config
+  copy:
+    dest: /var/cyhy/code-gov-update/secrets/aws_config
+    owner: cyhy
+    group: cyhy
+    mode: 0440
+    content: |
+      [default]
+      region = {{ aws_region }}
+
+
+#
+# Create a cron job
+#
+- name: Add /usr/local/bin to cron's path
+  cron:
+    env: yes
+    name: PATH
+    value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+    user: cyhy
+  when: production_workspace
+# This cron job runs at midnight UTC on Friday mornings
+- name: Create a cron job for updating the code.gov JSON
+  cron:
+    name: "code.gov update"
+    minute: 0
+    hour: 0
+    weekday: 5
+    user: cyhy
+    job: cd /var/cyhy/code-gov-update && docker-compose up -d 2>&1 | /usr/bin/logger -t code-gov-update
+  when: production_workspace

--- a/ansible/roles/code_gov_update/tests/inventory
+++ b/ansible/roles/code_gov_update/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible/roles/code_gov_update/tests/test.yml
+++ b/ansible/roles/code_gov_update/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - bod_docker

--- a/ansible/roles/code_gov_update/vars/main.yml
+++ b/ansible/roles/code_gov_update/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for bod_docker

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -63,6 +63,7 @@
     - xfs
     - orchestrator
     - cyhy_mailer
+    - code_gov_update
 
 - hosts: cyhy_commander
   name: Install and configure cyhy-commander

--- a/packer/ansible/roles/code_gov_update/README.md
+++ b/packer/ansible/roles/code_gov_update/README.md
@@ -1,0 +1,41 @@
+code_gov_update
+===============
+
+An Ansible role for configuring a host to generate updated code.gov
+JSON files and email them.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Here's how to use it in a playbook:
+
+    - hosts: bod_docker
+      become: yes
+      become_method: sudo
+      roles:
+         - code_gov_updater
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Shane Frasier <jeremy.frasier@trio.dhs.gov>

--- a/packer/ansible/roles/code_gov_update/defaults/main.yml
+++ b/packer/ansible/roles/code_gov_update/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for bod_docker

--- a/packer/ansible/roles/code_gov_update/handlers/main.yml
+++ b/packer/ansible/roles/code_gov_update/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for bod_docker

--- a/packer/ansible/roles/code_gov_update/meta/main.yml
+++ b/packer/ansible/roles/code_gov_update/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.

--- a/packer/ansible/roles/code_gov_update/tasks/main.yml
+++ b/packer/ansible/roles/code_gov_update/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# tasks file for code_gov_update
+- name: Create the /var/cyhy/code-gov-update directory
+  file:
+    path: /var/cyhy/code-gov-update
+    state: directory
+    mode: 0755
+
+- name: Download and untar the code-gov-update tarball
+  unarchive:
+    src: https://api.github.com/repos/cisagov/code-gov-update/tarball/develop
+    dest: /var/cyhy/code-gov-update
+    remote_src: yes
+    extra_opts:
+      - "--strip-components=1"

--- a/packer/ansible/roles/code_gov_update/tests/inventory
+++ b/packer/ansible/roles/code_gov_update/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/packer/ansible/roles/code_gov_update/tests/test.yml
+++ b/packer/ansible/roles/code_gov_update/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - bod_docker

--- a/packer/ansible/roles/code_gov_update/vars/main.yml
+++ b/packer/ansible/roles/code_gov_update/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for bod_docker

--- a/packer/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/packer/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Download and untar the cyhy-mailer tarball
   unarchive:
-    src: https://api.github.com/repos/dhs-ncats/cyhy-mailer/tarball/develop
+    src: https://api.github.com/repos/cisagov/cyhy-mailer/tarball/develop
     dest: /var/cyhy/cyhy-mailer
     remote_src: yes
     extra_opts:

--- a/packer/ansible/roles/orchestrator/tasks/main.yml
+++ b/packer/ansible/roles/orchestrator/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Download and untar the orchestrator tarball
   unarchive:
-    src: https://api.github.com/repos/dhs-ncats/orchestrator/tarball/develop
+    src: https://api.github.com/repos/cisagov/orchestrator/tarball/develop
     dest: /var/cyhy/orchestrator
     remote_src: yes
     extra_opts:


### PR DESCRIPTION
I want to eventually use ECS for this, but until I figure out the details for that I will run this via a cron job from the BOD Docker instance.