### PR TITLE
Add workspace support to scripts

### DIFF
--- a/terraform/deploy_new_docker_ami.sh
+++ b/terraform/deploy_new_docker_ami.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
+# deploy_new_docker_ami.sh
+# deploy_new_docker_ami.sh workspace_name
+
 set -o nounset
 set -o errexit
 set -o pipefail
+
+workspace=prod-a
+if [ $# -ge 1 ]
+then
+    workspace=$1
+fi
+
+terraform workspace select "$workspace"
 
 docker_instance_id=$(terraform state show aws_instance.bod_docker | \
                          grep "^id" | sed "s/^id *= \(.*\)/\1/")
@@ -11,7 +22,7 @@ docker_instance_id=$(terraform state show aws_instance.bod_docker | \
 aws ec2 terminate-instances --instance-ids "$docker_instance_id"
 aws ec2 wait instance-terminated --instance-ids "$docker_instance_id"
 
-terraform apply -var-file=prod-a.tfvars \
+terraform apply -var-file="$workspace.tfvars" \
           -target=aws_instance.bod_docker \
           -target=aws_route53_record.bod_docker_A \
           -target=aws_route53_record.bod_rev_docker_PTR \

--- a/terraform/deploy_new_lambdas.sh
+++ b/terraform/deploy_new_lambdas.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
 
+# deploy_new_lambdas.sh
+# deploy_new_lambdas.sh workspace_name
+
 set -o nounset
 set -o errexit
 set -o pipefail
+
+workspace=prod-a
+if [ $# -ge 1 ]
+then
+    workspace=$1
+fi
+
+terraform workspace select "$workspace"
 
 for i in $(seq 0 2)
 do
     terraform taint "aws_lambda_function.lambdas.$i"
 done
 
-terraform apply -var-file=prod-a.tfvars \
+terraform apply -var-file="$workspace.tfvars" \
           -target=aws_lambda_function.lambdas \
           -target=aws_iam_role_policy.lambda_cloudwatch_policies \
           -target=aws_iam_role_policy.lambda_bod_docker_policy \

--- a/terraform/deploy_new_reporter_ami.sh
+++ b/terraform/deploy_new_reporter_ami.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
+# deploy_new_reporter_ami.sh
+# deploy_new_reporter_ami.sh workspace_name
+
 set -o nounset
 set -o errexit
 set -o pipefail
+
+workspace=prod-a
+if [ $# -ge 1 ]
+then
+    workspace=$1
+fi
+
+terraform workspace select "$workspace"
 
 reporter_instance_id=$(terraform state show aws_instance.cyhy_reporter | \
                            grep "^id" | sed "s/^id *= \(.*\)/\1/")
@@ -11,7 +22,7 @@ reporter_instance_id=$(terraform state show aws_instance.cyhy_reporter | \
 aws ec2 terminate-instances --instance-ids "$reporter_instance_id"
 aws ec2 wait instance-terminated --instance-ids "$reporter_instance_id"
 
-terraform apply -var-file=prod-a.tfvars \
+terraform apply -var-file="$workspace.tfvars" \
           -target=aws_instance.cyhy_reporter \
           -target=aws_route53_record.cyhy_reporter_A \
           -target=aws_route53_record.cyhy_rev_reporter_PTR \


### PR DESCRIPTION
Now you can specify the workspace on the command line, or not.  If you don't specify a workspace then the `prod-a` workspace is used.