### PR TITLE
Add cloud-init code to set hostnames to match private DNS entries

### DIFF
--- a/terraform/bod_private_dns.tf
+++ b/terraform/bod_private_dns.tf
@@ -88,7 +88,7 @@ resource "aws_route53_record" "bod_rev_1_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "router.${local.bod_private_domain}."
+    "router.${aws_route53_zone.bod_private_zone.name}"
   ]
 }
 
@@ -98,7 +98,7 @@ resource "aws_route53_record" "bod_rev_2_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "ns.${local.bod_private_domain}."
+    "ns.${aws_route53_zone.bod_private_zone.name}"
   ]
 }
 
@@ -108,7 +108,7 @@ resource "aws_route53_record" "bod_rev_3_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "reserved.${local.bod_private_domain}."
+    "reserved.${aws_route53_zone.bod_private_zone.name}"
   ]
 }
 
@@ -123,7 +123,7 @@ resource "aws_route53_record" "bod_rev_bastion_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "bastion.${local.bod_private_domain}."
+    "bastion.${aws_route53_zone.bod_private_zone.name}"
   ]
 }
 
@@ -157,6 +157,6 @@ resource "aws_route53_record" "bod_rev_docker_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "docker.${local.bod_private_domain}."
+    "docker.${aws_route53_zone.bod_private_zone.name}"
   ]
 }

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -41,8 +41,8 @@ WORKSPACE_CONFIGS = {
         'nmap': 4, 'nessus': 1, 'mongo': 1,
         'mgmt_bastion': 0, 'mgmt_nessus': 0},
     'jsf9k': {
-        'nmap': 0, 'nessus': 0, 'mongo': 1,
-        'mgmt_bastion': 0, 'mgmt_nessus': 0}
+        'nmap': 1, 'nessus': 1, 'mongo': 1,
+        'mgmt_bastion': 1, 'mgmt_nessus': 1}
     }
 
 # the default configuration if a workspace is not defined above
@@ -136,8 +136,7 @@ def main():
         template_key, unused = os.path.splitext(filename)
         # lookup the count for this template
         count = config[template_key]
-        print(f"Creating {count} instantiation{'' if count==1 else 's'} "
-              f"of template {template_file}")
+        print(f"Creating {count} instantiation{'' if count == 1 else 's'} of template {template_file}")
         # read in the template
         template = read_template(template_file)
         for i in range(count):

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -22,7 +22,8 @@ from string import Template
 import sys
 
 # This script uses a subprocess feature added in python 3.7
-assert sys.version_info >= (3,7), 'This script requires Python version 3.7 or newer'
+assert sys.version_info >= (3, 7), \
+    'This script requires Python version 3.7 or newer'
 
 # for each workspace, set the number of instances to create for each template
 # NOTE: mgmt_bastion should only be set to 0 or 1
@@ -56,25 +57,28 @@ LOCAL_DEFS = {
     'mongo':         'mongo_instance_count',
     'mgmt_bastion':  'mgmt_bastion_instance_count',
     'mgmt_nessus':   'mgmt_nessus_instance_count'
-    }
+}
 
 # filename constant definitions
 TEMPLATE_EXTENSION = '.template'
-DYNAMIC_EXTENSION =  '.dyn.tf'
+DYNAMIC_EXTENSION = '.dyn.tf'
 DELETE_GLOB = '**/*' + DYNAMIC_EXTENSION
 LOCALS_FILE = 'locals' + DYNAMIC_EXTENSION
 
 # the command to read the current terraform workspace
 TERRAFORM_WORKSPACE_CMD = 'terraform workspace show'
 
+
 def get_terraform_workspace():
     '''returns the current workspace'''
     completed_process = subprocess.run(TERRAFORM_WORKSPACE_CMD,
-        capture_output=True, shell=True)
+                                       capture_output=True, shell=True)
     return completed_process.stdout.decode().strip()
+
 
 def find_templates():
     return glob.iglob('**/*' + TEMPLATE_EXTENSION, recursive=True)
+
 
 def read_template(filename):
     '''read in the template, returns a Template object'''
@@ -84,19 +88,22 @@ def read_template(filename):
     # convert from a list to a single string and return
     return Template(''.join(template))
 
+
 def remove_dynamic_files():
     '''delete all the previously created dynamic files'''
     for filename in glob.iglob(DELETE_GLOB, recursive=True):
         os.unlink(filename)
 
+
 def create_dynamic_files(template, path, name, count):
     '''create count number files using the template'''
     for i in range(count):
-        filename = '.'.join([name,str(i),DYNAMIC_EXTENSION[1:]])
+        filename = '.'.join([name, str(i), DYNAMIC_EXTENSION[1:]])
         full_path = os.path.join(path, filename)
         rendered_template = template.substitute(index=i)
         with open(full_path, mode='wb') as f:
             f.write(rendered_template.encode('utf-8'))
+
 
 def create_dynamic_locals(config):
     '''create a dynamic locals file from configuration'''
@@ -104,8 +111,9 @@ def create_dynamic_locals(config):
         f.write('locals {\n'.encode('utf-8'))
         for key, variable_name in LOCAL_DEFS.items():
             value = config.get(key)
-            f.write('    {} = {}\n'.format(variable_name, value).encode('utf-8'))
+            f.write(f'    {variable_name} = {value}\n'.encode('utf-8'))
         f.write('}\n'.encode('utf-8'))
+
 
 def main():
     # get workspace
@@ -128,7 +136,8 @@ def main():
         template_key, unused = os.path.splitext(filename)
         # lookup the count for this template
         count = config[template_key]
-        print('Creating {} instantiation{} of template {}'.format(count, ('' if count==1 else 's'), template_file))
+        print(f"Creating {count} instantiation{'' if count==1 else 's'} "
+              f"of template {template_file}")
         # read in the template
         template = read_template(template_file)
         for i in range(count):
@@ -139,7 +148,8 @@ def main():
     print('Create dynamic locals file')
     create_dynamic_locals(config)
 
-    #import IPython; IPython.embed() #<<< BREAKPOINT >>>
+    # import IPython; IPython.embed() #<<< BREAKPOINT >>>
+
 
 if __name__ == '__main__':
     main()

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -41,8 +41,8 @@ WORKSPACE_CONFIGS = {
         'nmap': 4, 'nessus': 1, 'mongo': 1,
         'mgmt_bastion': 0, 'mgmt_nessus': 0},
     'jsf9k': {
-        'nmap': 1, 'nessus': 1, 'mongo': 1,
-        'mgmt_bastion': 1, 'mgmt_nessus': 1}
+        'nmap': 0, 'nessus': 0, 'mongo': 1,
+        'mgmt_bastion': 0, 'mgmt_nessus': 0}
     }
 
 # the default configuration if a workspace is not defined above

--- a/terraform/cyhy_private_dns.tf
+++ b/terraform/cyhy_private_dns.tf
@@ -109,7 +109,7 @@ resource "aws_route53_record" "cyhy_rev_1_PTR" {
   name    = "1.${aws_route53_zone.cyhy_scanner_zone_reverse.name}"
   type    = "PTR"
   ttl     = 300
-  records = [ "router.${local.cyhy_private_domain}." ]
+  records = [ "router.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 resource "aws_route53_record" "cyhy_rev_2_PTR" {
@@ -117,7 +117,7 @@ resource "aws_route53_record" "cyhy_rev_2_PTR" {
   name    = "2.${aws_route53_zone.cyhy_scanner_zone_reverse.name}"
   type    = "PTR"
   ttl     = 300
-  records = [ "ns.${local.cyhy_private_domain}." ]
+  records = [ "ns.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 resource "aws_route53_record" "cyhy_rev_3_PTR" {
@@ -125,7 +125,7 @@ resource "aws_route53_record" "cyhy_rev_3_PTR" {
   name    = "3.${aws_route53_zone.cyhy_scanner_zone_reverse.name}"
   type    = "PTR"
   ttl     = 300
-  records = [ "reserved.${local.cyhy_private_domain}." ]
+  records = [ "reserved.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 resource "aws_route53_record" "cyhy_rev_portscan_PTR" {
@@ -139,7 +139,7 @@ resource "aws_route53_record" "cyhy_rev_portscan_PTR" {
   )}"
   type    = "PTR"
   ttl     = 300
-  records = [ "portscan${count.index + 1}.${local.cyhy_private_domain}." ]
+  records = [ "portscan${count.index + 1}.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 resource "aws_route53_record" "cyhy_rev_vulnscan_PTR" {
@@ -153,7 +153,7 @@ resource "aws_route53_record" "cyhy_rev_vulnscan_PTR" {
   )}"
   type    = "PTR"
   ttl     = 300
-  records = [ "vulnscan${count.index + 1}.${local.cyhy_private_domain}." ]
+  records = [ "vulnscan${count.index + 1}.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 ##############################################
@@ -185,7 +185,7 @@ resource "aws_route53_record" "cyhy_rev_bastion_PTR" {
   )}"
   type    = "PTR"
   ttl     = 300
-  records = [ "bastion.${local.cyhy_private_domain}." ]
+  records = [ "bastion.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 resource "aws_route53_record" "cyhy_rev_reporter_PTR" {
@@ -198,7 +198,7 @@ resource "aws_route53_record" "cyhy_rev_reporter_PTR" {
   )}"
   type    = "PTR"
   ttl     = 300
-  records = [ "reporter.${local.cyhy_private_domain}." ]
+  records = [ "reporter.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 resource "aws_route53_record" "cyhy_rev_database_PTR" {
@@ -212,7 +212,7 @@ resource "aws_route53_record" "cyhy_rev_database_PTR" {
   )}"
   type    = "PTR"
   ttl     = 300
-  records = [ "database${count.index + 1}.${local.cyhy_private_domain}." ]
+  records = [ "database${count.index + 1}.${aws_route53_zone.cyhy_private_zone.name}" ]
 }
 
 resource "aws_route53_record" "cyhy_rev_dashboard_PTR" {
@@ -225,5 +225,5 @@ resource "aws_route53_record" "cyhy_rev_dashboard_PTR" {
   )}"
   type    = "PTR"
   ttl     = 300
-  records = [ "dashboard.${local.cyhy_private_domain}." ]
+  records = [ "dashboard.${aws_route53_zone.cyhy_private_zone.name}" ]
 }

--- a/terraform/cyhy_ssh_cloud_init.tf
+++ b/terraform/cyhy_ssh_cloud_init.tf
@@ -20,5 +20,10 @@ data "template_cloudinit_config" "cyhy_ssh_cloud_init_tasks" {
     content      = "${data.template_file.cyhy_user_ssh_setup.rendered}"
     merge_type   = "list(append)+dict(recurse_array)+str()"
   }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.set_hostname.rendered}"
+  }
 }
 

--- a/terraform/cyhy_vpc.tf
+++ b/terraform/cyhy_vpc.tf
@@ -19,7 +19,8 @@ resource "aws_vpc_dhcp_options_association" "cyhy_vpc_dhcp" {
   dhcp_options_id = "${aws_vpc_dhcp_options.cyhy_dhcp_options.id}"
 }
 
-# Private subnet of the VPC, for database and CyHy commander
+# Private subnet of the VPC, for reporter, database, and CyHy
+# commander
 resource "aws_subnet" "cyhy_private_subnet" {
  vpc_id = "${aws_vpc.cyhy_vpc.id}"
  cidr_block = "10.10.10.0/25"

--- a/terraform/docker_cloud_init.tf
+++ b/terraform/docker_cloud_init.tf
@@ -34,4 +34,9 @@ data "template_cloudinit_config" "ssh_and_docker_cloud_init_tasks" {
     content_type = "text/x-shellscript"
     content = "${data.template_file.docker_disk_setup.rendered}"
   }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.set_hostname.rendered}"
+  }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -87,8 +87,8 @@ locals {
   # DNS zone calculations based on requested instances.  The numbers
   # represent the count of IP addresses in a subnet.
   #
-  # NOTE: there is an assumption that subnets are /24 in the reverse
-  # zone names.
+  # NOTE: there is an assumption that subnets are /24 or smaller in
+  # the reverse zone names.
 
   # Port Scanners DNS entries
   count_port_scanner = "${local.nmap_instance_count}"

--- a/terraform/mgmt_private_dns.tf
+++ b/terraform/mgmt_private_dns.tf
@@ -101,7 +101,7 @@ resource "aws_route53_record" "mgmt_rev_1_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "router.${local.mgmt_private_domain}."
+    "router.${aws_route53_zone.mgmt_private_zone.name}"
   ]
 }
 
@@ -113,7 +113,7 @@ resource "aws_route53_record" "mgmt_rev_2_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "ns.${local.mgmt_private_domain}."
+    "ns.${aws_route53_zone.mgmt_private_zone.name}"
   ]
 }
 
@@ -125,7 +125,7 @@ resource "aws_route53_record" "mgmt_rev_3_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "reserved.${local.mgmt_private_domain}."
+    "reserved.${aws_route53_zone.mgmt_private_zone.name}"
   ]
 }
 
@@ -142,7 +142,7 @@ resource "aws_route53_record" "mgmt_rev_bastion_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "bastion.${local.mgmt_private_domain}."
+    "bastion.${aws_route53_zone.mgmt_private_zone.name}"
   ]
 }
 
@@ -180,6 +180,6 @@ resource "aws_route53_record" "mgmt_rev_nessus_PTR" {
   type = "PTR"
   ttl = 300
   records = [
-    "vulnscan${count.index + 1}.${local.mgmt_private_domain}."
+    "vulnscan${count.index + 1}.${aws_route53_zone.mgmt_private_zone.name}"
   ]
 }

--- a/terraform/mongo_cloud_init.tf
+++ b/terraform/mongo_cloud_init.tf
@@ -90,4 +90,9 @@ data "template_cloudinit_config" "ssh_and_mongo_cloud_init_tasks" {
     content_type = "text/x-shellscript"
     content = "${data.template_file.mongo_dir_setup.rendered}"
   }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.set_hostname.rendered}"
+  }
 }

--- a/terraform/nessus_cyhy_runner_cloud_init.tf
+++ b/terraform/nessus_cyhy_runner_cloud_init.tf
@@ -34,4 +34,9 @@ data "template_cloudinit_config" "ssh_and_nessus_cyhy_runner_cloud_init_tasks" {
     content_type = "text/x-shellscript"
     content = "${data.template_file.nessus_disk_setup.rendered}"
   }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.set_hostname.rendered}"
+  }
 }

--- a/terraform/nmap_cyhy_runner_cloud_init.tf
+++ b/terraform/nmap_cyhy_runner_cloud_init.tf
@@ -34,4 +34,9 @@ data "template_cloudinit_config" "ssh_and_nmap_cyhy_runner_cloud_init_tasks" {
     content_type = "text/x-shellscript"
     content = "${data.template_file.nmap_disk_setup.rendered}"
   }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.set_hostname.rendered}"
+  }
 }

--- a/terraform/reporter_cloud_init.tf
+++ b/terraform/reporter_cloud_init.tf
@@ -34,4 +34,9 @@ data "template_cloudinit_config" "ssh_and_reporter_cloud_init_tasks" {
     content_type = "text/x-shellscript"
     content = "${data.template_file.reporter_disk_setup.rendered}"
   }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.set_hostname.rendered}"
+  }
 }

--- a/terraform/scripts/set_hostname.sh
+++ b/terraform/scripts/set_hostname.sh
@@ -8,14 +8,18 @@ set -o pipefail
 
 ip_addr=$(hostname --all-ip-addresses | cut --delimiter=' ' --fields=1)
 
-while ! host "$ip_addr"
+# The return value of variable=$(command) is the return value of the
+# command.  We need this because sometimes at boot the host will
+# resolve, then briefly fail to resolve while AWS networking settles
+# into place.
+while ! hostinfo=$(host "$ip_addr")
 do
     echo Waiting for IP to resolve to an address...
     sleep 5
 done
 
-name=$(host "$ip_addr" | \
+name=$(echo "$hostinfo" | \
            cut --delimiter=' ' --fields=5 | \
            sed 's/\(.*\)\.local\./\1/')
 
-hostnamectl set-hostname "$name"
+hostnamectl set-hostname --no-ask-password "$name"

--- a/terraform/scripts/set_hostname.sh
+++ b/terraform/scripts/set_hostname.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This code works on all the Debian instances
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+ip_addr=$(hostname --all-ip-addresses | cut --delimiter=' ' --fields=1)
+
+while ! host "$ip_addr"
+do
+    echo Waiting for IP to resolve to an address...
+    sleep 5
+done
+
+name=$(host "$ip_addr" | \
+           cut --delimiter=' ' --fields=5 | \
+           sed 's/\(.*\)\.local\./\1/')
+
+hostnamectl set-hostname "$name"

--- a/terraform/ssh_cloud_init.tf
+++ b/terraform/ssh_cloud_init.tf
@@ -4,6 +4,10 @@ data "template_file" "user_ssh_setup" {
   template = "${file("scripts/user_ssh_setup.yml")}"
 }
 
+data "template_file" "set_hostname" {
+  template = "${file("${path.module}/scripts/set_hostname.sh")}"
+}
+
 data "template_cloudinit_config" "ssh_cloud_init_tasks" {
   gzip = true
   base64_encode = true
@@ -12,5 +16,10 @@ data "template_cloudinit_config" "ssh_cloud_init_tasks" {
     filename     = "user_ssh_setup.yml"
     content_type = "text/cloud-config"
     content      = "${data.template_file.user_ssh_setup.rendered}"
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    content = "${data.template_file.set_hostname.rendered}"
   }
 }


### PR DESCRIPTION
This pull request improves quality of life a bit by setting the hostnames of the EC2 instances to `bastion`, `database1`, etc. as appropriate.  It is also a stepping stone toward my goal of being able to resolve `database1.cyhy` from `docker.bod` so that I don't need to pass the database IP to `docker.bod`'s Ansible.

This pull request resolves #56.