### PR TITLE
Remove the dhs-nccic organization from the scraper configuration

### DIFF
--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -35,7 +35,6 @@
 
              "orgs": [
                 "cisagov",
-                "dhs-nccic",
                 "US-CBP",
                 "usdhs"
               ],


### PR DESCRIPTION
The repositories under the `dhs-nccic` organization have been moved to our `cisagov` organization.