### PR TITLE
Add assessment data import lambda

### DIFF
--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -168,11 +168,13 @@ resource "aws_lambda_function" "adi_lambda" {
 
   environment {
     variables = {
-      assessment_data_s3_bucket = "${data.aws_s3_bucket.assessment_data.id}"
-      assessment_data_filename = "${var.assessment_data_filename}"
-      # TODO: Coming soon...
-      # db_creds_s3_bucket = "${var.db_creds_s3_bucket}"
-      # db_creds_filename = "${var.db_creds_filename}"
+      s3_bucket = "${data.aws_s3_bucket.assessment_data.id}"
+      data_filename = "${var.assessment_data_filename}"
+      db_hostname = "${var.assessment_data_import_db_hostname}"
+      db_port = "${var.assessment_data_import_db_port}"
+      ssm_db_name = "${var.assessment_data_import_ssm_db_name}"
+      ssm_db_user = "${var.assessment_data_import_ssm_db_user}"
+      ssm_db_password = "${var.assessment_data_import_ssm_db_password}"
     }
   }
 

--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -1,0 +1,158 @@
+# Infrastructure related to the assessment data import lambda
+
+# IAM assume role policy document for the roles we're creating for the
+# lambda function
+data "aws_iam_policy_document" "adi_lambda_assume_role_doc" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+# The role we're creating for the lambda function
+resource "aws_iam_role" "adi_lambda_role" {
+  assume_role_policy = "${data.aws_iam_policy_document.adi_lambda_assume_role_doc.json}"
+}
+
+# IAM policy document that that allows some Cloudwatch permissions
+# for our Lambda function.  This will allow the Lambda function to
+# generate log output in Cloudwatch.  This will be applied to the
+# role we are creating.
+data "aws_iam_policy_document" "adi_lambda_cloudwatch_doc" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.adi_lambda_logs.arn}",
+    ]
+  }
+}
+
+# The CloudWatch policy for our role
+resource "aws_iam_role_policy" "adi_lambda_cloudwatch_policy" {
+  role = "${aws_iam_role.adi_lambda_role.id}"
+  policy = "${data.aws_iam_policy_document.adi_lambda_cloudwatch_doc.json}"
+}
+
+# IAM policy documents that that allows some EC2 permissions
+# for our Lambda function.  This will allow the Lambda function to
+# create and destroy ENI resources, as described here:
+# https://docs.aws.amazon.com/lambda/latest/dg/vpc.html.
+#
+# It would be great if there were a way to add a condition to reduce
+# the number of resources to which this policy can apply, but I don't
+# see a way to do that.
+#
+# This policy document will be applied to the role we are creating.
+data "aws_iam_policy_document" "adi_lambda_ec2_doc" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# The EC2 policy for our role (needed to run the lambda from within our VPC)
+resource "aws_iam_role_policy" "adi_lambda_ec2_policy" {
+  role = "${aws_iam_role.adi_lambda_role.id}"
+  policy = "${data.aws_iam_policy_document.adi_lambda_ec2_doc.json}"
+}
+
+# The S3 bucket where the assessment data is stored
+# Terraform code for this bucket is in:
+#   https://github.com/cisagov/assessment-data-import-terraform
+data "aws_s3_bucket" "assessment_data" {
+  bucket = "${local.production_workspace ? format("%s-production", var.assessment_data_s3_bucket) : format("%s-%s", var.assessment_data_s3_bucket, terraform.workspace)}"
+}
+
+# The S3 bucket where the assessment data import lambda function is stored
+# Terraform code for this bucket is in:
+#   https://github.com/cisagov/assessment-data-import-terraform
+data "aws_s3_bucket" "adi_lambda" {
+  bucket = "${local.production_workspace ? format("%s-production", var.assessment_data_import_lambda_s3_bucket) : format("%s-%s", var.assessment_data_import_lambda_s3_bucket, terraform.workspace)}"
+}
+
+# The AWS Lambda function that imports the assessment data to our database
+# Note that this lambda runs from within the CyHy private subnet
+resource "aws_lambda_function" "adi_lambda" {
+  s3_bucket = "${data.aws_s3_bucket.adi_lambda.id}"
+  s3_key = "${var.assessment_data_import_lambda_s3_key}"
+  function_name =  "${format("assessment_data_import-%s", terraform.workspace)}"
+  role = "${aws_iam_role.adi_lambda_role.arn}"
+  handler = "lambda_handler.handler"
+  runtime = "python3.6"
+  timeout = 300
+  memory_size = 128
+  description = "Lambda function for importing assessment data"
+  vpc_config {
+    subnet_ids = [
+      "${aws_subnet.cyhy_private_subnet.id}"
+    ]
+
+    security_group_ids = [
+      "${aws_security_group.adi_lambda_sg.id}"
+    ]
+  }
+
+  environment {
+    variables = {
+      assessment_data_s3_bucket = "${data.aws_s3_bucket.assessment_data.id}"
+      assessment_data_filename = "${var.assessment_data_filename}"
+      # TODO: Coming soon...
+      # db_creds_s3_bucket = "${var.db_creds_s3_bucket}"
+      # db_creds_filename = "${var.db_creds_filename}"
+    }
+  }
+
+  tags = "${var.tags}"
+}
+
+# Permission to allow the lambda to get notifications from our
+# assessment data bucket
+resource "aws_lambda_permission" "adi_lambda_allow_bucket" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.adi_lambda.arn}"
+  principal     = "s3.amazonaws.com"
+  source_arn    = "${data.aws_s3_bucket.assessment_data.arn}"
+}
+
+# Create the notification that triggers our lambda function to run whenever
+# an object is created in our assessment data bucket
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = "${data.aws_s3_bucket.assessment_data.id}"
+
+  lambda_function {
+    lambda_function_arn = "${aws_lambda_function.adi_lambda.arn}"
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "${var.assessment_data_filename}"
+  }
+}
+
+# The Cloudwatch log group for the Lambda functions
+resource "aws_cloudwatch_log_group" "adi_lambda_logs" {
+  name = "/aws/lambda/${aws_lambda_function.adi_lambda.function_name}"
+  retention_in_days = 30
+
+  tags = "${var.tags}"
+}

--- a/terraform/adi_lambda_security_group_rules.tf
+++ b/terraform/adi_lambda_security_group_rules.tf
@@ -9,3 +9,13 @@ resource "aws_security_group_rule" "adi_lambda_to_cyhy_mongo" {
   from_port = "27017"
   to_port = "27017"
 }
+
+# Allow HTTPS egress anywhere; needed to access AWS S3 bucket via boto3
+resource "aws_security_group_rule" "adi_lambda_https_egress_anywhere" {
+  security_group_id = "${aws_security_group.adi_lambda_sg.id}"
+  type = "egress"
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port = 443
+  to_port = 443
+}

--- a/terraform/adi_lambda_security_group_rules.tf
+++ b/terraform/adi_lambda_security_group_rules.tf
@@ -6,8 +6,8 @@ resource "aws_security_group_rule" "adi_lambda_to_cyhy_mongo" {
   cidr_blocks = [
     "${aws_instance.cyhy_mongo.private_ip}/32"
   ]
-  from_port = "27017"
-  to_port = "27017"
+  from_port = "${var.assessment_data_import_db_port}"
+  to_port = "${var.assessment_data_import_db_port}"
 }
 
 # Allow HTTPS egress anywhere; needed to access AWS S3 bucket via boto3

--- a/terraform/adi_lambda_security_group_rules.tf
+++ b/terraform/adi_lambda_security_group_rules.tf
@@ -1,0 +1,11 @@
+# Allow egress to the mongo database instance on the mongo port
+resource "aws_security_group_rule" "adi_lambda_to_cyhy_mongo" {
+  security_group_id = "${aws_security_group.adi_lambda_sg.id}"
+  type = "egress"
+  protocol = "tcp"
+  cidr_blocks = [
+    "${aws_instance.cyhy_mongo.private_ip}/32"
+  ]
+  from_port = "27017"
+  to_port = "27017"
+}

--- a/terraform/cyhy_private_security_group_rules.tf
+++ b/terraform/cyhy_private_security_group_rules.tf
@@ -63,6 +63,16 @@ resource "aws_security_group_rule" "private_mongodb_ingress" {
   to_port = 27017
 }
 
+# Allow MongoDB ingress from the assessment data import Lambda security group
+resource "aws_security_group_rule" "private_mongodb_ingress_from_adi_lambda" {
+  security_group_id = "${aws_security_group.cyhy_private_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  source_security_group_id = "${aws_security_group.adi_lambda_sg.id}"
+  from_port = 27017
+  to_port = 27017
+}
+
 # Allow MongoDB egress to Mongo host
 resource "aws_security_group_rule" "private_mongodb_egress_to_mongo_host" {
   security_group_id = "${aws_security_group.cyhy_private_sg.id}"

--- a/terraform/cyhy_vpc.tf
+++ b/terraform/cyhy_vpc.tf
@@ -145,7 +145,7 @@ resource "aws_route" "cyhy_private_route_external_traffic_through_bod_vpc_peerin
 # connection
 resource "aws_route" "cyhy_private_route_external_traffic_through_mgmt_vpc_peering_connection" {
   count = "${var.enable_mgmt_vpc}"
-  
+
   route_table_id = "${aws_route_table.cyhy_private_route_table.id}"
   destination_cidr_block = "${aws_vpc.mgmt_vpc.cidr_block}"
   vpc_peering_connection_id = "${aws_vpc_peering_connection.cyhy_mgmt_peering_connection.id}"
@@ -224,4 +224,11 @@ resource "aws_security_group" "cyhy_bastion_sg" {
   vpc_id = "${aws_vpc.cyhy_vpc.id}"
 
   tags = "${merge(var.tags, map("Name", "CyHy Bastion"))}"
+}
+
+# Security group for the assessment data import Lambda portion of the VPC
+resource "aws_security_group" "adi_lambda_sg" {
+  vpc_id = "${aws_vpc.cyhy_vpc.id}"
+
+  tags = "${merge(var.tags, map("Name", "Assessment Data Import Lambda"))}"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -179,3 +179,33 @@ variable "assessment_data_import_lambda_s3_key" {
   type = "string"
   description = "The key (name) of the zip file for the assessment data import Lambda function inside the S3 bucket."
 }
+
+variable "assessment_data_import_db_hostname" {
+  type        = "string"
+  description = "The hostname that has the database to store the assessment data in."
+  default     = ""
+}
+
+variable "assessment_data_import_db_port" {
+  type        = "string"
+  description = "The port that the database server is listening on."
+  default     = ""
+}
+
+variable "assessment_data_import_ssm_db_name" {
+  type        = "string"
+  description = "The name of the parameter in AWS SSM that holds the name of the database to store the assessment data in."
+  default     = ""
+}
+
+variable "assessment_data_import_ssm_db_user" {
+  type        = "string"
+  description = "The name of the parameter in AWS SSM that holds the database username with write permission to the assessment database."
+  default     = ""
+}
+
+variable "assessment_data_import_ssm_db_password" {
+  type        = "string"
+  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the assessment database."
+  default     = ""
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -158,3 +158,24 @@ variable "enable_mgmt_vpc" {
   description = "Whether or not to enable unfettered access from the vulnerability scanner in the Management VPC to other VPCs (CyHy, BOD).  This should only be enabled while running security scans from the Management VPC.  Zero means access is disabled and one means access is enabled."
   default = 0
 }
+
+variable "assessment_data_s3_bucket" {
+  type = "string"
+  description = "The name of the bucket where the assessment data JSON file can be found.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+  default = ""
+}
+
+variable "assessment_data_filename" {
+  type = "string"
+  description = "The name of the assessment data JSON file that can be found in the assessment_data_s3_bucket."
+}
+
+variable "assessment_data_import_lambda_s3_bucket" {
+  type = "string"
+  description = "The name of the bucket where the assessment data import Lambda function can be found.  This bucket should be created with https://github.com/cisagov/assessment-data-import-terraform.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+}
+
+variable "assessment_data_import_lambda_s3_key" {
+  type = "string"
+  description = "The key (name) of the zip file for the assessment data import Lambda function inside the S3 bucket."
+}


### PR DESCRIPTION
This PR creates the lambda and related infrastructure to import assessment data from an S3 bucket (created [here](https://github.com/cisagov/assessment-data-import-terraform) and populated via the [assessment data export](https://github.com/cisagov/assessment-data-export) process) to a mongo database.  

Note that the code executed by the assessment data import lambda is maintained [here](https://github.com/cisagov/assessment-data-import-lambda).