### PR TITLE
Get rid of some Ansible warnings

### DIFF
--- a/ansible/roles/client_cert_update/tasks/main.yml
+++ b/ansible/roles/client_cert_update/tasks/main.yml
@@ -44,14 +44,14 @@
     name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     user: cyhy
-  when: production_workspace
+  when: production_workspace|bool
 # This cron job runs at 5AM UTC on Tuesday mornings
 - name: Create a cron job for updating the list of hosts that require client certs
   cron:
     name: "client cert update"
-    minute: 0
-    hour: 5
-    weekday: 2
+    minute: '0'
+    hour: '5'
+    weekday: '2'
     user: cyhy
     job: cd /var/cyhy/client-cert-update && docker-compose up -d 2>&1 | /usr/bin/logger -t client-cert-update
-  when: production_workspace
+  when: production_workspace|bool

--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -65,14 +65,14 @@
     name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     user: cyhy
-  when: production_workspace
+  when: production_workspace|bool
 # This cron job runs at midnight UTC on Friday mornings
 - name: Create a cron job for updating the code.gov JSON
   cron:
     name: "code.gov update"
-    minute: 0
-    hour: 0
-    weekday: 5
+    minute: '0'
+    hour: '0'
+    weekday: '5'
     user: cyhy
     job: cd /var/cyhy/code-gov-update && docker-compose up -d 2>&1 | /usr/bin/logger -t code-gov-update
-  when: production_workspace
+  when: production_workspace|bool

--- a/ansible/roles/cyhy_archive/tasks/main.yml
+++ b/ansible/roles/cyhy_archive/tasks/main.yml
@@ -20,8 +20,8 @@
 - name: Set up weekly cyhy-archive cron job
   cron:
     name: Weekly cyhy-archive
-    weekday: 6
-    hour: 5
-    minute: 0
+    weekday: '6'
+    hour: '5'
+    minute: '0'
     user: cyhy
     job: /var/cyhy/scripts/cyhy_archive.sh /var/lib/mongodb/cyhy_archives {{ cyhy_archive_s3_bucket_name }} {{ cyhy_archive_s3_bucket_region }} 2>&1 | /usr/bin/logger -t cyhy-archive

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -159,7 +159,7 @@
 - name: Set up nightly cron job to sync NVD data
   cron:
     name: Nightly cyhy-nvdsync
-    hour: 08
-    minute: 15
+    hour: '8'
+    minute: '15'
     user: cyhy
     job: /usr/local/bin/cyhy-nvdsync --use-network 2>&1 | /usr/bin/logger -t cyhy-nvdsync

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -140,8 +140,8 @@
 - name: Set up nightly cron job to sync NSD data for MOE extract
   cron:
     name: Nightly cyhy extract
-    hour: 08
-    minute: 15
+    hour: '8'
+    minute: '15'
     user: cyhy
     job: cd /var/cyhy/scripts/cyhy-feeds && export AWS_CONFIG_FILE=/var/cyhy/scripts/cyhy-feeds/aws_config; python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --cyhy_section production --scan_section production_scan_reader --assessment_section production_assessment_reader --aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg 2>&1 | /usr/bin/logger -t cyhy-feeds
-  when: production_workspace
+  when: production_workspace|bool

--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -38,7 +38,7 @@
     name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     user: cyhy
-  when: production_workspace
+  when: production_workspace|bool
 # This cron job runs at midnight UTC on Sunday mornings.  The BOD
 # scanning is long since completed by that time.
 #
@@ -47,12 +47,12 @@
 # - name: Create a cron job for report generation
 #   cron:
 #     name: "Snapshot, CyHy report, and CybEx scorecard generation"
-#     minute: 0
-#     hour: 0
-#     weekday: 0
+#     minute: '0'
+#     hour: '0'
+#     weekday: '0'
 #     user: cyhy
 #     job: cd /var/cyhy/reports && ./create_snapshots_reports_scorecard.py --no-dock cyhy scan 2>&1 | /usr/bin/logger -t cyhy-reports
-#   when: production_workspace
+#   when: production_workspace|bool
 
 #
 # Add dev users to the cyhy group

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -19,8 +19,7 @@
 - name: Install pymongo 3.5.  This should be changed to install the latest once that is possible.
   pip:
     name: pymongo
-    version: 3.5
-    # state: latest
+    version: '3.5'
 
 - name: Create admin user in admin db (first user, no authentication)
   mongodb_user:

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -73,15 +73,15 @@
     name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     user: cyhy
-  when: production_workspace
+  when: production_workspace|bool
 # This cron job runs at midnight UTC on Saturday mornings, so it
 # should be done by 2PM on Saturday.
 - name: Create a cron job for BOD 18-01 scanning
   cron:
     name: "BOD 18-01 scanning"
-    minute: 0
-    hour: 0
-    weekday: 6
+    minute: '0'
+    hour: '0'
+    weekday: '6'
     user: cyhy
     job: cd /var/cyhy/orchestrator && docker-compose up -d 2>&1 | /usr/bin/logger -t orchestrator
-  when: production_workspace
+  when: production_workspace|bool


### PR DESCRIPTION
Ansible 2.8 is touchier about types and therefore outputs warnings about:
* Not casting the production_workspace variable to a bool
* Using integer values where a string value is expected

This pull request makes some minor adjustments so that these warnings go away.