### PR TITLE
Update script location for daily CyHy notification cron job

### DIFF
--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -64,7 +64,7 @@
     minute: 0
     hour: 10
     user: cyhy
-    job: cd /var/cyhy/notifications && ./create_send_notifications.py --log-level=info cyhy 2>&1 | /usr/bin/logger -t cyhy-notifications
+    job: cd /var/cyhy/reports && ./create_send_notifications.py --log-level=info cyhy 2>&1 | /usr/bin/logger -t cyhy-notifications
   when: production_workspace
 
 #

--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -65,7 +65,7 @@
     hour: '10'
     user: cyhy
     job: cd /var/cyhy/reports && ./create_send_notifications.py --log-level=info cyhy 2>&1 | /usr/bin/logger -t cyhy-notifications
-  when: production_workspace
+  when: production_workspace|bool
 
 #
 # Add dev users to the cyhy group

--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -61,8 +61,8 @@
 - name: Create cron job for daily CyHy notifications
   cron:
     name: "Generate and send daily CyHy notifications"
-    minute: 0
-    hour: 10
+    minute: '0'
+    hour: '10'
     user: cyhy
     job: cd /var/cyhy/reports && ./create_send_notifications.py --log-level=info cyhy 2>&1 | /usr/bin/logger -t cyhy-notifications
   when: production_workspace


### PR DESCRIPTION
The location of the daily notification script (`create_send_notifications.py`) changes in cisagov/ansible-role-cyhy-reports#4.  This PR updates the cron job to point to the new location.

This PR should be deployed in conjunction with cisagov/ansible-role-cyhy-reports#4 and cisagov/cyhy-mailer#54.