### PR TITLE
Update script for Terraform 0.12

### DIFF
--- a/terraform/deploy_new_lambdas.sh
+++ b/terraform/deploy_new_lambdas.sh
@@ -17,7 +17,7 @@ terraform workspace select "$workspace"
 
 for i in $(seq 0 2)
 do
-    terraform taint "aws_lambda_function.lambdas.$i"
+    terraform taint "aws_lambda_function.lambdas[$i]"
 done
 
 terraform apply -var-file="$workspace.tfvars" \

--- a/terraform/deploy_new_portscan_instance.sh
+++ b/terraform/deploy_new_portscan_instance.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# deploy_new_portscan_instance.sh instance_index
+# deploy_new_portscan_instance.sh workspace_name instance_index
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+index=none
+workspace=prod-a
+if [ $# -eq 2 ]
+then
+    workspace=$1
+    index=$2
+elif [ $# -eq 1 ]
+then
+    index=$1
+else
+    echo "Usage:  deploy_new_portscan_instance.sh instance_index"
+    echo "        deploy_new_portscan_instance.sh workspace_name instance_index"
+    exit 1
+fi
+
+terraform workspace select "$workspace"
+
+nmap_instance_id=$(terraform state show aws_instance.cyhy_nmap[$index] | \
+                       grep "^id" | sed "s/^id *= \(.*\)/\1/")
+
+# Terminate the existing nmap instance
+aws ec2 terminate-instances --instance-ids "$nmap_instance_id"
+aws ec2 wait instance-terminated --instance-ids "$nmap_instance_id"
+
+terraform apply -var-file="$workspace.tfvars" \
+          -target=aws_eip_association.cyhy_nmap_eip_assocs[$index] \
+          -target=aws_instance.cyhy_nmap[$index] \
+          -target=aws_route53_record.cyhy_portscan_A[$index] \
+          -target=aws_route53_record.cyhy_rev_portscan_PTR[$index] \
+          -target=aws_volume_attachment.nmap_cyhy_runner_data_attachment[$index] \
+          -target="module.dyn_nmap.module.cyhy_nmap_ansible_provisioner_$index"


### PR DESCRIPTION
Update the `deploy_new_lambdas.sh` script.  The syntax for identifying an item in an array has changed in Terraform 0.12.

Also add a script for deploying a new portscan instance.  This is occasionally useful when doing a full deploy, since sometimes one of the portscan instances fails to mount its data EBS volume and needs to be redeployed.