### PR TITLE
Add a workaround for a bug related to empty lists

### DIFF
--- a/terraform/dyn_mgmt_nessus/mgmt_nessus.template
+++ b/terraform/dyn_mgmt_nessus/mgmt_nessus.template
@@ -7,7 +7,18 @@ module "mgmt_nessus_ansible_provisioner_$index" {
     "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q $${var.remote_ssh_user}@$${var.mgmt_bastion_public_ip}\"'"
   ]
   envs = [
-    "host=$${element(var.mgmt_nessus_private_ips, $index)}",
+    # If you terminate all the existing management Nessus instances
+    # and then run apply, the list var.mgmt_nessus_private_ips is
+    # empty at that time.  Then there is an error condition when
+    # Terraform evaluates what must be done for the apply because you
+    # are trying to use element() to reference indices in an empty
+    # list.  The list will be populated with the actual values as the
+    # apply runs, so we just need to get past the pre-apply stage.
+    # Therefore this ugly hack works.
+    #
+    # If you find a better way, please use it and get rid of this
+    # affront to basic decency.
+    "host=$${length(var.mgmt_nessus_private_ips) > 0 ? element(var.mgmt_nessus_private_ips, $index) : ""}",
     "bastion_host=$${var.mgmt_bastion_public_ip}",
     "host_groups=nessus",
     "nessus_activation_code=$${var.mgmt_nessus_activation_codes[$index]}"

--- a/terraform/dyn_nessus/nessus.template
+++ b/terraform/dyn_nessus/nessus.template
@@ -7,7 +7,18 @@ module "cyhy_nessus_ansible_provisioner_$index" {
     "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q $${var.remote_ssh_user}@$${var.bastion_public_ip}\"'"
   ]
   envs = [
-    "host=$${element(var.nessus_private_ips, $index)}",
+    # If you terminate all the existing management Nessus instances
+    # and then run apply, the list var.nessus_private_ips is empty at
+    # that time.  Then there is an error condition when Terraform
+    # evaluates what must be done for the apply because you are trying
+    # to use element() to reference indices in an empty list.  The
+    # list will be populated with the actual values as the apply runs,
+    # so we just need to get past the pre-apply stage.  Therefore this
+    # ugly hack works.
+    #
+    # If you find a better way, please use it and get rid of this
+    # affront to basic decency.
+    "host=$${length(var.nessus_private_ips) > 0 ? element(var.nessus_private_ips, $index) : ""}",
     "bastion_host=$${var.bastion_public_ip}",
     "host_groups=cyhy_runner,nessus",
     "nessus_activation_code=$${var.nessus_activation_codes[$index]}"

--- a/terraform/dyn_nmap/nmap.template
+++ b/terraform/dyn_nmap/nmap.template
@@ -7,7 +7,18 @@ module "cyhy_nmap_ansible_provisioner_$index" {
     "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q $${var.remote_ssh_user}@$${var.bastion_public_ip}\"'"
   ]
   envs = [
-    "host=$${element(var.nmap_private_ips, $index)}",
+    # If you terminate all the existing management Nessus instances
+    # and then run apply, the list var.nmap_private_ips is empty at
+    # that time.  Then there is an error condition when Terraform
+    # evaluates what must be done for the apply because you are trying
+    # to use element() to reference indices in an empty list.  The
+    # list will be populated with the actual values as the apply runs,
+    # so we just need to get past the pre-apply stage.  Therefore this
+    # ugly hack works.
+    #
+    # If you find a better way, please use it and get rid of this
+    # affront to basic decency.
+    "host=$${length(var.nmap_private_ips) > 0 ? element(var.nmap_private_ips, $index) : ""}",
     "bastion_host=$${var.bastion_public_ip}",
     "host_groups=cyhy_runner,nmap"
   ]


### PR DESCRIPTION
If you terminate all the existing instances for a particular template and then run `terraform apply`, the corresponding list `var.*_private_ips` is empty at that time.  Then there is an error condition when Terraform evaluates what must be done for the apply because you are trying to use `element()` to reference indices in an empty list.  The list will be populated with the actual values as the apply runs, so we just need to get past the pre-apply stage.  Therefore this ugly hack works.

If you find a better way, please use it and get rid of this affront to basic decency.