### PR TITLE
Deploy script improvements

### DIFF
--- a/terraform/deploy_new_docker_ami.sh
+++ b/terraform/deploy_new_docker_ami.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 
-# deploy_new_docker_ami.sh
-# deploy_new_docker_ami.sh workspace_name
+# deploy_new_docker_ami.sh region workspace_name
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-workspace=prod-a
-if [ $# -ge 1 ]
+if [ $# -eq 2 ]
 then
-    workspace=$1
+    region=$1
+    workspace=$2
+else
+    echo "Usage:  deploy_new_docker_ami.sh region workspace_name"
+    exit 1
 fi
 
 terraform workspace select "$workspace"
@@ -25,8 +27,8 @@ docker_instance_id=$(terraform state show aws_instance.bod_docker | \
                          sed "s/[[:space:]]*id[[:space:]]*= \"\(.*\)\"/\1/")
 
 # Terminate the existing docker instance
-aws ec2 terminate-instances --instance-ids "$docker_instance_id"
-aws ec2 wait instance-terminated --instance-ids "$docker_instance_id"
+aws --region "$region" ec2 terminate-instances --instance-ids "$docker_instance_id"
+aws --region "$region" ec2 wait instance-terminated --instance-ids "$docker_instance_id"
 
 terraform apply -var-file="$workspace.tfvars" \
           -target=aws_instance.bod_docker \

--- a/terraform/deploy_new_portscan_instance.sh
+++ b/terraform/deploy_new_portscan_instance.sh
@@ -1,24 +1,18 @@
 #!/usr/bin/env bash
 
-# deploy_new_portscan_instance.sh instance_index
-# deploy_new_portscan_instance.sh workspace_name instance_index
+# deploy_new_portscan_instance.sh region workspace_name instance_index
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-index=none
-workspace=prod-a
-if [ $# -eq 2 ]
+if [ $# -eq 3 ]
 then
-    workspace=$1
-    index=$2
-elif [ $# -eq 1 ]
-then
-    index=$1
+    region=$1
+    workspace=$2
+    index=$3
 else
-    echo "Usage:  deploy_new_portscan_instance.sh instance_index"
-    echo "        deploy_new_portscan_instance.sh workspace_name instance_index"
+    echo "Usage:  deploy_new_portscan_instance.sh region workspace_name instance_index"
     exit 1
 fi
 
@@ -34,8 +28,8 @@ nmap_instance_id=$(terraform state show aws_instance.cyhy_nmap[$index] | \
                        sed "s/[[:space:]]*id[[:space:]]*= \"\(.*\)\"/\1/")
 
 # Terminate the existing nmap instance
-aws ec2 terminate-instances --instance-ids "$nmap_instance_id"
-aws ec2 wait instance-terminated --instance-ids "$nmap_instance_id"
+aws --region "$region" ec2 terminate-instances --instance-ids "$nmap_instance_id"
+aws --region "$region" ec2 wait instance-terminated --instance-ids "$nmap_instance_id"
 
 terraform apply -var-file="$workspace.tfvars" \
           -target=aws_eip_association.cyhy_nmap_eip_assocs[$index] \

--- a/terraform/deploy_new_reporter_ami.sh
+++ b/terraform/deploy_new_reporter_ami.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 
-# deploy_new_reporter_ami.sh
-# deploy_new_reporter_ami.sh workspace_name
+# deploy_new_reporter_ami.sh region workspace_name
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-workspace=prod-a
-if [ $# -ge 1 ]
+if [ $# -eq 2 ]
 then
-    workspace=$1
+    region=$1
+    workspace=$2
+else
+    echo "Usage:  deploy_new_reporter_ami.sh region workspace_name"
+    exit 1
 fi
 
 terraform workspace select "$workspace"
@@ -25,8 +27,8 @@ reporter_instance_id=$(terraform state show aws_instance.cyhy_reporter | \
                            sed "s/[[:space:]]*id[[:space:]]*= \"\(.*\)\"/\1/")
 
 # Terminate the existing reporter instance
-aws ec2 terminate-instances --instance-ids "$reporter_instance_id"
-aws ec2 wait instance-terminated --instance-ids "$reporter_instance_id"
+aws --region "$region" ec2 terminate-instances --instance-ids "$reporter_instance_id"
+aws --region "$region" ec2 wait instance-terminated --instance-ids "$reporter_instance_id"
 
 terraform apply -var-file="$workspace.tfvars" \
           -target=aws_instance.cyhy_reporter \


### PR DESCRIPTION
Update all deploy scripts to:
* Require all command-line parameters; previously, scripts would default to `prod-a` workspace
* Include new 'region' parameter so we can run scripts in regions other than previous default of `us-east-1`
* Include usage output if no parameters given (for scripts that didn't already have this)