### PR TITLE
Update splat syntax

### DIFF
--- a/terraform/bod_lambdas.tf
+++ b/terraform/bod_lambdas.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role" "lambda_roles" {
 # generate log output in Cloudwatch.  These will be applied to the
 # roles we are creating.
 data "aws_iam_policy_document" "lambda_cloudwatch_docs" {
-  count = length(var.scan_types)
+  count = length(aws_cloudwatch_log_group.lambda_logs)
 
   statement {
     effect = "Allow"
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "lambda_cloudwatch_docs" {
 
 # The CloudWatch policies for our roles
 resource "aws_iam_role_policy" "lambda_cloudwatch_policies" {
-  count = length(var.scan_types)
+  count = length(aws_iam_role.lambda_roles)
 
   role   = aws_iam_role.lambda_roles[count.index].id
   policy = data.aws_iam_policy_document.lambda_cloudwatch_docs[count.index].json
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "lambda_ec2_docs" {
 
 # The EC2 policies for our roles
 resource "aws_iam_role_policy" "lambda_ec2_policies" {
-  count = length(var.scan_types)
+  count = length(aws_iam_role.lambda_roles)
 
   role   = aws_iam_role.lambda_roles[count.index].id
   policy = data.aws_iam_policy_document.lambda_ec2_docs[count.index].json
@@ -88,7 +88,7 @@ resource "aws_iam_role_policy" "lambda_ec2_policies" {
 
 # The AWS Lambda functions that perform the scans
 resource "aws_lambda_function" "lambdas" {
-  count = length(var.scan_types)
+  count = length(aws_iam_role.lambda_roles)
 
   # Terraform cannot access buckets that are not in the provider's
   # region.  This limitation means that we have to create
@@ -117,7 +117,7 @@ resource "aws_lambda_function" "lambdas" {
 
 # The Cloudwatch log groups for the Lambda functions
 resource "aws_cloudwatch_log_group" "lambda_logs" {
-  count = length(var.scan_types)
+  count = length(aws_lambda_function.lambdas)
 
   name              = "/aws/lambda/${aws_lambda_function.lambdas[count.index].function_name}"
   retention_in_days = 30

--- a/terraform/bod_vpc.tf
+++ b/terraform/bod_vpc.tf
@@ -119,8 +119,8 @@ resource "aws_nat_gateway" "bod_nat_gw" {
   # for more details.
   allocation_id = element(
     coalescelist(
-      data.aws_eip.bod_production_eip.*.id,
-      aws_eip.bod_nonproduction_eip.*.id,
+      data.aws_eip.bod_production_eip[*].id,
+      aws_eip.bod_nonproduction_eip[*].id,
     ),
     0,
   )

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -157,19 +157,14 @@ resource "aws_volume_attachment" "nessus_cyhy_runner_data_attachment" {
   # allows terraform to successfully destroy the volume attachments.
   provisioner "local-exec" {
     when = destroy
-
-    # Use element(aws_instance.cyhy_nessus.*.id, count.index) rather than
-    # aws_instance.cyhy_nessus.*.id[count.index] to avoid Terraform 'index out
-    # of range' error, similar to the one documented here:
-    # https://github.com/hashicorp/terraform/issues/14536#issue-228958605
-    command    = "aws --region=${var.aws_region} ec2 terminate-instances --instance-ids ${element(aws_instance.cyhy_nessus.*.id, count.index)}"
+    command    = "aws --region=${var.aws_region} ec2 terminate-instances --instance-ids ${aws_instance.cyhy_nessus[count.index].id}"
     on_failure = continue
   }
 
   # Wait until cyhy_nessus instance is terminated before continuing on
   provisioner "local-exec" {
     when    = destroy
-    command = "aws --region=${var.aws_region} ec2 wait instance-terminated --instance-ids ${element(aws_instance.cyhy_nessus.*.id, count.index)}"
+    command = "aws --region=${var.aws_region} ec2 wait instance-terminated --instance-ids ${aws_instance.cyhy_nessus[count.index].id}"
   }
 
   skip_destroy = true

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -103,11 +103,11 @@ resource "aws_eip" "cyhy_nessus_random_eips" {
 # VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
 resource "aws_eip_association" "cyhy_nessus_eip_assocs" {
   count       = local.nessus_instance_count
-  instance_id = element(aws_instance.cyhy_nessus.*.id, count.index)
+  instance_id = aws_instance.cyhy_nessus[count.index].id
   allocation_id = element(
     coalescelist(
-      data.aws_eip.cyhy_nessus_eips.*.id,
-      aws_eip.cyhy_nessus_random_eips.*.id,
+      data.aws_eip.cyhy_nessus_eips[*].id,
+      aws_eip.cyhy_nessus_random_eips[*].id,
     ),
     count.index,
   )
@@ -180,7 +180,7 @@ resource "aws_volume_attachment" "nessus_cyhy_runner_data_attachment" {
 module "dyn_nessus" {
   source                  = "./dyn_nessus"
   bastion_public_ip       = aws_instance.cyhy_bastion.public_ip
-  nessus_private_ips      = aws_instance.cyhy_nessus.*.private_ip
+  nessus_private_ips      = aws_instance.cyhy_nessus[*].private_ip
   nessus_activation_codes = var.nessus_activation_codes
   remote_ssh_user         = var.remote_ssh_user
 }

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "cyhy_nmap" {
 # manually and are intended to be a public IP address that rarely
 # changes.
 data "aws_eip" "cyhy_nmap_eips" {
-  count = local.production_workspace ? local.nmap_instance_count : 0
+  count = local.production_workspace ? length(aws_instance.cyhy_nmap) : 0
   public_ip = cidrhost(
     var.cyhy_elastic_ip_cidr_block,
     var.cyhy_portscan_first_elastic_ip_offset + count.index,
@@ -77,7 +77,7 @@ data "aws_eip" "cyhy_nmap_eips" {
 # workspaces and are randomly-assigned public IP address for temporary
 # use.
 resource "aws_eip" "cyhy_nmap_random_eips" {
-  count = local.production_workspace ? 0 : local.nmap_instance_count
+  count = local.production_workspace ? 0 : length(aws_instance.cyhy_nmap)
   vpc   = true
   tags = merge(
     var.tags,
@@ -104,7 +104,7 @@ resource "aws_eip" "cyhy_nmap_random_eips" {
 #
 # VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
 resource "aws_eip_association" "cyhy_nmap_eip_assocs" {
-  count       = local.nmap_instance_count
+  count       = length(aws_instance.cyhy_nmap)
   instance_id = aws_instance.cyhy_nmap[count.index].id
   allocation_id = element(
     coalescelist(
@@ -126,7 +126,7 @@ resource "aws_eip_association" "cyhy_nmap_eip_assocs" {
 # inside of the lifecycle block
 # (https://github.com/hashicorp/terraform/issues/3116).
 resource "aws_ebs_volume" "nmap_cyhy_runner_data" {
-  count             = local.nmap_instance_count
+  count             = length(aws_instance.cyhy_nmap)
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # availability_zone = "${element(data.aws_availability_zones.all.names, count.index)}"
@@ -147,7 +147,7 @@ resource "aws_ebs_volume" "nmap_cyhy_runner_data" {
 }
 
 resource "aws_volume_attachment" "nmap_cyhy_runner_data_attachment" {
-  count       = local.nmap_instance_count
+  count       = length(aws_instance.cyhy_nmap)
   device_name = "/dev/xvdb"
   volume_id   = aws_ebs_volume.nmap_cyhy_runner_data[count.index].id
   instance_id = aws_instance.cyhy_nmap[count.index].id
@@ -160,19 +160,14 @@ resource "aws_volume_attachment" "nmap_cyhy_runner_data_attachment" {
   # allows terraform to successfully destroy the volume attachments.
   provisioner "local-exec" {
     when = destroy
-
-    # Use element(aws_instance.cyhy_nmap.*.id, count.index) rather than
-    # aws_instance.cyhy_nmap.*.id[count.index] to avoid Terraform 'index out of
-    # range' error, similar to the one documented here:
-    # https://github.com/hashicorp/terraform/issues/14536#issue-228958605
-    command    = "aws --region=${var.aws_region} ec2 terminate-instances --instance-ids ${element(aws_instance.cyhy_nmap.*.id, count.index)}"
+    command    = "aws --region=${var.aws_region} ec2 terminate-instances --instance-ids ${aws_instance.cyhy_nmap[count.index].id}"
     on_failure = continue
   }
 
   # Wait until cyhy_nmap instance is terminated before continuing on
   provisioner "local-exec" {
     when    = destroy
-    command = "aws --region=${var.aws_region} ec2 wait instance-terminated --instance-ids ${element(aws_instance.cyhy_nmap.*.id, count.index)}"
+    command = "aws --region=${var.aws_region} ec2 wait instance-terminated --instance-ids ${aws_instance.cyhy_nmap[count.index].id}"
   }
 
   skip_destroy = true

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -90,7 +90,7 @@ resource "aws_eip" "cyhy_nmap_random_eips" {
 
 # Associate the appropriate Elastic IP above with the CyHy nmap
 # instances.  Since our elastic IPs are handled differently in
-# production vs.  non-production workspaces, their corresponding
+# production vs. non-production workspaces, their corresponding
 # terraform resources (data.aws_eip.cyhy_nmap_eips,
 # data.aws_eip.cyhy_nmap_random_eips) may or may not be created.  To
 # handle that, we use "splat syntax" (the *), which resolves to either
@@ -105,11 +105,11 @@ resource "aws_eip" "cyhy_nmap_random_eips" {
 # VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
 resource "aws_eip_association" "cyhy_nmap_eip_assocs" {
   count       = local.nmap_instance_count
-  instance_id = element(aws_instance.cyhy_nmap.*.id, count.index)
+  instance_id = aws_instance.cyhy_nmap[count.index].id
   allocation_id = element(
     coalescelist(
-      data.aws_eip.cyhy_nmap_eips.*.id,
-      aws_eip.cyhy_nmap_random_eips.*.id,
+      data.aws_eip.cyhy_nmap_eips[*].id,
+      aws_eip.cyhy_nmap_random_eips[*].id,
     ),
     count.index,
   )
@@ -183,6 +183,6 @@ resource "aws_volume_attachment" "nmap_cyhy_runner_data_attachment" {
 module "dyn_nmap" {
   source            = "./dyn_nmap"
   bastion_public_ip = aws_instance.cyhy_bastion.public_ip
-  nmap_private_ips  = aws_instance.cyhy_nmap.*.private_ip
+  nmap_private_ips  = aws_instance.cyhy_nmap[*].private_ip
   remote_ssh_user   = var.remote_ssh_user
 }

--- a/terraform/cyhy_private_dns.tf
+++ b/terraform/cyhy_private_dns.tf
@@ -174,28 +174,28 @@ resource "aws_route53_record" "cyhy_rev_portscan_PTR" {
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nmap.*.private_ip, count.index),
+        aws_instance.cyhy_nmap[count.index].private_ip,
       ),
       3,
     ),
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nmap.*.private_ip, count.index),
+        aws_instance.cyhy_nmap[count.index].private_ip,
       ),
       2,
     ),
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nmap.*.private_ip, count.index),
+        aws_instance.cyhy_nmap[count.index].private_ip,
       ),
       1,
     ),
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nmap.*.private_ip, count.index),
+        aws_instance.cyhy_nmap[count.index].private_ip,
       ),
       0,
     ),
@@ -214,28 +214,28 @@ resource "aws_route53_record" "cyhy_rev_vulnscan_PTR" {
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nessus.*.private_ip, count.index),
+        aws_instance.cyhy_nessus[count.index].private_ip,
       ),
       3,
     ),
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nessus.*.private_ip, count.index),
+        aws_instance.cyhy_nessus[count.index].private_ip,
       ),
       2,
     ),
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nessus.*.private_ip, count.index),
+        aws_instance.cyhy_nessus[count.index].private_ip,
       ),
       1,
     ),
     element(
       split(
         ".",
-        element(aws_instance.cyhy_nessus.*.private_ip, count.index),
+        aws_instance.cyhy_nessus[count.index].private_ip,
       ),
       0,
     ),

--- a/terraform/mgmt_nessus_ec2.tf
+++ b/terraform/mgmt_nessus_ec2.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "mgmt_nessus" {
 module "dyn_mgmt_nessus" {
   source                       = "./dyn_mgmt_nessus"
   mgmt_bastion_public_ip       = aws_instance.mgmt_bastion[0].public_ip
-  mgmt_nessus_private_ips      = aws_instance.mgmt_nessus.*.private_ip
+  mgmt_nessus_private_ips      = aws_instance.mgmt_nessus[*].private_ip
   mgmt_nessus_activation_codes = var.mgmt_nessus_activation_codes
   remote_ssh_user              = var.remote_ssh_user
 }


### PR DESCRIPTION
There is a new and much more intuitive version of the Terraform splat syntax in version 0.12, so I updated the code to use it.

@dav3r and I noticed some cases where we were previously setting `count` equal to `local.nessus_instance_count`, for example, and then indexing into structures such as `aws_instance.cyhy_nessus[count.index].id`.  This used to work, but now can cause problems.  This is because when `terraform apply` is run, `length(aws_instance.cyhy_nessus)` and `local.nessus_instance_count` are only _eventually_ consistent.  Therefore we sometimes get errors because we're indexing into an empty list, for example.

A better practice is to set `count` equal to the thing we're actually indexing into where possible, such as `length(aws_instance.cyhy_nessus)`.  I made that change in several places in this pull request, and we should adopt this practice going forward.