### PR TITLE
Use CyHy EIPs for "manual" Nessus scanners

### DIFF
--- a/terraform_nessus_only/configure.py
+++ b/terraform_nessus_only/configure.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+"""Configure the terraform environment based on the active workspace.
+
+Due to a terraform limitation, modules can not be scaled with the "count"
+keyword the same way resource can.  This leads to a great deal of copying and
+pasting in order to get provisioners and other modules to execute correctly.
+
+This script can be retired once this limitation is removed from Terraform.
+See: https://github.com/hashicorp/terraform/issues/953
+
+To create a unique configuration for your own workspace edit the
+WORKSPACE_CONFIGS constant below.
+"""
+
+import glob
+import os
+import subprocess
+from string import Template
+import sys
+
+# This script uses a subprocess feature added in python 3.7
+assert sys.version_info >= (3, 7), "This script requires Python 3.7 or newer"
+
+# for each workspace, set the number of instances to create for each template
+WORKSPACE_CONFIGS = {"production": {"nessus": 1}, "daver": {"nessus": 2}}
+
+# the default configuration if a workspace is not defined above
+DEFAULT_CONFIG = {"nessus": 1}
+
+# variables to be defined in a dynamic locals file
+LOCAL_DEFS = {"nessus": "nessus_instance_count"}
+
+# filename constant definitions
+TEMPLATE_EXTENSION = ".template"
+DYNAMIC_EXTENSION = ".dyn.tf"
+DELETE_GLOB = "**/*" + DYNAMIC_EXTENSION
+LOCALS_FILE = "locals" + DYNAMIC_EXTENSION
+
+# the command to read the current terraform workspace
+TERRAFORM_WORKSPACE_CMD = "terraform workspace show"
+
+
+def get_terraform_workspace():
+    """Return the current workspace."""
+    completed_process = subprocess.run(
+        TERRAFORM_WORKSPACE_CMD, capture_output=True, shell=True
+    )
+    return completed_process.stdout.decode().strip()
+
+
+def find_templates():
+    """Find template files."""
+    return glob.iglob("**/*" + TEMPLATE_EXTENSION, recursive=True)
+
+
+def read_template(filename):
+    """Read in the template and return a Template object."""
+    # read in the template
+    with open(filename) as f:
+        template = f.readlines()
+    # convert from a list to a single string and return
+    return Template("".join(template))
+
+
+def remove_dynamic_files():
+    """Delete all the previously-created dynamic files."""
+    for filename in glob.iglob(DELETE_GLOB, recursive=True):
+        os.unlink(filename)
+
+
+def create_dynamic_files(template, path, name, count):
+    """Create count number files using the template."""
+    for i in range(count):
+        filename = ".".join([name, str(i), DYNAMIC_EXTENSION[1:]])
+        full_path = os.path.join(path, filename)
+        rendered_template = template.substitute(index=i)
+        with open(full_path, mode="wb") as f:
+            f.write(rendered_template.encode("utf-8"))
+
+
+def create_dynamic_locals(config):
+    """Create a dynamic locals file from configuration."""
+    with open(LOCALS_FILE, mode="wb") as f:
+        f.write("locals {\n".encode("utf-8"))
+        for key, variable_name in LOCAL_DEFS.items():
+            value = config.get(key)
+            f.write(f"    {variable_name} = {value}\n".encode("utf-8"))
+        f.write("}\n".encode("utf-8"))
+
+
+def main():
+    """Configure terraform environment."""
+    workspace = get_terraform_workspace()  # get workspace
+    print("Current Terraform workspace = ", workspace)
+
+    # lookup the workspace config based on the current terraform workspace
+    config = WORKSPACE_CONFIGS.get(workspace, DEFAULT_CONFIG)
+    print("Configuration for workspace = ", config)
+
+    # remove the previously generate files
+    print("Removing previously generated files")
+    remove_dynamic_files()
+
+    print("Searching for templates to render...")
+    # find templates and render them
+    for template_file in find_templates():
+        # calculate working directory and config keys from template name
+        template_dir, filename = os.path.split(template_file)
+        template_key, unused = os.path.splitext(filename)
+        # lookup the count for this template
+        count = config[template_key]
+        print(
+            f"Creating {count} instantiation{'' if count == 1 else 's'} "
+            "of template {template_file}"
+        )
+        # read in the template
+        template = read_template(template_file)
+        for i in range(count):
+            # render the template and create files
+            create_dynamic_files(template, template_dir, template_key, count)
+
+    # create a locals file that defines the counts for each template type
+    print("Create dynamic locals file")
+    create_dynamic_locals(config)
+
+    # import IPython; IPython.embed() #<<< BREAKPOINT >>>
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform_nessus_only/configure.py
+++ b/terraform_nessus_only/configure.py
@@ -23,7 +23,7 @@ import sys
 assert sys.version_info >= (3, 7), "This script requires Python 3.7 or newer"
 
 # for each workspace, set the number of instances to create for each template
-WORKSPACE_CONFIGS = {"production": {"nessus": 1}, "daver": {"nessus": 2}}
+WORKSPACE_CONFIGS = {"production": {"nessus": 1}}
 
 # the default configuration if a workspace is not defined above
 DEFAULT_CONFIG = {"nessus": 1}

--- a/terraform_nessus_only/configure.py
+++ b/terraform_nessus_only/configure.py
@@ -112,7 +112,7 @@ def main():
         count = config[template_key]
         print(
             f"Creating {count} instantiation{'' if count == 1 else 's'} "
-            "of template {template_file}"
+            f"of template {template_file}"
         )
         # read in the template
         template = read_template(template_file)

--- a/terraform_nessus_only/dyn_nessus/nessus.template
+++ b/terraform_nessus_only/dyn_nessus/nessus.template
@@ -1,0 +1,26 @@
+# Provision a Nessus EC2 instance via Ansible
+module "nessus_ansible_provisioner_$index" {
+  source = "github.com/cloudposse/terraform-null-ansible"
+
+  arguments = [
+    "--user=$${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no'"
+  ]
+  envs = [
+    # If you terminate all the existing Nessus instances and then run apply,
+    # the list var.nessus_private_ips is empty at that time.  Then there is
+    # an error condition when Terraform evaluates what must be done for the
+    # apply because you are trying to use element() to reference indices in an
+    # empty list.  The list will be populated with the actual values as the
+    # apply runs, so we just need to get past the pre-apply stage.
+    # Therefore this ugly hack works.
+    #
+    # If you find a better way, please use it and get rid of this
+    # affront to basic decency.
+    "host=$${length(var.nessus_public_ips) > 0 ? element(var.nessus_public_ips, $index) : ""}",
+    "host_groups=nessus",
+    "nessus_activation_code=$${var.nessus_activation_codes[$index]}"
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}

--- a/terraform_nessus_only/dyn_nessus/nessus.template
+++ b/terraform_nessus_only/dyn_nessus/nessus.template
@@ -8,7 +8,7 @@ module "nessus_ansible_provisioner_$index" {
   ]
   envs = [
     # If you terminate all the existing Nessus instances and then run apply,
-    # the list var.nessus_private_ips is empty at that time.  Then there is
+    # the list var.nessus_public_ips is empty at that time.  Then there is
     # an error condition when Terraform evaluates what must be done for the
     # apply because you are trying to use element() to reference indices in an
     # empty list.  The list will be populated with the actual values as the

--- a/terraform_nessus_only/dyn_nessus/variables.tf
+++ b/terraform_nessus_only/dyn_nessus/variables.tf
@@ -1,0 +1,3 @@
+variable "nessus_public_ips" { type = "list" }
+variable "nessus_activation_codes" { type = "list" }
+variable "remote_ssh_user" {}

--- a/terraform_nessus_only/locals.tf
+++ b/terraform_nessus_only/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  # This is a goofy but necessary way to determine if
+  # terraform.workspace contains the substring "prod"
+  production_workspace = replace(terraform.workspace, "prod", "") != terraform.workspace
+}

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -27,6 +27,7 @@ resource "aws_instance" "nessus" {
   ami               = data.aws_ami.nessus.id
   instance_type     = "m4.large"
   ebs_optimized     = true
+  instance_type     = "m5.large"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   subnet_id                   = aws_subnet.nessus_scanner_subnet.id
@@ -34,8 +35,8 @@ resource "aws_instance" "nessus" {
 
   root_block_device {
     volume_type           = "gp2"
-    volume_size           = 100
-    delete_on_termination = false
+    volume_size           = local.production_workspace ? 100 : 16
+    delete_on_termination = true
   }
 
   vpc_security_group_ids = [

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "nessus" {
     aws_security_group.nessus_scanner_sg.id,
   ]
 
-  user_data = data.template_cloudinit_config.ssh_cloud_init_tasks.rendered
+  user_data_base64 = data.template_cloudinit_config.ssh_cloud_init_tasks.rendered
 
   tags = merge(
     var.tags,

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -53,3 +53,61 @@ resource "aws_instance" "nessus" {
   }
 }
 
+# The Elastic IPs for *production* Nessus instances.  These are within the
+# block of EIPs that AWS assigned for CyHy; see variables.tf for details.
+data "aws_eip" "nessus_eips" {
+  count = local.production_workspace ? length(aws_instance.nessus) : 0
+  public_ip = cidrhost(
+    var.cyhy_elastic_ip_cidr_block,
+    var.nessus_first_elastic_ip_offset + count.index,
+  )
+}
+
+# The Elastic IP for *non-production* CyHy Nessus instances. These EIPs are
+# only created in *non-production* workspaces and are randomly-assigned
+# public IP addresses for temporary use.
+resource "aws_eip" "nessus_random_eips" {
+  count = local.production_workspace ? 0 : length(aws_instance.nessus)
+  vpc   = true
+  tags = merge(
+    var.tags,
+    {
+      "Name"           = format("Manual CyHy Nessus EIP %d", count.index + 1)
+      "Publish Egress" = "True"
+    },
+  )
+}
+
+# Associate the appropriate Elastic IPs above with the Nessus instances.
+# Since our elastic IPs are handled differently in production vs.
+# non-production workspaces, their corresponding terraform resources
+# (data.aws_eip.nessus_eips, aws_eip.nessus_random_eips) may or may not be
+# created.  To handle that, we use "splat syntax" (the *), which resolves to
+# either an empty list (if the resource is not present in the current
+# workspace) or a valid list (if the resource is present).  Then we
+# use coalescelist() to choose the (non-empty) list containing the
+# valid eip.id. Finally, we use element() to choose the appropriate
+# element in that non-empty list, which is the allocation_id of our
+# elastic IP.  See
+# https://github.com/hashicorp/terraform/issues/11566#issuecomment-289417805
+#
+# VOTED WORST LINE OF TERRAFORM 2019 (so far) BY DEV TEAM WEEKLY!!
+resource "aws_eip_association" "nessus_eip_assocs" {
+  count       = length(aws_instance.nessus)
+  instance_id = aws_instance.nessus[count.index].id
+  allocation_id = element(
+    coalescelist(
+      data.aws_eip.nessus_eips[*].id,
+      aws_eip.nessus_random_eips[*].id,
+    ),
+    count.index,
+  )
+}
+
+# load in the dynamically created provisioner modules
+module "dyn_nessus" {
+  source                  = "./dyn_nessus"
+  nessus_public_ips       = aws_eip_association.nessus_eip_assocs[*].public_ip
+  nessus_activation_codes = var.nessus_activation_codes
+  remote_ssh_user         = var.remote_ssh_user
+}

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -21,17 +21,12 @@ data "aws_ami" "nessus" {
 }
 
 resource "aws_instance" "nessus" {
-  # Number of Nessus instances to create
-  count = terraform.workspace == "production" ? 3 : 1
-
   ami               = data.aws_ami.nessus.id
-  instance_type     = "m4.large"
-  ebs_optimized     = true
   instance_type     = "m5.large"
+  count             = local.nessus_instance_count   # Set by configure.py
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   subnet_id                   = aws_subnet.nessus_scanner_subnet.id
-  associate_public_ip_address = true
 
   root_block_device {
     volume_type           = "gp2"

--- a/terraform_nessus_only/scripts/user_ssh_setup.yml
+++ b/terraform_nessus_only/scripts/user_ssh_setup.yml
@@ -25,9 +25,9 @@ users:
     shell: /bin/bash
     ssh-authorized-keys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKY5tqMRtnZSkVPwU0X1zKA8L3RnvmhSAR/bHAtd3Vcr kyle.evers
-  - name: robert.mcneal
+  - name: nicholas.mcdonnell
     groups: [ sudo ]
     sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
     shell: /bin/bash
     ssh-authorized-keys:
-      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9Br+LIxekK7bWSgVEVh0ryV2iE80qSlcMuvLgl1JZD5yGtIHigBiwLmriwiyTYsNBFxWY2ypEgsQ384/1kNvH6vSFzAbssBf15elV+SNNHH0OOHEh19CtHJIsZV2ry9i6SSllXIUsClmSR3rj/83sOwtclIDzes0vg8NfVyTsFWnywhZ1mCsCUwr0vu/jKKQvIohy4JwdMz8sgKl6zzUvg+5Q7e8i3lEKC1Grehkj1vG8ro/C4eltUtg8CwUxx/JA5csbR5NleGayyrQ6ZRtTckUyYnk3L7cVgBh4TnpxtoUbe/B4Coq0m9hxCclmYgC0s37Ynix7bacCSiyTM11l fedadmin@MAC-410941
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFWZgKiUcpnS8PwEJ54sxrb3/bt35mcG6xSb6rv447aj nicholas.mcdonnell

--- a/terraform_nessus_only/ssh_cloud_init.tf
+++ b/terraform_nessus_only/ssh_cloud_init.tf
@@ -5,8 +5,8 @@ data "template_file" "user_ssh_setup" {
 }
 
 data "template_cloudinit_config" "ssh_cloud_init_tasks" {
-  gzip          = false
-  base64_encode = false
+  gzip          = true
+  base64_encode = true
 
   part {
     filename     = "user_ssh_setup.yml"
@@ -14,4 +14,3 @@ data "template_cloudinit_config" "ssh_cloud_init_tasks" {
     content      = data.template_file.user_ssh_setup.rendered
   }
 }
-

--- a/terraform_nessus_only/variables.tf
+++ b/terraform_nessus_only/variables.tf
@@ -33,3 +33,28 @@ variable "trusted_ingress_networks_ipv6" {
   description = "Trusted IPv6 ingress networks"
 }
 
+variable "remote_ssh_user" {
+  description = "The username to use when sshing to the EC2 instances"
+}
+
+variable "nessus_instance_count" {
+  type        = number
+  description = "The number of Nessus instances to create."
+  default     = 1
+}
+
+variable "nessus_activation_codes" {
+  type        = list(string)
+  description = "A list of strings containing Nessus activation codes"
+}
+
+variable "cyhy_elastic_ip_cidr_block" {
+  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances.  This is only used in Production workspaces."
+  default     = ""
+}
+
+variable "nessus_first_elastic_ip_offset" {
+  type        = number
+  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* Nessus instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first Nessus address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional Nessus instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available.  This is only used in Production workspaces."
+  default     = 1
+}

--- a/terraform_nessus_only/vpc.tf
+++ b/terraform_nessus_only/vpc.tf
@@ -15,7 +15,7 @@ resource "aws_subnet" "nessus_scanner_subnet" {
   tags = merge(
     var.tags,
     {
-      "Name" = "CyHy Nessus Scanners"
+      "Name" = "Manual CyHy Nessus Scanners"
     },
   )
 }
@@ -31,7 +31,7 @@ resource "aws_network_acl" "nessus_scanner_acl" {
   tags = merge(
     var.tags,
     {
-      "Name" = "CyHy Nessus Scanners"
+      "Name" = "Manual CyHy Nessus Scanners"
     },
   )
 }
@@ -43,8 +43,7 @@ resource "aws_security_group" "nessus_scanner_sg" {
   tags = merge(
     var.tags,
     {
-      "Name" = "CyHy Nessus Scanners"
+      "Name" = "Manual CyHy Nessus Scanners"
     },
   )
 }
-


### PR DESCRIPTION
This PR adds several improvements to the Terraform code for deploying "manual" Nessus scanners (i.e. instances that are **not** used for the automated CyHy scans; these are available to be used by the CyHy team to manually run scans):
- For production terraform workspaces, give the Nessus instances public elastic IPs in the same AWS-assigned CIDR block as the production CyHy scanners
- For non-production terraform workspaces, give the Nessus instances random public elastic IPs
- Add dynamic terraform module configuration, similar to the main CyHy terraform
- A few other miscellaneous changes to make this terraform code similar to the main CyHy Nessus terraform
