### PR TITLE
Increase retry count in nessus_base.py

### DIFF
--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -31,7 +31,7 @@ WAIT_TIME_SEC = 10
 # Would be nice to get this working
 VERIFY_SSL = False
 # Number of times to retry a failed request before giving up
-FAILED_REQUEST_MAX_RETRIES = 3
+FAILED_REQUEST_MAX_RETRIES = 10
 # Seconds to wait between failed request retries
 FAILED_REQUEST_RETRY_WAIT_SEC = 30
 

--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -6,22 +6,22 @@ import requests
 import sys
 import time
 
-USER = ''
-PASSWORD = ''
-URL = 'https://localhost:8834'
-BASE_POLICY_NAME = 'cyhy-base'
-BASE_POLICY_FILE_NAME = '/tmp/cyhy-base-nessus8-policy.xml'
+USER = ""
+PASSWORD = ""
+URL = "https://localhost:8834"
+BASE_POLICY_NAME = "cyhy-base"
+BASE_POLICY_FILE_NAME = "/tmp/cyhy-base-nessus8-policy.xml"
 
 DEBUG = False
-LOGIN = '/session'
-POLICY_BASE = '/policies'
-FILE_UPLOAD = '/file/upload'
-POLICY_IMPORT = '/policies/import'
+LOGIN = "/session"
+POLICY_BASE = "/policies"
+FILE_UPLOAD = "/file/upload"
+POLICY_IMPORT = "/policies/import"
 OK_STATUS = 200
 NOT_FOUND_STATUS = 404
 INVALID_CREDS_STATUS = 401
 
-LOGGER_FORMAT = '%(asctime)-15s %(levelname)s %(message)s'
+LOGGER_FORMAT = "%(asctime)-15s %(levelname)s %(message)s"
 LOGGER_LEVEL = logging.INFO
 LOGGER = None  # initialized in setup_logging()
 
@@ -39,6 +39,7 @@ FAILED_REQUEST_RETRY_WAIT_SEC = 30
 # particular bit of code
 if DEBUG:
     import httplib as http_client  # lgtm[py/unreachable-statement]
+
     http_client.HTTPConnection.debuglevel = 1
     logging.basicConfig()
     logging.getLogger().setLevel(logging.DEBUG)
@@ -71,70 +72,82 @@ class NessusController(object):
 
         while num_retries < FAILED_REQUEST_MAX_RETRIES:
             if num_retries > 0:
-                LOGGER.warning('Waiting {!r} seconds...'.format(
-                    FAILED_REQUEST_RETRY_WAIT_SEC)
+                LOGGER.warning(
+                    "Waiting {!r} seconds...".format(FAILED_REQUEST_RETRY_WAIT_SEC)
                 )
                 time.sleep(FAILED_REQUEST_RETRY_WAIT_SEC)
 
             # Send everything as json content
-            headers = {'Content-Type': 'application/json; charset=UTF-8'}
+            headers = {"Content-Type": "application/json; charset=UTF-8"}
 
             # If we aren't logged in (don't have a session token) and
             # we aren't already attempting to login, then try to login
             if self.token is None and target != LOGIN:
-                LOGGER.info('Attempting to login to Nessus server')
-                self.__make_request(LOGIN, 'POST', {
-                    'username': USER,
-                    'password': PASSWORD
-                })
+                LOGGER.info("Attempting to login to Nessus server")
+                self.__make_request(
+                    LOGIN, "POST", {"username": USER, "password": PASSWORD}
+                )
 
             # If we are already logged in, add the token to the
             # headers
             if self.token:
-                headers['X-Cookie'] = 'token={!s}'.format(self.token)
+                headers["X-Cookie"] = "token={!s}".format(self.token)
 
-            if method == 'GET':
-                response = requests.get(self.url + target, headers=headers,
-                                        params=payload, verify=VERIFY_SSL)
-            elif method == 'POST':
+            if method == "GET":
+                response = requests.get(
+                    self.url + target,
+                    headers=headers,
+                    params=payload,
+                    verify=VERIFY_SSL,
+                )
+            elif method == "POST":
                 if files:
                     # This reassigning of headers is to remove the
                     # content type assignment
-                    headers = {'X-Cookie': 'token={!s}'.format(self.token)}
-                    response = requests.post(self.url + target,
-                                             headers=headers,
-                                             files=files,
-                                             verify=VERIFY_SSL)
+                    headers = {"X-Cookie": "token={!s}".format(self.token)}
+                    response = requests.post(
+                        self.url + target,
+                        headers=headers,
+                        files=files,
+                        verify=VERIFY_SSL,
+                    )
                 else:
-                    response = requests.post(self.url + target,
-                                             headers=headers,
-                                             data=payload,
-                                             verify=VERIFY_SSL)
-            elif method == 'PUT':
-                response = requests.put(self.url + target, headers=headers,
-                                        data=payload, verify=VERIFY_SSL)
-            elif method == 'DELETE':
-                response = requests.delete(self.url + target,
-                                           headers=headers,
-                                           verify=VERIFY_SSL)
+                    response = requests.post(
+                        self.url + target,
+                        headers=headers,
+                        data=payload,
+                        verify=VERIFY_SSL,
+                    )
+            elif method == "PUT":
+                response = requests.put(
+                    self.url + target, headers=headers, data=payload, verify=VERIFY_SSL
+                )
+            elif method == "DELETE":
+                response = requests.delete(
+                    self.url + target, headers=headers, verify=VERIFY_SSL
+                )
 
             if response.status_code == OK_STATUS:
-                if target == LOGIN and method == 'POST':
-                    LOGGER.info('Successfully logged into Nessus server')
+                if target == LOGIN and method == "POST":
+                    LOGGER.info("Successfully logged into Nessus server")
                     # Store the token if we just logged in
-                    self.token = response.json().get('token')
+                    self.token = response.json().get("token")
                 return response
 
-            LOGGER.warning('Request failed ({!r} {!r}, attempt #{!r}); '
-                           'response={!r}'.format(
-                               method, self.url + target,
-                               num_retries+1, response.text
-                           ))
+            LOGGER.warning(
+                "Request failed ({!r} {!r}, attempt #{!r}); "
+                "response={!r}".format(
+                    method, self.url + target, num_retries + 1, response.text
+                )
+            )
             if self.token and response.status_code == INVALID_CREDS_STATUS:
-                LOGGER.warning('Invalid credentials error; '
-                               'Nessus session probably expired.')
-                LOGGER.warning('Attempting to establish new Nessus '
-                               'session (username: {!r})'.format(USER))
+                LOGGER.warning(
+                    "Invalid credentials error; " "Nessus session probably expired."
+                )
+                LOGGER.warning(
+                    "Attempting to establish new Nessus "
+                    "session (username: {!r})".format(USER)
+                )
                 # Clear token to force re-login on next loop
                 self.token = None
                 # Don't increment num_retries here; upcoming re-login
@@ -143,15 +156,15 @@ class NessusController(object):
                 num_retries += 1
 
         # The while loop has reached FAILED_REQUEST_MAX_RETRIES
-        LOGGER.critical('Maximum retry attempts reached without success.')
+        LOGGER.critical("Maximum retry attempts reached without success.")
         sys.exit(num_retries)
 
     def find_policy(self, policy_name):
-        '''Attempts to grab the policy ID for a name'''
+        """Attempts to grab the policy ID for a name"""
         policies = self.policy_list()
-        if policies.get('policies'):
-            for p in policies['policies']:
-                if p['name'] == policy_name:
+        if policies.get("policies"):
+            for p in policies["policies"]:
+                if p["name"] == policy_name:
                     return p
             # If no matching policy name is found, return None
             return None
@@ -159,73 +172,76 @@ class NessusController(object):
             return None
 
     def import_policy(self, filename):
-        response = self.__make_request(POLICY_IMPORT, 'POST',
-                                       payload={'file': filename})
+        response = self.__make_request(
+            POLICY_IMPORT, "POST", payload={"file": filename}
+        )
         if response.status_code == OK_STATUS:
             return response.json()
         else:
-            raise Warning('Policy import failed; response='
-                          '{!r}'.format(response.text))
+            raise Warning(
+                "Policy import failed; response=" "{!r}".format(response.text)
+            )
 
     def upload_file(self, files):
-        response = self.__make_request(FILE_UPLOAD, 'POST', files=files)
+        response = self.__make_request(FILE_UPLOAD, "POST", files=files)
         if response.status_code == OK_STATUS:
             return response.json()
         else:
-            raise Warning('File upload failed; response='
-                          '{!r}'.format(response.text))
+            raise Warning("File upload failed; response=" "{!r}".format(response.text))
 
     def policy_list(self):
-        response = self.__make_request(POLICY_BASE, 'GET')
+        response = self.__make_request(POLICY_BASE, "GET")
         if response.status_code == OK_STATUS:
             return response.json()
         else:
-            raise Warning('Policy list failed; response='
-                          '{!r}'.format(response.text))
+            raise Warning("Policy list failed; response=" "{!r}".format(response.text))
 
     def destroy_session(self):
-        response = self.__make_request(LOGIN, 'DELETE')
+        response = self.__make_request(LOGIN, "DELETE")
         if response.status_code == OK_STATUS:
             return response
         else:
-            raise Warning('Session destruction failed; response='
-                          '{!r}'.format(response.text))
+            raise Warning(
+                "Session destruction failed; response=" "{!r}".format(response.text)
+            )
 
 
 def main():
     setup_logging()
-    LOGGER.info('Nessus job starting')
+    LOGGER.info("Nessus job starting")
 
-    LOGGER.info('Instantiating Nessus controller at: {!s}'.format(URL))
+    LOGGER.info("Instantiating Nessus controller at: {!s}".format(URL))
     controller = NessusController(URL)
 
     # create new policy
-    LOGGER.info('Creating new policy based on base policy')
+    LOGGER.info("Creating new policy based on base policy")
     if not controller.find_policy(BASE_POLICY_NAME):
-        files = {'Filedata': (BASE_POLICY_FILE_NAME,
-                              open(BASE_POLICY_FILE_NAME, 'rb'),
-                              'text/xml')}
+        files = {
+            "Filedata": (
+                BASE_POLICY_FILE_NAME,
+                open(BASE_POLICY_FILE_NAME, "rb"),
+                "text/xml",
+            )
+        }
         upload_response = controller.upload_file(files)
-        assert upload_response, 'Response empty, upload failed'
-        LOGGER.info('Policy Uploaded to Nessus Server')
-        import_response = controller.import_policy(
-            upload_response['fileuploaded']
-        )
-        assert import_response, 'Response empty, policy upload failed'
-        LOGGER.info('Base Policy Imported to Nessus Server Policies')
+        assert upload_response, "Response empty, upload failed"
+        LOGGER.info("Policy Uploaded to Nessus Server")
+        import_response = controller.import_policy(upload_response["fileuploaded"])
+        assert import_response, "Response empty, policy upload failed"
+        LOGGER.info("Base Policy Imported to Nessus Server Policies")
     else:
-        LOGGER.info('Policy already exists')
+        LOGGER.info("Policy already exists")
 
     # destroy session
-    LOGGER.info('Destroying session')
+    LOGGER.info("Destroying session")
     result = controller.destroy_session()
-    assert result, 'Session not properly destroyed'
-    LOGGER.info('Session destroyed successfully')
+    assert result, "Session not properly destroyed"
+    LOGGER.info("Session destroyed successfully")
 
     # great success!
-    LOGGER.info('Policy Created. (GREAT SUCCESS!)')
+    LOGGER.info("Policy Created. (GREAT SUCCESS!)")
     sys.exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR increases the maximum number of retries for a failed request in [nessus_base.py](https://github.com/cisagov/cyhy_amis/blob/develop/ansible/roles/nessus/files/nessus_base.py#L34). 
 This will be helpful in cases when `nessus_base.py` is run shortly after the `nessusd` service has been started/restarted and it is starting up slowly (e.g. when the plugin database is being built).

Currently, the ansible provisioner often fails for this reason when a new Nessus instance is initially deployed; the goal of this PR is to remedy that sitation.