### PR TITLE
Fix typo in URI for scan_reader.yml configuration.

### DIFF
--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -50,7 +50,7 @@
     mode: 0660
     content: |
       database:
-        uri: mmongodb://{{ scan_reader_user }}:{{ scan_reader_pw }}@database1.cyhy:27017/{{ scan_reader_db }}
+        uri: mongodb://{{ scan_reader_user }}:{{ scan_reader_pw }}@database1.cyhy:27017/{{ scan_reader_db }}
         name: {{ scan_reader_db }}
 
 # assessment-reader


### PR DESCRIPTION
PR to fix issues with the cyhy-feeds deploy setup after it was deployed to production.