### PR TITLE
Remove explicit installation of Docker

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -48,22 +48,27 @@
     - nessus
     - more_ephemeral_ports
 
-- hosts: docker
-  name: Install Docker
-  become: yes
-  become_method: sudo
-  roles:
-    - docker
-
-- hosts: bod_docker
-  name: Configure Docker host for BOD 18-01 scanning and reporting
+- hosts: bod
+  name: Configure host for BOD 18-01 scanning and reporting
   become: yes
   become_method: sudo
   roles:
     - xfs
     - orchestrator
     - cyhy_mailer
+
+- hosts: code_gov
+  name: Configure host for code.gov updating
+  become: yes
+  become_method: sudo
+  roles:
     - code_gov_update
+
+- hosts: client_cert
+  name: Configure host for client cert auth updating
+  become: yes
+  become_method: sudo
+  roles:
     - client_cert_update
 
 - hosts: cyhy_commander

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -36,8 +36,7 @@
             "type": "ansible",
             "playbook_file": "packer/ansible/playbook.yml",
             "groups": [
-                "cyhy_dashboard",
-                "docker"
+                "cyhy_dashboard"
             ]
         }
     ]

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -50,8 +50,9 @@
             "type": "ansible",
             "playbook_file": "packer/ansible/playbook.yml",
             "groups": [
-                "docker",
-                "bod_docker"
+                "bod",
+                "code_gov",
+                "client_cert"
             ]
         }
     ]

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -36,7 +36,6 @@
             "type": "ansible",
             "playbook_file": "packer/ansible/playbook.yml",
             "groups": [
-                "docker",
                 "cyhy_reporter"
             ]
         }


### PR DESCRIPTION
Since Docker is installed as an Ansible role dependency of the Docker composition roles that use it, there is no longer a need for a Docker group.  This also necessitates some changes to the Packer JSON files.

I'd like to remove the explicit installation of Docker in `packer/dashboard.json` too, but that doesn't appear possible at this time.  Maybe when I start to converge the first and second Ansibles it will become possible.