### PR TITLE
Encrypt root volumes and delete them on termination

### DIFF
--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -22,6 +22,22 @@
             "us-west-2"
         ],
 
+        "ami_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
+        "launch_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
         "tags": {
             "Team": "NCATS OIS - Development",
             "Application": "Cyber Hygiene",

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -22,6 +22,22 @@
             "us-west-2"
         ],
 
+        "ami_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
+        "launch_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
         "tags": {
             "Team": "NCATS OIS - Development",
             "Application": "Cyber Hygiene",

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -26,6 +26,7 @@
             "device_name": "xvda",
             "volume_size": 10,
             "volume_type": "gp2",
+            "encrypted": true,
             "delete_on_termination": true
         }],
 
@@ -33,6 +34,7 @@
             "device_name": "xvda",
             "volume_size": 10,
             "volume_type": "gp2",
+            "encrypted": true,
             "delete_on_termination": true
         }],
 

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -22,6 +22,22 @@
              "us-west-2"
         ],
 
+        "ami_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
+        "launch_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
         "tags": {
             "Team": "NCATS OIS - Development",
             "Application": "Cyber Hygiene",

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -22,6 +22,22 @@
             "us-west-2"
         ],
 
+        "ami_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
+        "launch_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
         "tags": {
             "Team": "NCATS OIS - Development",
             "Application": "Cyber Hygiene",

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -22,6 +22,22 @@
             "us-west-2"
         ],
 
+        "ami_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
+        "launch_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
         "tags": {
             "Team": "NCATS OIS - Development",
             "Application": "Cyber Hygiene",

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -22,6 +22,22 @@
             "us-west-2"
         ],
 
+        "ami_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
+        "launch_block_device_mappings": [{
+            "device_name": "xvda",
+            "volume_size": 8,
+            "volume_type": "gp2",
+            "encrypted": true,
+            "delete_on_termination": true
+        }],
+
         "tags": {
             "Team": "NCATS OIS - Development",
             "Application": "Cyber Hygiene",


### PR DESCRIPTION
This applies to the root disk devices of EC2 instances started from these AMIs, as well as the disk devices used when creating the AMI via `packer`.

This will put the kibosh on the proliferation of dead snapshots in AWS.