### PR TITLE
Specify the default KMS key for each region

### DIFF
--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -21,6 +21,11 @@
             "us-west-1",
             "us-west-2"
         ],
+        "region_kms_key_ids": {
+            "us-east-1": "alias/aws/ebs",
+            "us-west-1": "alias/aws/ebs",
+            "us-west-2": "alias/aws/ebs"
+        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -21,6 +21,11 @@
             "us-west-1",
             "us-west-2"
         ],
+        "region_kms_key_ids": {
+            "us-east-1": "alias/aws/ebs",
+            "us-west-1": "alias/aws/ebs",
+            "us-west-2": "alias/aws/ebs"
+        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -21,6 +21,11 @@
             "us-west-1",
             "us-west-2"
         ],
+        "region_kms_key_ids": {
+            "us-east-1": "alias/aws/ebs",
+            "us-west-1": "alias/aws/ebs",
+            "us-west-2": "alias/aws/ebs"
+        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -21,6 +21,11 @@
              "us-west-1",
              "us-west-2"
         ],
+        "region_kms_key_ids": {
+            "us-east-1": "alias/aws/ebs",
+            "us-west-1": "alias/aws/ebs",
+            "us-west-2": "alias/aws/ebs"
+        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -21,6 +21,11 @@
             "us-west-1",
             "us-west-2"
         ],
+        "region_kms_key_ids": {
+            "us-east-1": "alias/aws/ebs",
+            "us-west-1": "alias/aws/ebs",
+            "us-west-2": "alias/aws/ebs"
+        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -21,6 +21,11 @@
             "us-west-1",
             "us-west-2"
         ],
+        "region_kms_key_ids": {
+            "us-east-1": "alias/aws/ebs",
+            "us-west-1": "alias/aws/ebs",
+            "us-west-2": "alias/aws/ebs"
+        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -21,6 +21,11 @@
             "us-west-1",
             "us-west-2"
         ],
+        "region_kms_key_ids": {
+            "us-east-1": "alias/aws/ebs",
+            "us-west-1": "alias/aws/ebs",
+            "us-west-2": "alias/aws/ebs"
+        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",


### PR DESCRIPTION
This fixes a bug where copied AMIs were not being encrypted.  The problem is described in hashicorp/packer#6778.

Thanks to @dav3r for pointing out the bug as well as the GitHub issue with the solution.