### PR TITLE
Revert "Specify the default KMS key for each region"

### DIFF
--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -21,11 +21,6 @@
             "us-west-1",
             "us-west-2"
         ],
-        "region_kms_key_ids": {
-            "us-east-1": "alias/aws/ebs",
-            "us-west-1": "alias/aws/ebs",
-            "us-west-2": "alias/aws/ebs"
-        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -21,11 +21,6 @@
             "us-west-1",
             "us-west-2"
         ],
-        "region_kms_key_ids": {
-            "us-east-1": "alias/aws/ebs",
-            "us-west-1": "alias/aws/ebs",
-            "us-west-2": "alias/aws/ebs"
-        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -21,11 +21,6 @@
             "us-west-1",
             "us-west-2"
         ],
-        "region_kms_key_ids": {
-            "us-east-1": "alias/aws/ebs",
-            "us-west-1": "alias/aws/ebs",
-            "us-west-2": "alias/aws/ebs"
-        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -21,11 +21,6 @@
              "us-west-1",
              "us-west-2"
         ],
-        "region_kms_key_ids": {
-            "us-east-1": "alias/aws/ebs",
-            "us-west-1": "alias/aws/ebs",
-            "us-west-2": "alias/aws/ebs"
-        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -21,11 +21,6 @@
             "us-west-1",
             "us-west-2"
         ],
-        "region_kms_key_ids": {
-            "us-east-1": "alias/aws/ebs",
-            "us-west-1": "alias/aws/ebs",
-            "us-west-2": "alias/aws/ebs"
-        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -21,11 +21,6 @@
             "us-west-1",
             "us-west-2"
         ],
-        "region_kms_key_ids": {
-            "us-east-1": "alias/aws/ebs",
-            "us-west-1": "alias/aws/ebs",
-            "us-west-2": "alias/aws/ebs"
-        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -21,11 +21,6 @@
             "us-west-1",
             "us-west-2"
         ],
-        "region_kms_key_ids": {
-            "us-east-1": "alias/aws/ebs",
-            "us-west-1": "alias/aws/ebs",
-            "us-west-2": "alias/aws/ebs"
-        },
 
         "ami_block_device_mappings": [{
             "device_name": "xvda",


### PR DESCRIPTION
Reverts cisagov/cyhy_amis#226

The issue that prompted cisagov/cyhy_amis#226 (hashicorp/packer#6778) was fixed in packer 1.4 (see hashicorp/packer#6787). I was running packer 1.3.3 when I observed the errors that prompted cisagov/cyhy_amis#226.

I upgraded to packer 1.4.1 and was able to verify that we no longer need that `region_kms_key_ids` block to successfully copy AMIs to other regions.
