### PR TITLE
Add mongo bucket permission

### DIFF
--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "s3_cyhy_mongo_doc" {
     effect = "Allow"
 
     actions = [
-      "s3:DeleteObject"
+      "s3:DeleteObject",
       "s3:PutObject",
     ]
 

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "s3_cyhy_mongo_doc" {
     effect = "Allow"
 
     actions = [
-      "s3.DeleteObject"
+      "s3:DeleteObject"
       "s3:PutObject",
     ]
 

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -89,6 +89,7 @@ data "aws_iam_policy_document" "s3_cyhy_mongo_doc" {
     effect = "Allow"
 
     actions = [
+      "s3.DeleteObject"
       "s3:PutObject",
     ]
 


### PR DESCRIPTION
Add permission to allow scripts running on the mongo instance to delete objects in the moe bucket. This allows [this cyhy-feeds PR](https://github.com/cisagov/cyhy-feeds/pull/32) to function.