### PR TITLE
Fix busted Nessus ansible provisioner

### DIFF
--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -31,9 +31,9 @@ WAIT_TIME_SEC = 10
 # Would be nice to get this working
 VERIFY_SSL = False
 # Number of times to retry a failed request before giving up
-FAILED_REQUEST_MAX_RETRIES = 10
+FAILED_REQUEST_MAX_RETRIES = 30
 # Seconds to wait between failed request retries
-FAILED_REQUEST_RETRY_WAIT_SEC = 30
+FAILED_REQUEST_RETRY_WAIT_SEC = 10
 
 # Note that we disable LGTM's unreachable statement warning for this
 # particular bit of code

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -68,16 +68,16 @@
 - name: Configure nessus base policy to use nessus username
   lineinfile:
     dest: /tmp/nessus_base.py
-    regexp: "USER = ''"
+    regexp: 'USER = ""'
     state: present
-    line: "USER = '{{ username }}'"
+    line: 'USER = "{{ username }}"'
 
 - name: Configure nessus base policy to use nessus password
   lineinfile:
     dest: /tmp/nessus_base.py
-    regexp: "PASSWORD = ''"
+    regexp: 'PASSWORD = ""'
     state: present
-    line: "PASSWORD = '{{ password }}'"
+    line: 'PASSWORD = "{{ password }}"'
 
 - name: Copy base nessus scan policy to instance tmp
   template:

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -84,6 +84,10 @@
     src: cyhy-base-nessus8-policy.xml.j2
     dest: /tmp/cyhy-base-nessus8-policy.xml
 
+- name: Wait for Nessus port to be open
+  wait_for:
+    port: 8834
+
 - name: Run nessus base policy import script
   command: python /tmp/nessus_base.py
 


### PR DESCRIPTION
Our Nessus Ansible provisioner has not been working properly for the past month or so.  I had thought it was a timing issue related to when the Nessusd instance was started and when our Nessus base policy import script (`nessus_base.py`) was running, but it turned out to be something much more nefarious: a single-quotes vs. double-quotes situation!

In the not-too-distant past (see 94878b512f95b764d1f219066c08e788db181332), I [blackened](https://github.com/psf/black) `nessus_base.py` (as part of https://github.com/cisagov/cyhy_amis/pull/221) and in doing so, I inadvertently broke the regexes in the Ansible playbook that are used to populate the username and password in `nessus_base.py`.  The regex was looking for single-quotes and black had turned them into double-quotes.  The fix was simple after I realized what was going on.  There's an important life lesson in there somewhere.

While I was mucking around with this stuff, I took the opportunity to also do the following:
* Add an Ansible task that waits for the default Nessus port to be open before attempting to run `nessus_base.py`
* Reduce the time between failed request retries and increase the maximum number of retries (same overall timeout, now with a shorter polling interval)