### PR TITLE
Remove deprecated aws_flow_log argument 

### DIFF
--- a/terraform/bod_vpc_flow_logs.tf
+++ b/terraform/bod_vpc_flow_logs.tf
@@ -66,9 +66,8 @@ resource "aws_cloudwatch_log_group" "bod_flow_log_group" {
 resource "aws_flow_log" "bod_flow_log" {
   count = var.create_bod_flow_logs ? 1 : 0
 
-  log_group_name = aws_cloudwatch_log_group.bod_flow_log_group[0].name
-  iam_role_arn   = aws_iam_role.bod_flow_log_role[0].arn
-  vpc_id         = aws_vpc.bod_vpc.id
-  traffic_type   = "ALL"
+  log_destination = aws_cloudwatch_log_group.bod_flow_log_group[0].name
+  iam_role_arn    = aws_iam_role.bod_flow_log_role[0].arn
+  vpc_id          = aws_vpc.bod_vpc.id
+  traffic_type    = "ALL"
 }
-

--- a/terraform/cyhy_vpc_flow_logs.tf
+++ b/terraform/cyhy_vpc_flow_logs.tf
@@ -66,9 +66,8 @@ resource "aws_cloudwatch_log_group" "cyhy_flow_log_group" {
 resource "aws_flow_log" "cyhy_flow_log" {
   count = var.create_cyhy_flow_logs ? 1 : 0
 
-  log_group_name = aws_cloudwatch_log_group.cyhy_flow_log_group[0].name
-  iam_role_arn   = aws_iam_role.cyhy_flow_log_role[0].arn
-  vpc_id         = aws_vpc.cyhy_vpc.id
-  traffic_type   = "ALL"
+  log_destination = aws_cloudwatch_log_group.cyhy_flow_log_group[0].name
+  iam_role_arn    = aws_iam_role.cyhy_flow_log_role[0].arn
+  vpc_id          = aws_vpc.cyhy_vpc.id
+  traffic_type    = "ALL"
 }
-

--- a/terraform/mgmt_vpc_flow_logs.tf
+++ b/terraform/mgmt_vpc_flow_logs.tf
@@ -66,8 +66,8 @@ resource "aws_cloudwatch_log_group" "mgmt_flow_log_group" {
 resource "aws_flow_log" "mgmt_flow_log" {
   count = var.create_mgmt_flow_logs ? 1 : 0
 
-  log_group_name = aws_cloudwatch_log_group.mgmt_flow_log_group[0].name
-  iam_role_arn   = aws_iam_role.mgmt_flow_log_role[0].arn
-  vpc_id         = aws_vpc.mgmt_vpc[0].id
-  traffic_type   = "ALL"
+  log_destination = aws_cloudwatch_log_group.mgmt_flow_log_group[0].name
+  iam_role_arn    = aws_iam_role.mgmt_flow_log_role[0].arn
+  vpc_id          = aws_vpc.mgmt_vpc[0].id
+  traffic_type    = "ALL"
 }


### PR DESCRIPTION
Get rid of "log_group_name" and use "log_destination" in its place.  Why?  Because terraform told me to:
```
Warning: "log_group_name": [DEPRECATED] use 'log_destination' argument instead
```