### PR TITLE
Correct Nessus key check regex.

### DIFF
--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -19,8 +19,9 @@
       set_fact:
         registered_key: "{{ key_result.stdout | regex_search(regexp, '\\1') }}"
       vars:
-        # Looking for key in format XXXX-XXXX-XXXX-XXXX-XXXX
-        regexp: '([a-zA-Z0-9]{4}(?:\-[a-zA-Z0-9]{4}){4})'
+        # Looking for key in format:
+        # XXXX-XXXX-XXXX-XXXX or XXXX-XXXX-XXXX-XXXX-XXXX
+        regexp: '([a-zA-Z0-9]{4}(?:\-[a-zA-Z0-9]{4}){3,4})'
 
     - name: See if the key in use matches the provided one
       set_fact:


### PR DESCRIPTION
This PR fixes an overlooked issue when checking for an existing Nessus key in the Terraform `nessus` Ansible role. It currently only matches the format for Essentials keys (used during testing), but Professional keys do not conform. It is a difference of one group of characters so the change is minor (but important!).