### PR TITLE
Fix for changed functionality in Terraform 0.12.12

### DIFF
--- a/terraform/mgmt_bastion_ec2.tf
+++ b/terraform/mgmt_bastion_ec2.tf
@@ -39,7 +39,7 @@ resource "aws_instance" "mgmt_bastion" {
 # load in the dynamically created provisioner modules
 module "dyn_mgmt_bastion" {
   source                 = "./dyn_mgmt_bastion"
-  mgmt_bastion_public_ip = aws_instance.mgmt_bastion[0].public_ip
+  mgmt_bastion_public_ip = aws_instance.mgmt_bastion[*].public_ip
   remote_ssh_user        = var.remote_ssh_user
 }
 

--- a/terraform/mgmt_nessus_ec2.tf
+++ b/terraform/mgmt_nessus_ec2.tf
@@ -41,7 +41,7 @@ resource "aws_instance" "mgmt_nessus" {
 # load in the dynamically created provisioner modules
 module "dyn_mgmt_nessus" {
   source                       = "./dyn_mgmt_nessus"
-  mgmt_bastion_public_ip       = aws_instance.mgmt_bastion[0].public_ip
+  mgmt_bastion_public_ip       = aws_instance.mgmt_bastion[*].public_ip
   mgmt_nessus_private_ips      = aws_instance.mgmt_nessus[*].private_ip
   mgmt_nessus_activation_codes = var.mgmt_nessus_activation_codes
   remote_ssh_user              = var.remote_ssh_user


### PR DESCRIPTION
These changes went live in Terraform 0.12.11, but due to a bug 0.12.12 was released the next day. This is likely a result of this fix:

> config: Always evaluate whole resources rather than instances in expressions, so that invalid instance indexes can return a useful error rather than unknown (#22846)

Which results in Terraform 0.12.12 throwing an error on the 0-index references in use. Changing to splats (*) resolved in this issue and should work in line with the desired functionality.