### PR TITLE
Add deploy_new_adi_lambda script

### DIFF
--- a/terraform/deploy_new_adi_lambda.sh
+++ b/terraform/deploy_new_adi_lambda.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
-# deploy_new_adi_lambda.sh region workspace_name
+# deploy_new_adi_lambda.sh workspace_name
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-if [ $# -eq 2 ]
+if [ $# -eq 1 ]
 then
-    region=$1
-    workspace=$2
+    workspace=$1
 else
-    echo "Usage:  deploy_new_adi_lambda.sh region workspace_name"
+    echo "Usage:  deploy_new_adi_lambda.sh workspace_name"
     exit 1
 fi
 

--- a/terraform/deploy_new_adi_lambda.sh
+++ b/terraform/deploy_new_adi_lambda.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# deploy_new_adi_lambda.sh region workspace_name
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+if [ $# -eq 2 ]
+then
+    region=$1
+    workspace=$2
+else
+    echo "Usage:  deploy_new_adi_lambda.sh region workspace_name"
+    exit 1
+fi
+
+terraform workspace select "$workspace"
+
+# taint the existing lambda instance
+terraform taint "aws_lambda_function.adi_lambda"
+
+# recreate the new lambda instance
+terraform apply -var-file="$workspace.tfvars" \
+          -target=aws_lambda_function.adi_lambda \
+          -target=aws_lambda_permission.adi_lambda_allow_bucket \
+          -target=aws_s3_bucket_notification.bucket_notification \
+          -target=aws_cloudwatch_log_group.adi_lambda_logs

--- a/terraform/dyn_mgmt_nessus/variables.tf
+++ b/terraform/dyn_mgmt_nessus/variables.tf
@@ -1,4 +1,4 @@
 variable "mgmt_bastion_public_ip" {}
-variable "mgmt_nessus_private_ips" { type = "list" }
-variable "mgmt_nessus_activation_codes" { type = "list" }
+variable "mgmt_nessus_private_ips" { type = list(string) }
+variable "mgmt_nessus_activation_codes" { type = list(string) }
 variable "remote_ssh_user" {}

--- a/terraform/dyn_nessus/variables.tf
+++ b/terraform/dyn_nessus/variables.tf
@@ -1,4 +1,4 @@
 variable "bastion_public_ip" {}
-variable "nessus_private_ips" { type = "list" }
-variable "nessus_activation_codes" { type = "list" }
+variable "nessus_private_ips" { type = list(string) }
+variable "nessus_activation_codes" { type = list(string) }
 variable "remote_ssh_user" {}

--- a/terraform/dyn_nmap/variables.tf
+++ b/terraform/dyn_nmap/variables.tf
@@ -1,3 +1,3 @@
 variable "bastion_public_ip" {}
-variable "nmap_private_ips" { type = "list" }
+variable "nmap_private_ips" { type = list(string) }
 variable "remote_ssh_user" {}

--- a/terraform_nessus_only/dyn_nessus/variables.tf
+++ b/terraform_nessus_only/dyn_nessus/variables.tf
@@ -1,3 +1,3 @@
-variable "nessus_public_ips" { type = "list" }
-variable "nessus_activation_codes" { type = "list" }
+variable "nessus_public_ips" { type = list(string) }
+variable "nessus_activation_codes" { type = list(string) }
 variable "remote_ssh_user" {}


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
This PR adds a new utility script `deploy_new_adi_lambda.sh`, which should be used to redeploy the ADI lambda-related resources after a new lambda zip file has been uploaded to assessment_data_import S3 bucket.

This PR also contains a commit (https://github.com/cisagov/cyhy_amis/commit/a404dfe25c0c9b652be705f952a838bd45c72de8) that makes a small syntax change in several files to avoid triggering the following terraform 0.12.x warning:
```
Warning: Quoted type constraints are deprecated
   3:   type    = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.
```

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I updated the ADI lambda code in https://github.com/cisagov/assessment-data-import-lambda/pull/3 and @jsf9k made the excellent suggestion that a helper script (similar to [deploy_new_lambdas.sh](https://github.com/cisagov/cyhy_amis/blob/develop/terraform/deploy_new_lambdas.sh)) would be useful, so here it is.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new script was tested and no issues were observed.

## 📷 Screenshots (if appropriate)
N/A

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes -> Note: No new tests are needed for this PR
- [x] All new and existing tests passed.
