### PR TITLE
Fix cyhy-feeds cron job

### DIFF
--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -97,7 +97,7 @@
   cron:
     name: Nightly cyhy extract
     hour: '0'
-    minute: '01'
+    minute: '0'
     user: cyhy
     job: cd /var/cyhy/scripts/cyhy-feeds && export AWS_CONFIG_FILE=/var/cyhy/scripts/cyhy-feeds/aws_config; python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --cyhy-config /var/cyhy/scripts/cyhy-feeds/cyhy.yml --scan-config /var/cyhy/scripts/cyhy-feeds/scan_reader.yml --assessment-config /var/cyhy/scripts/cyhy-feeds/assessment_reader.yml --aws --cleanup-aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg
   when: production_workspace|bool

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -90,8 +90,16 @@
     ansible_ssh_pipelining: yes
 
 #
-# Create a cron job to run the extract script nightly at 0815 (UTC) as
-# cyhy
+# Create a cron job to run the extract script nightly at 0000 (UTC) as cyhy
+# NOTE:
+# We run at this time to reduce the odds of having documents, specifically
+# tickets, get missed in successive daily extracts. The previous time of 08:15
+# left an eight hour gap between the close of the query window for the script
+# and the start of the extract process. Since we are continuously scanning this
+# resulted in documents being updated and their modification time being updated
+# to fall past the end of the query cutoff. Changes were made to the script in
+# relation to this issue, and more information can be found in the pull request at
+# https://github.com/cisagov/cyhy-feeds/pull/37
 #
 - name: Set up nightly cron job to sync NSD data for MOE extract
   cron:

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -96,8 +96,8 @@
 - name: Set up nightly cron job to sync NSD data for MOE extract
   cron:
     name: Nightly cyhy extract
-    hour: '8'
-    minute: '15'
+    hour: '0'
+    minute: '01'
     user: cyhy
     job: cd /var/cyhy/scripts/cyhy-feeds && export AWS_CONFIG_FILE=/var/cyhy/scripts/cyhy-feeds/aws_config; python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --cyhy-config /var/cyhy/scripts/cyhy-feeds/cyhy.yml --scan-config /var/cyhy/scripts/cyhy-feeds/scan_reader.yml --assessment-config /var/cyhy/scripts/cyhy-feeds/assessment_reader.yml --aws --cleanup-aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg 2>&1 | /usr/bin/logger -t cyhy-feeds
   when: production_workspace|bool

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -99,5 +99,5 @@
     hour: '0'
     minute: '0'
     user: cyhy
-    job: cd /var/cyhy/scripts/cyhy-feeds && export AWS_CONFIG_FILE=/var/cyhy/scripts/cyhy-feeds/aws_config; python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --cyhy-config /var/cyhy/scripts/cyhy-feeds/cyhy.yml --scan-config /var/cyhy/scripts/cyhy-feeds/scan_reader.yml --assessment-config /var/cyhy/scripts/cyhy-feeds/assessment_reader.yml --aws --cleanup-aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg
+    job: cd /var/cyhy/scripts/cyhy-feeds && export AWS_CONFIG_FILE=/var/cyhy/scripts/cyhy-feeds/aws_config; python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --cyhy-config /var/cyhy/scripts/cyhy-feeds/cyhy.yml --scan-config /var/cyhy/scripts/cyhy-feeds/scan_reader.yml --assessment-config /var/cyhy/scripts/cyhy-feeds/assessment_reader.yml --aws --cleanup-aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg 2>&1 | /usr/bin/logger -t cyhy-feeds
   when: production_workspace|bool

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -99,5 +99,5 @@
     hour: '0'
     minute: '01'
     user: cyhy
-    job: cd /var/cyhy/scripts/cyhy-feeds && export AWS_CONFIG_FILE=/var/cyhy/scripts/cyhy-feeds/aws_config; python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --cyhy-config /var/cyhy/scripts/cyhy-feeds/cyhy.yml --scan-config /var/cyhy/scripts/cyhy-feeds/scan_reader.yml --assessment-config /var/cyhy/scripts/cyhy-feeds/assessment_reader.yml --aws --cleanup-aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg 2>&1 | /usr/bin/logger -t cyhy-feeds
+    job: cd /var/cyhy/scripts/cyhy-feeds && export AWS_CONFIG_FILE=/var/cyhy/scripts/cyhy-feeds/aws_config; python2.7 /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.py --cyhy-config /var/cyhy/scripts/cyhy-feeds/cyhy.yml --scan-config /var/cyhy/scripts/cyhy-feeds/scan_reader.yml --assessment-config /var/cyhy/scripts/cyhy-feeds/assessment_reader.yml --aws --cleanup-aws --config /var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg
   when: production_workspace|bool


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This fixes the `cron` job for `cyhy-feeds` to start at 00:00 UTC instead of 08:15 UTC to align with the time window used when the `cyhy-data-extract` script is run.

This PR aligns with updates to the `cyhy-data-extract` script in https://github.com/cisagov/cyhy-feeds/pull/37
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Concerns were raised that the `cyhy-data-extract` script was either filtering or missing data in it's export. Upon investigation I realized that the start time for the script was over eight hours after the end of the time window being used. Since CyHy runs continuously it resulted in records being updated with new last time changed values that were past the end fo the query window. If a record had this happen repeatedly either due to happenstance or scan windows there was the possibility that it would never be included in a data extraction. This change has the script start at midnight to align with the end fo the query time window.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Manually modified production environment to use these new parameters for the `cron` job. Confirmed output is as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
