### PR TITLE
Increase nmap Instance Swap Size from 2GiB to 4GiB

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -61,7 +61,7 @@
   become: yes
   become_method: sudo
   roles:
-    - { role: swap, swapfile_size: 2GiB}
+    - { role: swap, swapfile_size: 4GiB}
 
 - hosts: cyhy_runner
   name: Configure cyhy-runner hosts
@@ -114,4 +114,3 @@
   become_method: sudo
   roles:
     - mgmt_ops
-    


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR will increase the swap size of nmap instances in the CyHy environment from 2GiB to 4GiB.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We have had some issues with nmap instances becoming unresponsive. This has resulted in the commander being unable to send out work because it fails on the SSH connection to the unresponsive nmap instance. Upon observing an instance that previously failed, the last thing seen in `htop` before the instance went unresponsive again was full use of system memory and the swap space. This was caused by one of the jobs being processed on that instance. We hope this change will provide the headroom for more intensive jobs to successfully complete without locking up the entire instance.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
