### PR TITLE
Beefier Dashboard Instance

### DIFF
--- a/terraform/cyhy_dashboard_ec2.tf
+++ b/terraform/cyhy_dashboard_ec2.tf
@@ -24,7 +24,7 @@ data "aws_ami" "dashboard" {
 # The cyhy dashboard EC2 instance
 resource "aws_instance" "cyhy_dashboard" {
   ami           = data.aws_ami.dashboard.id
-  instance_type = local.production_workspace ? "t3.medium" : "t3.medium" # This is a placeholder for a larger instance type for production
+  instance_type = local.production_workspace ? "c5.large" : "t3.medium"
 
   # This is the private subnet
   subnet_id                   = aws_subnet.cyhy_private_subnet.id
@@ -72,4 +72,3 @@ module "cyhy_dashboard_ansible_provisioner" {
   playbook = "../ansible/playbook.yml"
   dry_run  = false
 }
-


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
Increase the AWS EC2 instance for the Dashboard from a `t3.medium` to a `c5.large`.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The users of the Dashboard had been complaining that various reports were taking a very long time to complete or not ever being displayed at all.  It appeared that this was due to the increase in the number of Dashboard users, as well as the continual increase in CyHy stakeholders and data.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I deployed the `c5.large` instance two weeks ago (January 3) and asked the users of the Dashboard to let me know if they continued to observe issues with it.  Since then, no issues have been reported.  I also have used the Dashboard without any problems since then.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
