### PR TITLE
Add deploy_new_fdi_lambda Script and Bump Python Environment Version for the fdi lambda

### DIFF
--- a/terraform/deploy_new_fdi_lambda.sh
+++ b/terraform/deploy_new_fdi_lambda.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# deploy_new_fdi_lambda.sh workspace_name
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+if [ $# -eq 1 ]
+then
+    workspace=$1
+else
+    echo "Usage:  deploy_new_fdi_lambda.sh workspace_name"
+    exit 1
+fi
+
+terraform workspace select "$workspace"
+
+# taint the existing lambda instance
+terraform taint "aws_lambda_function.fdi_lambda"
+
+# recreate the new lambda instance
+terraform apply -var-file="$workspace.tfvars" \
+          -target=aws_lambda_function.fdi_lambda \
+          -target=aws_lambda_permission.fdi_lambda_allow_bucket \
+          -target=aws_s3_bucket_notification.bucket_notification \
+          -target=aws_cloudwatch_log_group.fdi_lambda_logs
+          

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -157,7 +157,7 @@ resource "aws_lambda_function" "fdi_lambda" {
   function_name = format("findings_data_import-%s", terraform.workspace)
   role          = aws_iam_role.fdi_lambda_role.arn
   handler       = "lambda_handler.handler"
-  runtime       = "python3.6"
+  runtime       = "python3.8"
   timeout       = 300
   memory_size   = 128
   description   = "Lambda function for importing findings data"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds a new utility script `deploy_new_fdi_lambda.sh` to redeploy FDI lambda-related resources after a new lambda zip file has been uploaded to the `findings-data-import` S3 bucket.

The environment for the lambda was changed from `python3.6` to `python3.8` to align with the build changes made in https://github.com/cisagov/findings-data-import-lambda/pull/17.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
@dav3r added a convenience script for the ADI lambda in #246 and I thought it would be good to mirror this for the FDI lambda.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I used this while working on https://github.com/cisagov/findings-data-import-lambda/pull/17 with no issues. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
