### PR TITLE
Use the COOL DNS account for sending emails via SES

### DIFF
--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -37,7 +37,9 @@
     mode: 0444
     content: |
       [default]
+      credential_source = Ec2InstanceMetadata
       region = {{ ses_aws_region }}
+      role_arn={{ ses_send_email_role }}
 
 # docker-compose will automatically use docker-compose.yml and
 # docker-compose.override.yml, so this is a way for us to tune

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -90,19 +90,20 @@ resource "aws_iam_role_policy" "es_bod_docker_policy" {
   policy = data.aws_iam_policy_document.es_bod_docker_doc.json
 }
 
-# IAM policy document that allows sending emails via SES.  This will
-# be applied to the role we are creating.
+# IAM policy document that allows us to assume a role that allows
+# sending of emails via SES.  This will be applied to the role we are
+# creating.
 data "aws_iam_policy_document" "ses_bod_docker_doc" {
   statement {
     effect = "Allow"
 
     actions = [
-      "ses:SendRawEmail",
+      "sts:AssumeRole",
     ]
 
-    # There are no resources for SES policies, although there are
-    # conditions
-    resources = ["*"]
+    resources = [
+      var.ses_role_arn,
+    ]
   }
 }
 
@@ -174,6 +175,7 @@ module "bod_docker_ansible_provisioner" {
     # This file will be used to add/override any settings in
     # docker-compose.yml (for cyhy-mailer).
     "docker_compose_override_file_for_mailer=${var.docker_mailer_override_filename}",
+    "ses_send_email_role=${var.ses_role_arn}",
   ]
   playbook = "../ansible/playbook.yml"
   dry_run  = false

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -42,19 +42,20 @@ resource "aws_iam_role" "cyhy_reporter_role" {
   assume_role_policy = data.aws_iam_policy_document.cyhy_reporter_assume_role_doc.json
 }
 
-# IAM policy document that allows sending emails via SES.  This will
-# be applied to the role we are creating.
+# IAM policy document that allows us to assume a role that allows
+# sending of emails via SES.  This will be applied to the role we are
+# creating.
 data "aws_iam_policy_document" "ses_cyhy_reporter_doc" {
   statement {
     effect = "Allow"
 
     actions = [
-      "ses:SendRawEmail",
+      "sts:AssumeRole",
     ]
 
-    # There are no resources for SES policies, although there are
-    # conditions
-    resources = ["*"]
+    resources = [
+      var.ses_role_arn,
+    ]
   }
 }
 
@@ -121,6 +122,7 @@ module "cyhy_reporter_ansible_provisioner" {
     "production_workspace=${local.production_workspace}",
     "ses_aws_region=${var.ses_aws_region}",
     "docker_compose_override_file_for_mailer=${var.reporter_mailer_override_filename}",
+    "ses_send_email_role=${var.ses_role_arn}",
   ]
   playbook = "../ansible/playbook.yml"
   dry_run  = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -283,3 +283,9 @@ variable "findings_data_import_ssm_db_password" {
   description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the findings database."
   default     = ""
 }
+
+variable "ses_role_arn" {
+  type        = string
+  description = "The ARN of the role that must be assumed in order to send emails."
+}
+


### PR DESCRIPTION
## 🗣 Description

This pull request changes the cyhy-mailer second Ansible as well as the BOD docker and CyHy reporter instance roles such that reports are emailed out via SES in the COOL DNS account.

## 💭 Motivation and Context

Since only a single account can be verified for a given email domain, `cyber.dhs.gov` emails can no longer be sent out via SES in the old CyHy account.  They must instead be sent via SES in the COOL DNS account, where that domain is now verified.

This pull request is linked to cisagov/cyhy-mailer#75, and is the Laurel to cisagov/cool-dns-cyber.dhs.gov#12's Hardy.

## 🧪 Testing

I successfully sent out the CyHy, CybEx, and BOD 18-01 reports with these changes.
## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
