### PR TITLE
Fix deploy_new_database_ami.sh

### DIFF
--- a/terraform/deploy_new_database_ami.sh
+++ b/terraform/deploy_new_database_ami.sh
@@ -46,5 +46,22 @@ terraform apply -var-file="$workspace.tfvars" \
                 -target=aws_security_group_rule.private_mongodb_egress_to_mongo_host \
                 -target=aws_volume_attachment.cyhy_mongo_data_attachment \
                 -target=aws_volume_attachment.cyhy_mongo_journal_attachment \
-                -target=aws_volume_attachment.cyhy_mongo_log_attachment \
+                -target=aws_volume_attachment.cyhy_mongo_log_attachment
+
+# We currently get an "Invalid index" error when attempting to run the
+# database provisioner before the new database instance has been created:
+#
+# Error: Invalid index
+#  on cyhy_mongo_ec2.tf line 160, in module "cyhy_mongo_ansible_provisioner":
+# 160:     "host=${aws_instance.cyhy_mongo[0].private_ip}",
+#    |----------------
+#    | aws_instance.cyhy_mongo is empty tuple
+#
+# The given key does not identify an element in this collection value.
+#
+# The workaround is to split our "terraform apply" command into two separate
+# steps.  In the first step (above), we apply everything except for the
+# provisioner.  In the second step (below), we only apply the provisioner.
+
+terraform apply -var-file="$workspace.tfvars" \
                 -target=module.cyhy_mongo_ansible_provisioner


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR updates the `deploy_new_database_ami.sh` script so that it runs without any errors.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
With the Terraform 0.12.x syntax changes, the old way of running this script generated an "Invalid index" error because the `cyhy_mongo_ansible_provisioner` would run before the new database instance had been created.  To remedy this, we split out the `cyhy_mongo_ansible_provisioner` into a separate Terraform apply that runs after the new database instance has been created.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
@mcdonnnj just successfully used this script to redeploy the Production database.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
