### PR TITLE
Use the dmarc-import Elasticsearch database in the COOL DNS account

### DIFF
--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -39,7 +39,7 @@
       [default]
       credential_source = Ec2InstanceMetadata
       region = {{ ses_aws_region }}
-      role_arn={{ ses_send_email_role }}
+      role_arn = {{ ses_send_email_role }}
 
 # docker-compose will automatically use docker-compose.yml and
 # docker-compose.override.yml, so this is a way for us to tune

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -61,8 +61,9 @@
       region = {{ aws_region }}
 
       [profile elasticsearch]
+      credential_source = Ec2InstanceMetadata
       region = {{ dmarc_import_aws_region }}
-
+      role_arn = {{ dmarc_import_es_role }}
 
 #
 # Create a cron job for scanning

--- a/terraform/scripts/fetch_production_tfvars.sh
+++ b/terraform/scripts/fetch_production_tfvars.sh
@@ -6,7 +6,7 @@
 
 TERRAFORM_TFVARS_S3_BUCKET="ncats-terraform-production-tfvars"
 TERRAFORM_DIR="terraform"
-TFVARS_FILE="production.tfvars"
+TFVARS_FILE="prod-a.tfvars"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 aws s3 cp s3://${TERRAFORM_TFVARS_S3_BUCKET}/${TERRAFORM_DIR}/${TFVARS_FILE} ${SCRIPT_DIR}/../${TFVARS_FILE}

--- a/terraform/scripts/push_production_tfvars.sh
+++ b/terraform/scripts/push_production_tfvars.sh
@@ -6,7 +6,7 @@
 
 TERRAFORM_TFVARS_S3_BUCKET="ncats-terraform-production-tfvars"
 TERRAFORM_DIR="terraform"
-TFVARS_FILE="production.tfvars"
+TFVARS_FILE="prod-a.tfvars"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 aws s3 cp ${SCRIPT_DIR}/../${TFVARS_FILE} s3://${TERRAFORM_TFVARS_S3_BUCKET}/${TERRAFORM_DIR}/${TFVARS_FILE}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -131,13 +131,19 @@ variable "dmarc_import_aws_region" {
   default     = "us-east-1"
 }
 
-variable "dmarc_import_es_arn" {
-  description = "The ARN of the dmarc-import Elasticsearch database."
+variable "dmarc_import_es_role_arn" {
+  type        = string
+  description = "The ARN of the role that must be assumed in order to read the dmarc-import Elasticsearch database."
 }
 
 variable "ses_aws_region" {
   description = "The AWS region where SES is configured."
   default     = "us-east-1"
+}
+
+variable "ses_role_arn" {
+  type        = string
+  description = "The ARN of the role that must be assumed in order to send emails."
 }
 
 variable "reporter_mailer_override_filename" {
@@ -282,10 +288,5 @@ variable "findings_data_import_ssm_db_password" {
   type        = string
   description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the findings database."
   default     = ""
-}
-
-variable "ses_role_arn" {
-  type        = string
-  description = "The ARN of the role that must be assumed in order to send emails."
 }
 


### PR DESCRIPTION
## 🗣 Description

This pull request makes the necessary changes to allow the BOD Docker instance to use the dmarc-import Elasticsearch database in the COOL DNS account.

## 💭 Motivation and Context

The dmarc-import Elasticsearch database moved to the COOL DNS account, so the BOD Docker instance must be able to query that database in order to generate the Trustworthy Email reports.

## 🧪 Testing

I applied these changes to production and generated this week's Trustworthy Email reports.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
