### PR TITLE
Change policy to allow assumption of a role

### DIFF
--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -23,7 +23,9 @@
       region = {{ aws_region }}
 
       [profile elasticsearch]
+      credential_source = Ec2InstanceMetadata
       region = {{ dmarc_import_aws_region }}
+      role_arn = {{ dmarc_import_es_role }}
 
 #
 # Create yml files for db access

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -46,20 +46,19 @@ resource "aws_iam_role_policy" "archive_cyhy_mongo_policy" {
   policy = data.aws_iam_policy_document.s3_cyhy_archive_write_doc.json
 }
 
-# IAM policy document that only allows GETting from the dmarc-import
-# Elasticsearch database.  This will be applied to the role we are
-# creating.
+# IAM policy document that allows us to assume a role that allows
+# reading of the dmarc-import Elasticsearch database.  This will be
+# applied to the role we are creating.
 data "aws_iam_policy_document" "es_cyhy_mongo_doc" {
   statement {
     effect = "Allow"
 
     actions = [
-      "es:ESHttpGet",
+      "sts:AssumeRole",
     ]
 
     resources = [
-      var.dmarc_import_es_arn,
-      "${var.dmarc_import_es_arn}/*",
+      var.dmarc_import_es_role_arn,
     ]
   }
 }

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -164,6 +164,7 @@ module "cyhy_mongo_ansible_provisioner" {
     "production_workspace=${local.production_workspace}",
     "aws_region=${var.aws_region}",
     "dmarc_import_aws_region=${var.dmarc_import_aws_region}",
+    "dmarc_import_es_role=${var.dmarc_import_es_role_arn}",
   ]
   playbook = "../ansible/playbook.yml"
   dry_run  = false


### PR DESCRIPTION
## 🗣 Description

Change the Elasticsearch instance role policy to allow assumption of a role instead of giving direct access to the ES DB.

## 💭 Motivation and Context

The dmarc-import Elasticsearch database now lives in the COOL DNS account. Therefore we can only access it via an assumed role.  I made an identical change to `bod_docker_ec2.tf` in #259, but I had forgotten that this instance queries that database as well.

## 🧪 Testing

_None yet._

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
