### PR TITLE
Fix email sending for code_gov_update and client_cert_update projects

### DIFF
--- a/ansible/roles/client_cert_update/tasks/main.yml
+++ b/ansible/roles/client_cert_update/tasks/main.yml
@@ -32,8 +32,9 @@
     mode: 0440
     content: |
       [default]
+      credential_source = Ec2InstanceMetadata
       region = {{ ses_aws_region }}
-
+      role_arn = {{ ses_send_email_role }}
 
 #
 # Create a cron job

--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -53,8 +53,9 @@
     mode: 0440
     content: |
       [default]
+      credential_source = Ec2InstanceMetadata
       region = {{ ses_aws_region }}
-
+      role_arn = {{ ses_send_email_role }}
 
 #
 # Create a cron job

--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -34,7 +34,7 @@
     dest: /var/cyhy/cyhy-mailer/secrets/aws_config
     owner: cyhy
     group: cyhy
-    mode: 0444
+    mode: 0440
     content: |
       [default]
       credential_source = Ec2InstanceMetadata


### PR DESCRIPTION
## 🗣 Description

This pull request changes the AWS configs for code_gov_update and client_cert_update to assume the SES role for email sending instead of trying to send email directly through the CyHy AWS account.

I neglected to update these two projects when I made the same change to cyhy-mailer, and I don't think the corresponding emails have been sent since the SES configuration in the old CyHy account
started to fail verification.

## 💭 Motivation and Context

The spice (emails) must flow!

## 🧪 Testing

I verified that the code_gov_update emails are sent successfully with these changes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
