### PR TITLE
Create rules page specific to web application scanning

### DIFF
--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -50,7 +50,9 @@ WORKSPACE_CONFIGS = {
         "mgmt_nessus": 0,
     },
     "felddy": {"nmap": 4, "nessus": 1, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
+    "hillary": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
     "jsf9k": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
+    "mcdonnnj": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
 }
 
 # the default configuration if a workspace is not defined above

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -49,6 +49,7 @@ WORKSPACE_CONFIGS = {
         "mgmt_bastion": 0,
         "mgmt_nessus": 0,
     },
+    "daver": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
     "felddy": {"nmap": 4, "nessus": 1, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
     "hillary": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
     "jsf9k": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -40,43 +40,39 @@ HEADER = '''###
 # application is compared to the app_regex field.  If it matches it
 # will be included in the associated filename.
 
-# The following CIDR blocks are where our test Qualys scans originate
-# from:
-# 64.39.99.19/32, 64.39.99.20/30, 64.39.99.24/31,
-# 64.39.99.98/31, 64.39.99.100/32, 64.39.99.131/32,
-# 64.39.99.132/30, 64.39.99.136/29, 64.39.99.144/31
+# The following CIDR blocks are where our Cyber Hygiene scans
+# originate from:
+cyhy_ips = (
+    '100.27.42.128/25', '64.69.57.0/24',
+)
+# The following CIDR blocks are where our Qualys web application scans
+# originate from:
+qualys_was_ips = (
+    '64.39.99.19/32', '64.39.99.20/30', '64.39.99.24/31',
+    '64.39.99.98/31', '64.39.99.100/32', '64.39.99.131/32',
+    '64.39.99.132/30', '64.39.99.136/29', '64.39.99.144/31',
+)
 FILE_CONFIGS = \
     [{
         'filename': 'all.txt',
         'app_regex': re.compile('.*'),
-        'static_ips': (
-            '100.27.42.128/25', '64.69.57.0/24',
-            '64.39.99.19/32', '64.39.99.20/30', '64.39.99.24/31',
-            '64.39.99.98/31', '64.39.99.100/32', '64.39.99.131/32',
-            '64.39.99.132/30', '64.39.99.136/29', '64.39.99.144/31',
-        ),
-        'description': 'This file contains a consolidated list of all the IP addresses that VM is currently using for external scanning.'
+        'static_ips': cyhy_ips + qualys_was_ips,
+        'description': 'This file contains a consolidated list of all the IP addresses that VM is currently using for external scanning.',
     }, {
         'filename': 'cyhy.txt',
         'app_regex': re.compile('(Manual )?Cyber Hygiene$'),
-        'static_ips': (
-            '100.27.42.128/25', '64.69.57.0/24',
-        ),
-        'description': 'This file contains a list of all IPs used for Cyber Hygiene scanning.'
+        'static_ips': cyhy_ips,
+        'description': 'This file contains a list of all IPs used for Cyber Hygiene scanning.',
     }, {
         'filename': 'pca.txt',
         'app_regex': re.compile('Phishing Campaign Assessment$'),
         'static_ips': (),
-        'description': 'This file contains a list of all IPs used for Phishing Campaign Assessments'
+        'description': 'This file contains a list of all IPs used for Phishing Campaign Assessments',
     }, {
         'filename': 'was.txt',
         'app_regex': re.compile('Web Application Scanning$'),
-        'static_ips': (
-            '64.39.99.19/32', '64.39.99.20/30', '64.39.99.24/31',
-            '64.39.99.98/31', '64.39.99.100/32', '64.39.99.131/32',
-            '64.39.99.132/30', '64.39.99.136/29', '64.39.99.144/31',
-        ),
-        'description': 'This file contains a list of all IPs used for Web Application Scanning.'
+        'static_ips': qualys_was_ips,
+        'description': 'This file contains a list of all IPs used for Web Application Scanning.',
     },]
 
 

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -67,7 +67,7 @@ FILE_CONFIGS = \
         'filename': 'pca.txt',
         'app_regex': re.compile('Phishing Campaign Assessment$'),
         'static_ips': (),
-        'description': 'This file contains a list of all IPs used for Phishing Campaign Assessments',
+        'description': 'This file contains a list of all IPs used for Phishing Campaign Assessments.',
     }, {
         'filename': 'was.txt',
         'app_regex': re.compile('Web Application Scanning$'),

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -29,9 +29,9 @@ APPLICATION_TAG = 'Application'
 HEADER = '''###
 # https://{domain}/{filename}
 # {timestamp}
-# DHS National Cybersecurity Assessments & Technical Services (NCATS)
+# CISA Vulnerability Management (VM)
 # {description}
-# Please contact ncats@hq.dhs.gov with any questions
+# Please contact vulnerability@cisa.dhs.gov with any questions
 ###
 '''
 
@@ -54,7 +54,7 @@ FILE_CONFIGS = \
             '64.39.99.98/31', '64.39.99.100/32', '64.39.99.131/32',
             '64.39.99.132/30', '64.39.99.136/29', '64.39.99.144/31',
         ),
-        'description': 'This file contains a consolidated list of all the IP addresses that NCATS is currently using for external scanning.'
+        'description': 'This file contains a consolidated list of all the IP addresses that VM is currently using for external scanning.'
     }, {
         'filename': 'cyhy.txt',
         'app_regex': re.compile('(Manual )?Cyber Hygiene$'),

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -35,12 +35,13 @@ HEADER = '''###
 ###
 '''
 
-# A list of dictionaries that define the files to be created and published.
-# When an ip is to be published, its assoicated application is compared to the
-# app_regex field.  If it matches it will be included in the associated
-# filename.
+# A list of dictionaries that define the files to be created and
+# published.  When an ip is to be published, its associated
+# application is compared to the app_regex field.  If it matches it
+# will be included in the associated filename.
 
-# The following CIDR blocks are where our test Qualys scans originate from:
+# The following CIDR blocks are where our test Qualys scans originate
+# from:
 # 64.39.99.19/32, 64.39.99.20/30, 64.39.99.24/31,
 # 64.39.99.98/31, 64.39.99.100/32, 64.39.99.131/32,
 # 64.39.99.132/30, 64.39.99.136/29, 64.39.99.144/31

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -60,9 +60,6 @@ FILE_CONFIGS = \
         'app_regex': re.compile('(Manual )?Cyber Hygiene$'),
         'static_ips': (
             '100.27.42.128/25', '64.69.57.0/24',
-            '64.39.99.19/32', '64.39.99.20/30', '64.39.99.24/31',
-            '64.39.99.98/31', '64.39.99.100/32', '64.39.99.131/32',
-            '64.39.99.132/30', '64.39.99.136/29', '64.39.99.144/31',
         ),
         'description': 'This file contains a list of all IPs used for Cyber Hygiene scanning.'
     }, {
@@ -70,7 +67,16 @@ FILE_CONFIGS = \
         'app_regex': re.compile('Phishing Campaign Assessment$'),
         'static_ips': (),
         'description': 'This file contains a list of all IPs used for Phishing Campaign Assessments'
-    }]
+    }, {
+        'filename': 'was.txt',
+        'app_regex': re.compile('Web Application Scanning$'),
+        'static_ips': (
+            '64.39.99.19/32', '64.39.99.20/30', '64.39.99.24/31',
+            '64.39.99.98/31', '64.39.99.100/32', '64.39.99.131/32',
+            '64.39.99.132/30', '64.39.99.136/29', '64.39.99.144/31',
+        ),
+        'description': 'This file contains a list of all IPs used for Web Application Scanning.'
+    },]
 
 
 def get_ec2_regions(filter=None):


### PR DESCRIPTION
## 🗣 Description

This pull request creates [a new rules page](https://rules.ncats.cyber.dhs.gov/was.txt) specific to web application scanning.  It also removes the Qualys IPs from `cyhy.txt`.

In an unrelated change, I also added workspace configs for @dav3r, @mcdonnnj, and @hillaryj.

## 💭 Motivation and Context

These changes were requested by the CyHy folks.

## 🧪 Testing

I deployed these changes to production and verified that the `cyhy.txt` and `was.txt` pages look correct.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
