### PR TITLE
Update Portscan Deployment Script to Support Sequential Instance Range

### DIFF
--- a/terraform/deploy_new_dashboard_ami.sh
+++ b/terraform/deploy_new_dashboard_ami.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# deploy_new_database_ami.sh region workspace_name
+# deploy_new_dashboard_ami.sh region workspace_name
 
 set -o nounset
 set -o errexit

--- a/terraform/deploy_new_portscan_instance.sh
+++ b/terraform/deploy_new_portscan_instance.sh
@@ -1,40 +1,62 @@
 #!/usr/bin/env bash
 
 # deploy_new_portscan_instance.sh region workspace_name instance_index
+# deploy_new_portscan_instance.sh region workspace_name first_instance last_instance
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
+function usage {
+    echo "Usage:"
+    echo "  ${0##*/} region workspace_name instance_index"
+    echo "  ${0##*/} region workspace_name first_instance last_instance"
+    exit 1
+}
+
+function redeploy_instances {
+    for index in $(seq "$1" "$2")
+    do
+        # Strip control characters, then look for the text "id" surrounded by
+        # space characters, then extract only the ID from that line.
+        # The first sed line has been carefully crafted to work with BSD sed.
+        nmap_instance_id=$(terraform state show aws_instance.cyhy_nmap[$index] | \
+                               sed $'s,\x1b\\[[0-9;]*[[:alpha:]],,g' | \
+                               grep "[[:space:]]id[[:space:]]" | \
+                               sed "s/[[:space:]]*id[[:space:]]*= \"\(.*\)\"/\1/")
+
+        # Terminate the existing nmap instance
+        aws --region "$region" ec2 terminate-instances --instance-ids "$nmap_instance_id"
+        aws --region "$region" ec2 wait instance-terminated --instance-ids "$nmap_instance_id"
+
+        terraform apply -var-file="$workspace.tfvars" \
+                  -target=aws_eip_association.cyhy_nmap_eip_assocs[$index] \
+                  -target=aws_instance.cyhy_nmap[$index] \
+                  -target=aws_route53_record.cyhy_portscan_A[$index] \
+                  -target=aws_route53_record.cyhy_rev_portscan_PTR[$index] \
+                  -target=aws_volume_attachment.nmap_cyhy_runner_data_attachment[$index] \
+                  -target="module.dyn_nmap.module.cyhy_nmap_ansible_provisioner_$index"
+    done
+}
+
 if [ $# -eq 3 ]
 then
-    region=$1
-    workspace=$2
-    index=$3
+    stop=$3
+elif [ $# -eq 4 ]
+then
+    stop=$4
 else
-    echo "Usage:  deploy_new_portscan_instance.sh region workspace_name instance_index"
-    exit 1
+    usage
+fi
+
+region=$1
+workspace=$2
+start=$3
+
+if [ "$start" -gt "$stop" ]
+then
+    usage
 fi
 
 terraform workspace select "$workspace"
-
-# Strip control characters, then look for the text "id" surrounded by
-# space characters, then extract only the ID from that line.
-#
-# The first sed line has been carefully crafted to work with BSD sed.
-nmap_instance_id=$(terraform state show aws_instance.cyhy_nmap[$index] | \
-                       sed $'s,\x1b\\[[0-9;]*[[:alpha:]],,g' | \
-                       grep "[[:space:]]id[[:space:]]" | \
-                       sed "s/[[:space:]]*id[[:space:]]*= \"\(.*\)\"/\1/")
-
-# Terminate the existing nmap instance
-aws --region "$region" ec2 terminate-instances --instance-ids "$nmap_instance_id"
-aws --region "$region" ec2 wait instance-terminated --instance-ids "$nmap_instance_id"
-
-terraform apply -var-file="$workspace.tfvars" \
-          -target=aws_eip_association.cyhy_nmap_eip_assocs[$index] \
-          -target=aws_instance.cyhy_nmap[$index] \
-          -target=aws_route53_record.cyhy_portscan_A[$index] \
-          -target=aws_route53_record.cyhy_rev_portscan_PTR[$index] \
-          -target=aws_volume_attachment.nmap_cyhy_runner_data_attachment[$index] \
-          -target="module.dyn_nmap.module.cyhy_nmap_ansible_provisioner_$index"
+redeploy_instances "$start" "$stop"

--- a/terraform/deploy_new_portscan_instance.sh
+++ b/terraform/deploy_new_portscan_instance.sh
@@ -15,7 +15,7 @@ function usage {
 }
 
 function redeploy_instances {
-    tf_args="-var-file=\"$workspace.tfvars\""
+    tf_args=("-var-file=\"$workspace.tfvar\"")
     for index in $(seq "$1" "$2")
     do
         # Strip control characters, then look for the text "id" surrounded by
@@ -30,15 +30,15 @@ function redeploy_instances {
         aws --region "$region" ec2 terminate-instances --instance-ids "$nmap_instance_id"
         aws --region "$region" ec2 wait instance-terminated --instance-ids "$nmap_instance_id"
 
-        tf_args="$tf_args -target=aws_eip_association.cyhy_nmap_eip_assocs[$index]"
-        tf_args="$tf_args -target=aws_instance.cyhy_nmap[$index]"
-        tf_args="$tf_args -target=aws_route53_record.cyhy_portscan_A[$index]"
-        tf_args="$tf_args -target=aws_route53_record.cyhy_rev_portscan_PTR[$index]"
-        tf_args="$tf_args -target=aws_volume_attachment.nmap_cyhy_runner_data_attachment[$index]"
-        tf_args="$tf_args -target=\"module.dyn_nmap.module.cyhy_nmap_ansible_provisioner_$index\""
+        tf_args+=("-target=aws_eip_association.cyhy_nmap_eip_assocs[$index]")
+        tf_args+=("-target=aws_instance.cyhy_nmap[$index]")
+        tf_args+=("-target=aws_route53_record.cyhy_portscan_A[$index]")
+        tf_args+=("-target=aws_route53_record.cyhy_rev_portscan_PTR[$index]")
+        tf_args+=("-target=aws_volume_attachment.nmap_cyhy_runner_data_attachment[$index]")
+        tf_args+=("-target=\"module.dyn_nmap.module.cyhy_nmap_ansible_provisioner_$index\"")
     done
 
-    terraform apply $tf_args
+    terraform apply "${tf_args[@]}"
 }
 
 if [ $# -eq 3 ]

--- a/terraform/deploy_new_portscan_instance.sh
+++ b/terraform/deploy_new_portscan_instance.sh
@@ -55,6 +55,11 @@ region=$1
 workspace=$2
 start=$3
 
+if [[ (! "$start" =~ ^[0-9]+$) || (! "$stop" =~ ^[0-9]+$) ]]
+then
+    usage
+fi
+
 if [ "$start" -gt "$stop" ]
 then
     usage


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR updates the `deploy_new_portscan_instance.sh` script to support a starting and ending instance range to deploy. It also fixes a typo noticed by @dav3r in #268 after it was merged.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
@dav3r mentioned that it would be convenient to be able to (re)deploy a range of portscan instances conveniently. This updates the deploy script to allow for that.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Just verification that the function and loop were providing expected values.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
