### PR TITLE
Increase Portscan Instance Count to 72

### DIFF
--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -17,7 +17,7 @@ nessus-hosts = vulnscan1
 database-name = cyhy
 jobs-per-nmap-host = 12
 jobs-per-nessus-host = 128
-nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64
+nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72
 nessus-hosts = vulnscan1,vulnscan2,vulnscan3
 
 [purge]
@@ -33,7 +33,7 @@ database-name = cyhy
 jobs-per-nmap-host = 0
 jobs-per-nessus-host = 0
 shutdown-when-idle = false
-nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64
+nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72
 nessus-hosts = vulnscan1,vulnscan2,vulnscan3
 
 [purge-trash]

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -29,21 +29,21 @@ assert sys.version_info >= (3, 7), "This script requires Python version 3.7 or n
 # NOTE: mgmt_bastion should only be set to 0 or 1
 WORKSPACE_CONFIGS = {
     "production": {
-        "nmap": 64,
+        "nmap": 72,
         "nessus": 3,
         "mongo": 1,
         "mgmt_bastion": 0,
         "mgmt_nessus": 0,
     },
     "prod-a": {
-        "nmap": 64,
+        "nmap": 72,
         "nessus": 3,
         "mongo": 1,
         "mgmt_bastion": 0,
         "mgmt_nessus": 0,
     },
     "prod-b": {
-        "nmap": 64,
+        "nmap": 72,
         "nessus": 3,
         "mongo": 1,
         "mgmt_bastion": 0,
@@ -51,9 +51,21 @@ WORKSPACE_CONFIGS = {
     },
     "daver": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
     "felddy": {"nmap": 4, "nessus": 1, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
-    "hillary": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
+    "hillary": {
+        "nmap": 0,
+        "nessus": 0,
+        "mongo": 1,
+        "mgmt_bastion": 0,
+        "mgmt_nessus": 0,
+    },
     "jsf9k": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
-    "mcdonnnj": {"nmap": 0, "nessus": 0, "mongo": 1, "mgmt_bastion": 0, "mgmt_nessus": 0},
+    "mcdonnnj": {
+        "nmap": 0,
+        "nessus": 0,
+        "mongo": 1,
+        "mgmt_bastion": 0,
+        "mgmt_nessus": 0,
+    },
 }
 
 # the default configuration if a workspace is not defined above


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds eight more `portscan` instances to bring the total to 72. The commander configuration and the dynamic module generating Python script have been modified to reflect the change.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
@dav3r noticed that we are slowly using a high enough percentage of `portscan` instances regularly that it would be a good idea to increase the number of available instances.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
This was deployed to the `prod-a` workspace earlier today (2020-06-18).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
