### PR TITLE
Increase timeout when rebuilding Nessus plugin database

### DIFF
--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -69,7 +69,7 @@
 
     - name: Rebuild the plugin database
       command: /opt/nessus/sbin/nessusd -R
-      async: 1200
+      async: 1800
       poll: 30
 
     - name: Start Nessus service


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR increases the timeout for the Ansible task that rebuilds the Nessus plugin database from 20 minutes to 30 minutes.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
The number of plugins has grown and the time to rebuild the plugin DB can now exceed 20 minutes on an `m5.large` instance.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Manually verified on the `prod-a` management Nessus instance (an `m5.large` instance) that the plugin DB rebuild took roughly 23 minutes to complete.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
