### PR TITLE
Add a missing SG rule for the Management vulnscanner

### DIFF
--- a/terraform/cyhy_scanner_security_group_rules.tf
+++ b/terraform/cyhy_scanner_security_group_rules.tf
@@ -86,3 +86,17 @@ resource "aws_security_group_rule" "scanner_egress_anywhere" {
   to_port   = 0
 }
 
+# Allow all TCP from vulnscanner instance in Management VPC,
+# for internal scanning
+resource "aws_security_group_rule" "scanner_ingress_all_tcp_from_mgmt_vulnscan" {
+  count = var.enable_mgmt_vpc ? local.mgmt_nessus_instance_count : 0
+
+  security_group_id = aws_security_group.cyhy_scanner_sg.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks = [
+    "${aws_instance.mgmt_nessus[count.index].private_ip}/32",
+  ]
+  from_port = 0
+  to_port   = 65535
+}


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds a security group rule allowing full TCP ingress from the Management vulnscan instance to any of the CyHy scanner instances.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We need the ability to run credentialed scans from the Management vulnscanner against the CyHy scanner instances.  Without this security group rule, SSH traffic from the Management vulnscanner is not allowed in to the CyHy scanner security group.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I verified that adding this SG rule produced the desired behavior (allowing inbound SSH traffic).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
