### PR TITLE
Explicitly set owner of authorized_keys file for SSH ops user

### DIFF
--- a/ansible/roles/cyhy_ops/tasks/main.yml
+++ b/ansible/roles/cyhy_ops/tasks/main.yml
@@ -27,4 +27,5 @@
     create: yes
     owner: cyhy_ops
     group: cyhy_ops
+    mode: 0600
   loop: "{{ ops_users }}"

--- a/ansible/roles/cyhy_ops/tasks/main.yml
+++ b/ansible/roles/cyhy_ops/tasks/main.yml
@@ -25,4 +25,6 @@
     path: /home/cyhy_ops/.ssh/authorized_keys
     line: "{{ lookup('aws_ssm', '/ssh/public_keys/{{ item }}') }}"
     create: yes
+    owner: cyhy_ops
+    group: cyhy_ops
   loop: "{{ ops_users }}"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
-  required_version = ">= 0.12"
+  # We want to hold off on 0.13 until we have tested it.
+  required_version = "~> 0.12.0"
+
+  # Pin to the latest 2.x AWS provider, since the 3.x provider is
+  # unstable and causing problems.
+  required_providers {
+    aws = "~> 2.0"
+  }
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR explicitly sets the owner of `~cyhy_ops/.ssh/authorized_keys` to `cyhy_ops:cyhy_ops` when the file is created.

It also pins Terraform to 0.12.x and the AWS provider to 2.x until we can fully test the newer versions.

## 💭 Motivation and Context

A recent change to Ansible made `~cyhy_ops/.ssh/authorized_keys` be owned by `root:root` and unreadable by the `cyhy_ops` user when it was created.  This was preventing successful SSH connections from `cyhy_ops` users with authorized keys.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I verified the fix by changing the owner of `~cyhy_ops/.ssh/authorized_keys` to `root:root`, then doing a targeted apply of `module.cyhy_bastion_ansible_provisioner.null_resource.provisioner` and verified that `~cyhy_ops/.ssh/authorized_keys` ownership was correctly set to `cyhy_ops:cyhy_ops`. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
