### PR TITLE
Explicitly set owner of authorized_keys file for SSH mgmt ops user

### DIFF
--- a/ansible/roles/mgmt_ops/tasks/main.yml
+++ b/ansible/roles/mgmt_ops/tasks/main.yml
@@ -25,4 +25,7 @@
     path: /home/mgmt_ops/.ssh/authorized_keys
     line: "{{ lookup('aws_ssm', '/ssh/public_keys/{{ item }}') }}"
     create: yes
+    owner: mgmt_ops
+    group: mgmt_ops
+    mode: 0600
   loop: "{{ ops_users }}"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR explicitly sets the owner of `~mgmt_ops/.ssh/authorized_keys` to `mgmt_ops:mgmt_ops` and the mode to `600` when the file is created. These changes mirror the ones done for the `cyhy_ops` role made in https://github.com/cisagov/cyhy_amis/pull/275
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

After the aforementioned PR was merged, I realized that we'd run into a situation before where we made changes for the regular CyHy configuration, but hadn't made similar changes that would be needed for the management configuration. I checked and saw what would possibly cause the same problem for the management configuration and this fixes that possibility.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

Assumption that the changes will work since they are based on an identical task in a previously tested PR.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
