### PR TITLE
Remove Unnecessary Private Repository Usage

### DIFF
--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -69,25 +69,19 @@
 
 - name: Download load_places.sh from GitHub
   get_url:
-    url: "https://raw.githubusercontent.com/jsf9k/cyhy-core/develop/var/load_places.sh"
-    headers:
-      Authorization: "token {{ github_oauth_token }}"
+    url: "https://raw.githubusercontent.com/cisagov/cyhy-core/develop/var/load_places.sh"
     dest: /tmp/cyhy-places/scripts/load_places.sh
     mode: 0755
 
 - name: Download GNIS_data_import.py from GitHub
   get_url:
-    url: "https://raw.githubusercontent.com/jsf9k/cyhy-core/develop/var/GNIS_data_import.py"
-    headers:
-      Authorization: "token {{ github_oauth_token }}"
+    url: "https://raw.githubusercontent.com/cisagov/cyhy-core/develop/var/GNIS_data_import.py"
     dest: /tmp/cyhy-places/scripts/GNIS_data_import.py
     mode: 0755
 
 - name: Download ADDL_CYHY_PLACES.txt from GitHub
   get_url:
-    url: "https://raw.githubusercontent.com/jsf9k/cyhy-core/develop/extras/ADDL_CYHY_PLACES.txt"
-    headers:
-      Authorization: "token {{ github_oauth_token }}"
+    url: "https://raw.githubusercontent.com/cisagov/cyhy-core/develop/extras/ADDL_CYHY_PLACES.txt"
     dest: /tmp/cyhy-places/extras/ADDL_CYHY_PLACES.txt
 
 - name: Check if cyhy.conf already exists

--- a/ansible/roles/cyhy_commander/vars/main.yml
+++ b/ansible/roles/cyhy_commander/vars/main.yml
@@ -10,6 +10,3 @@ commander_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/user') }}"
 commander_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/password') }}"
 # commander mongo database
 commander_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/database') }}"
-
-# The GitHub OAUTH token
-github_oauth_token: "{{ lookup('aws_ssm', '/github/oauth_token') }}"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR removes usage of old, private repository URLs because the repository they reference is now a public `cisagov` repository. The variable storing the OAuth token needed to access them has also been removed.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

I was looking in the Ansible roles used during deployment and noticed that we still had some private repo references that were no longer needed.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

I used these changes as part of a test deployment and had no issues.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
