### PR TITLE
Tweak scraper configuration

### DIFF
--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -20,7 +20,6 @@
     content: |
       {
           "agency": "DHS",
-          "organization": "Department of Homeland Security",
           "contact_email": "do_not_email_just_use_github@dhs.gov",
 
           "permissions": {


### PR DESCRIPTION
## 🗣 Description

This pull request tweaks the [LLNL/scraper](https://github.com/LLNL/scraper) configuration to fix an issue brought up by @h-m-f-t in #279.  Specifically, it removes the `organization` field from the configuration, so that the scraper will instead fill that field for each repo with the corresponding GitHub organization's name.  This will allow us to differentiate between CISA and CBP repositories in [the code.gov JSON](https://www.dhs.gov/code.json).

Fixes #279.

## 💭 Motivation and Context

We need to differentiate between CBP and CISA repositories in [the code.gov JSON](https://www.dhs.gov/code.json) for proper attribution.  Previously we were attributing everything to DHS.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
