### PR TITLE
Add monthly cyhy redeploy issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/monthly-cyhy-environment-redeploy.md
+++ b/.github/ISSUE_TEMPLATE/monthly-cyhy-environment-redeploy.md
@@ -7,7 +7,7 @@ assignees: hillaryj, mcdonnnj
 
 ---
 
-## Procedure
+## Procedure ##
 
 Add the following to the [`Redeployments` list](https://github.com/cisagov/cyhy_amis/issues/272)
 
@@ -19,15 +19,16 @@ Follow the [build and deploy instructions](https://github.com/cisagov/cyhy_amis#
 
 Check off each service as it is redeployed to track the overall status. Once all services have been redeployed and functionality confirms, close this issue and check off the month on the [`Redeployments` list](https://github.com/cisagov/cyhy_amis/issues/272).
 
-## Status
+## Status ##
 
-- [ ] Bastions
-  - [ ] BOD
-  - [ ] CyHy
-- [ ] Dashboard
-- [ ] Database
-- [ ] Docker
-- [ ] Reporter
-- [ ] Scanners
-  - [ ] Portscanners (nmap)
-  - [ ] Vulnscanners (Nessus)
+- [ ] BOD
+  - [ ] Bastion
+  - [ ] Docker
+- [ ] CyHy
+  - [ ] Bastion
+  - [ ] Dashboard
+  - [ ] Database
+  - [ ] Reporter
+  - [ ] Scanners
+    - [ ] Portscanners (nmap)
+    - [ ] Vulnscanners (Nessus)

--- a/.github/ISSUE_TEMPLATE/monthly-cyhy-environment-redeploy.md
+++ b/.github/ISSUE_TEMPLATE/monthly-cyhy-environment-redeploy.md
@@ -1,0 +1,33 @@
+---
+name: Monthly CyHy Environment Redeploy
+about: Monthly redeploy of the CyHy .nvironment
+title: 2020-XX Redeploy CyHy Environment
+labels: ''
+assignees: hillaryj, mcdonnnj
+
+---
+
+## Procedure
+
+Add the following to the [`Redeployments` list](https://github.com/cisagov/cyhy_amis/issues/272)
+
+```
+- [ ] [202X-XX](link to comment for that month)
+```
+
+Follow the [build and deploy instructions](https://github.com/cisagov/cyhy_amis#building-the-amis).
+
+Check off each service as it is redeployed to track the overall status. Once all services have been redeployed and functionality confirms, close this issue and check off the month on the [`Redeployments` list](https://github.com/cisagov/cyhy_amis/issues/272).
+
+## Status
+
+- [ ] Bastions
+  - [ ] BOD
+  - [ ] CyHy
+- [ ] Dashboard
+- [ ] Database
+- [ ] Docker
+- [ ] Reporter
+- [ ] Scanners
+  - [ ] Portscanners (nmap)
+  - [ ] Vulnscanners (Nessus)

--- a/.github/ISSUE_TEMPLATE/monthly-cyhy-environment-redeploy.md
+++ b/.github/ISSUE_TEMPLATE/monthly-cyhy-environment-redeploy.md
@@ -1,7 +1,7 @@
 ---
 name: Monthly CyHy Environment Redeploy
-about: Monthly redeploy of the CyHy .nvironment
-title: 2020-XX Redeploy CyHy Environment
+about: Monthly redeploy of the CyHy Environment
+title: 202X-XX Redeploy CyHy Environment
 labels: ''
 assignees: hillaryj, mcdonnnj
 
@@ -9,15 +9,15 @@ assignees: hillaryj, mcdonnnj
 
 ## Procedure ##
 
-Add the following to the [`Redeployments` list](https://github.com/cisagov/cyhy_amis/issues/272)
+Add the following to the [`Redeployments` tracker](https://github.com/cisagov/cyhy_amis/issues/272)
 
 ```
-- [ ] [202X-XX](link to comment for that month)
+- [ ] [202X-XX](https://github.com/cisagov/cyhy_amis/issues/###)
 ```
 
 Follow the [build and deploy instructions](https://github.com/cisagov/cyhy_amis#building-the-amis).
 
-Check off each service as it is redeployed to track the overall status. Once all services have been redeployed and functionality confirms, close this issue and check off the month on the [`Redeployments` list](https://github.com/cisagov/cyhy_amis/issues/272).
+Check off each service as it is redeployed to track the overall status. Once all services have been redeployed and functionality confirmed, close this issue and check off the month on the [`Redeployments` tracker](https://github.com/cisagov/cyhy_amis/issues/272).
 
 ## Status ##
 


### PR DESCRIPTION
Creates an issue template for redeploying CyHy envs so we can have an issue to move around the board and close, monthly. Will need to be updated to 2021 when the year rolls over.