### PR TITLE
Update bastion Image to build on Debian Buster

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -12,6 +12,14 @@
     - banner
     - persist_journald
 
+# Any instances that are built on Debian Buster should have Python 2 removed
+- hosts: bastion
+  name: Remove Python 2
+  become: yes
+  become_method: sudo
+  roles:
+    - remove_python2
+
 # The bastion should have as little installed as possible, since it's
 # exposed to the cruel world
 - hosts: all:!bastion

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -6,19 +6,9 @@
   become: yes
   become_method: sudo
   roles:
-    - upgrade
-    - python
     - nvme
     - banner
     - persist_journald
-
-# Any instances that are built on Debian Buster should have Python 2 removed
-- hosts: bastion
-  name: Remove Python 2
-  become: yes
-  become_method: sudo
-  roles:
-    - remove_python2
 
 # The bastion should have as little installed as possible, since it's
 # exposed to the cruel world

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  name: Install pip3/python3
+  become: yes
+  become_method: sudo
+  roles:
+    - pip
+    - python
+
+# Any instances that are built on Debian Buster should have Python 2 removed
+- hosts: bastion
+  name: Remove pip2/python2
+  become: yes
+  become_method: sudo
+  roles:
+    - remove_python2

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -50,6 +50,8 @@
   name: pip
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+- src: https://github.com/cisagov/ansible-role-remove-python2
+  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade
 - src: https://github.com/cisagov/ansible-role-xfs

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  name: Upgrade base image
+  become: yes
+  become_method: sudo
+  roles:
+    - upgrade

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -44,7 +44,7 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Buster",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -1,59 +1,61 @@
 {
-    "builders": [{
-        "type": "amazon-ebs",
-        "region": "us-east-2",
-        "source_ami_filter": {
-            "filters": {
-                "virtualization-type": "hvm",
-                "name": "debian-stretch-hvm-x86_64-gp2-*",
-                "root-device-type": "ebs"
-            },
-            "owners": [
-                "379101102735"
-            ],
-            "most_recent": true
-        },
-        "instance_type": "t3.micro",
-        "ssh_username": "admin",
-        "ami_name": "cyhy-bastion-hvm-{{timestamp}}-x86_64-ebs",
-        "ami_regions": [
-            "us-east-1",
-            "us-west-1",
-            "us-west-2"
-        ],
-
-        "ami_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "launch_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "tags": {
-            "Team": "NCATS OIS - Development",
-            "Application": "Cyber Hygiene",
-            "OS_Version": "Debian Stretch",
-            "Release": "Latest",
-            "Base_AMI_Name": "{{ .SourceAMIName }}"
-        }
-    }],
-
-    "provisioners": [
+  "builders": [
+    {
+      "ami_block_device_mappings": [
         {
-            "type": "ansible",
-            "playbook_file": "packer/ansible/playbook.yml",
-            "groups": [
-                "bastion"
-            ]
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
         }
-    ]
+      ],
+      "ami_name": "cyhy-bastion-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "instance_type": "t3.micro",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
+        }
+      ],
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type": "ebs",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true,
+        "owners": [
+          "379101102735"
+        ]
+      },
+      "ssh_username": "admin",
+      "tags": {
+        "Application": "Cyber Hygiene",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "OS_Version": "Debian Stretch",
+        "Release": "Latest",
+        "Team": "NCATS OIS - Development"
+      },
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "groups": [
+        "bastion"
+      ],
+      "playbook_file": "packer/ansible/playbook.yml",
+      "type": "ansible"
+    }
+  ]
 }

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -4,7 +4,7 @@
       "ami_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp2"
@@ -20,7 +20,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp2"
@@ -29,20 +29,20 @@
       "region": "us-east-2",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "name": "debian-10-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "379101102735"
+          "136693071363"
         ]
       },
       "ssh_username": "admin",
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Stretch",
+        "OS_Version": "Debian Buster",
         "Release": "Latest",
         "Team": "NCATS OIS - Development"
       },
@@ -51,6 +51,10 @@
   ],
   "provisioners": [
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=/usr/bin/python3"
+      ],
       "groups": [
         "bastion"
       ],

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -51,10 +51,20 @@
   ],
   "provisioners": [
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=/usr/bin/python3"
+      "groups": [
+        "bastion"
       ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "bastion"
+      ],
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
       "groups": [
         "bastion"
       ],

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -1,59 +1,75 @@
 {
-    "builders": [{
-        "type": "amazon-ebs",
-        "region": "us-east-2",
-        "source_ami_filter": {
-            "filters": {
-                "virtualization-type": "hvm",
-                "name": "debian-stretch-hvm-x86_64-gp2-*",
-                "root-device-type": "ebs"
-            },
-            "owners": [
-                "379101102735"
-            ],
-            "most_recent": true
-        },
-        "instance_type": "t3.micro",
-        "ssh_username": "admin",
-        "ami_name": "cyhy-dashboard-hvm-{{timestamp}}-x86_64-ebs",
-        "ami_regions": [
-            "us-east-1",
-            "us-west-1",
-            "us-west-2"
-        ],
-
-        "ami_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "launch_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "tags": {
-            "Team": "NCATS OIS - Development",
-            "Application": "Cyber Hygiene",
-            "OS_Version": "Debian Stretch",
-            "Release": "Latest",
-            "Base_AMI_Name": "{{ .SourceAMIName }}"
-        }
-    }],
-
-    "provisioners": [
+  "builders": [
+    {
+      "ami_block_device_mappings": [
         {
-            "type": "ansible",
-            "playbook_file": "packer/ansible/playbook.yml",
-            "groups": [
-                "cyhy_dashboard"
-            ]
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
         }
-    ]
+      ],
+      "ami_name": "cyhy-dashboard-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "instance_type": "t3.micro",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
+        }
+      ],
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type": "ebs",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true,
+        "owners": [
+          "379101102735"
+        ]
+      },
+      "ssh_username": "admin",
+      "tags": {
+        "Application": "Cyber Hygiene",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "OS_Version": "Debian Stretch",
+        "Release": "Latest",
+        "Team": "NCATS OIS - Development"
+      },
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "groups": [
+        "dashboard"
+      ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "dashboard"
+      ],
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "cyhy_dashboard"
+      ],
+      "playbook_file": "packer/ansible/playbook.yml",
+      "type": "ansible"
+    }
+  ]
 }

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -44,7 +44,7 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -1,61 +1,77 @@
 {
-    "builders": [{
-        "type": "amazon-ebs",
-        "region": "us-east-2",
-        "source_ami_filter": {
-            "filters": {
-                "virtualization-type": "hvm",
-                "name": "debian-stretch-hvm-x86_64-gp2-*",
-                "root-device-type": "ebs"
-            },
-            "owners": [
-                "379101102735"
-            ],
-            "most_recent": true
-        },
-        "instance_type": "t3.micro",
-        "ssh_username": "admin",
-        "ami_name": "cyhy-docker-hvm-{{timestamp}}-x86_64-ebs",
-        "ami_regions": [
-            "us-east-1",
-            "us-west-1",
-            "us-west-2"
-        ],
-
-        "ami_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 10,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "launch_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 10,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "tags": {
-            "Team": "NCATS OIS - Development",
-            "Application": "Cyber Hygiene",
-            "OS_Version": "Debian Stretch",
-            "Release": "Latest",
-            "Base_AMI_Name": "{{ .SourceAMIName }}"
-        }
-    }],
-
-    "provisioners": [
+  "builders": [
+    {
+      "ami_block_device_mappings": [
         {
-            "type": "ansible",
-            "playbook_file": "packer/ansible/playbook.yml",
-            "groups": [
-                "bod",
-                "code_gov",
-                "client_cert"
-            ]
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 10,
+          "volume_type": "gp2"
         }
-    ]
+      ],
+      "ami_name": "cyhy-docker-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "instance_type": "t3.micro",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 10,
+          "volume_type": "gp2"
+        }
+      ],
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type": "ebs",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true,
+        "owners": [
+          "379101102735"
+        ]
+      },
+      "ssh_username": "admin",
+      "tags": {
+        "Application": "Cyber Hygiene",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "OS_Version": "Debian Stretch",
+        "Release": "Latest",
+        "Team": "NCATS OIS - Development"
+      },
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "groups": [
+        "docker"
+      ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "docker"
+      ],
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "bod",
+        "code_gov",
+        "client_cert"
+      ],
+      "playbook_file": "packer/ansible/playbook.yml",
+      "type": "ansible"
+    }
+  ]
 }

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -44,7 +44,7 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -44,7 +44,7 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -1,61 +1,77 @@
 {
-    "builders": [{
-        "type": "amazon-ebs",
-        "region": "us-east-2",
-        "source_ami_filter": {
-            "filters": {
-                "virtualization-type": "hvm",
-                "name": "debian-stretch-hvm-x86_64-gp2-*",
-                "root-device-type": "ebs"
-            },
-            "owners": [
-                "379101102735"
-            ],
-            "most_recent": true
-        },
-        "instance_type": "t3.micro",
-        "ssh_username": "admin",
-        "ami_name": "cyhy-mongo-hvm-{{timestamp}}-x86_64-ebs",
-        "ami_regions": [
-             "us-east-1",
-             "us-west-1",
-             "us-west-2"
-        ],
-
-        "ami_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "launch_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "tags": {
-            "Team": "NCATS OIS - Development",
-            "Application": "Cyber Hygiene",
-            "OS_Version": "Debian Stretch",
-            "Release": "Latest",
-            "Base_AMI_Name": "{{ .SourceAMIName }}"
-        }
-    }],
-
-    "provisioners": [
+  "builders": [
+    {
+      "ami_block_device_mappings": [
         {
-            "type": "ansible",
-            "playbook_file": "packer/ansible/playbook.yml",
-            "groups": [
-                "mongo",
-                "cyhy_commander",
-                "cyhy_archive"
-            ]
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
         }
-    ]
+      ],
+      "ami_name": "cyhy-mongo-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "instance_type": "t3.micro",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
+        }
+      ],
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type": "ebs",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true,
+        "owners": [
+          "379101102735"
+        ]
+      },
+      "ssh_username": "admin",
+      "tags": {
+        "Application": "Cyber Hygiene",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "OS_Version": "Debian Stretch",
+        "Release": "Latest",
+        "Team": "NCATS OIS - Development"
+      },
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "groups": [
+        "mongo"
+      ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "mongo"
+      ],
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "mongo",
+        "cyhy_commander",
+        "cyhy_archive"
+      ],
+      "playbook_file": "packer/ansible/playbook.yml",
+      "type": "ansible"
+    }
+  ]
 }

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -1,59 +1,75 @@
 {
-    "builders": [{
-        "type": "amazon-ebs",
-        "region": "us-east-2",
-        "source_ami_filter": {
-            "filters": {
-                "virtualization-type": "hvm",
-                "name": "debian-stretch-hvm-x86_64-gp2-*",
-                "root-device-type": "ebs"
-            },
-            "owners": [
-                "379101102735"
-            ],
-            "most_recent": true
-        },
-        "instance_type": "m5.large",
-        "ssh_username": "admin",
-        "ami_name": "cyhy-nessus-hvm-{{timestamp}}-x86_64-ebs",
-        "ami_regions": [
-            "us-east-1",
-            "us-west-1",
-            "us-west-2"
-        ],
-
-        "ami_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "launch_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "tags": {
-            "Team": "NCATS OIS - Development",
-            "Application": "Cyber Hygiene",
-            "OS_Version": "Debian Stretch",
-            "Release": "Latest",
-            "Base_AMI_Name": "{{ .SourceAMIName }}"
-        }
-    }],
-
-    "provisioners": [
+  "builders": [
+    {
+      "ami_block_device_mappings": [
         {
-            "type": "ansible",
-            "playbook_file": "packer/ansible/playbook.yml",
-            "groups": [
-                "nessus"
-            ]
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
         }
-    ]
+      ],
+      "ami_name": "cyhy-nessus-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "instance_type": "m5.large",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
+        }
+      ],
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type": "ebs",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true,
+        "owners": [
+          "379101102735"
+        ]
+      },
+      "ssh_username": "admin",
+      "tags": {
+        "Application": "Cyber Hygiene",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "OS_Version": "Debian Stretch",
+        "Release": "Latest",
+        "Team": "NCATS OIS - Development"
+      },
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "groups": [
+        "nessus"
+      ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "nessus"
+      ],
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "nessus"
+      ],
+      "playbook_file": "packer/ansible/playbook.yml",
+      "type": "ansible"
+    }
+  ]
 }

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -44,7 +44,7 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -1,59 +1,75 @@
 {
-    "builders": [{
-        "type": "amazon-ebs",
-        "region": "us-east-2",
-        "source_ami_filter": {
-            "filters": {
-                "virtualization-type": "hvm",
-                "name": "debian-stretch-hvm-x86_64-gp2-*",
-                "root-device-type": "ebs"
-            },
-            "owners": [
-                "379101102735"
-            ],
-            "most_recent": true
-        },
-        "instance_type": "t3.micro",
-        "ssh_username": "admin",
-        "ami_name": "cyhy-nmap-hvm-{{timestamp}}-x86_64-ebs",
-        "ami_regions": [
-            "us-east-1",
-            "us-west-1",
-            "us-west-2"
-        ],
-
-        "ami_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "launch_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "tags": {
-            "Team": "NCATS OIS - Development",
-            "Application": "Cyber Hygiene",
-            "OS_Version": "Debian Stretch",
-            "Release": "Latest",
-            "Base_AMI_Name": "{{ .SourceAMIName }}"
-        }
-    }],
-
-    "provisioners": [
+  "builders": [
+    {
+      "ami_block_device_mappings": [
         {
-            "type": "ansible",
-            "playbook_file": "packer/ansible/playbook.yml",
-            "groups": [
-                "nmap"
-            ]
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
         }
-    ]
+      ],
+      "ami_name": "cyhy-nmap-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "instance_type": "t3.micro",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
+        }
+      ],
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type": "ebs",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true,
+        "owners": [
+          "379101102735"
+        ]
+      },
+      "ssh_username": "admin",
+      "tags": {
+        "Application": "Cyber Hygiene",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "OS_Version": "Debian Stretch",
+        "Release": "Latest",
+        "Team": "NCATS OIS - Development"
+      },
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "groups": [
+        "nmap"
+      ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "nmap"
+      ],
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "nmap"
+      ],
+      "playbook_file": "packer/ansible/playbook.yml",
+      "type": "ansible"
+    }
+  ]
 }

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -44,7 +44,7 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -44,7 +44,7 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -1,59 +1,75 @@
 {
-    "builders": [{
-        "type": "amazon-ebs",
-        "region": "us-east-2",
-        "source_ami_filter": {
-            "filters": {
-                "virtualization-type": "hvm",
-                "name": "debian-stretch-hvm-x86_64-gp2-*",
-                "root-device-type": "ebs"
-            },
-            "owners": [
-                "379101102735"
-            ],
-            "most_recent": true
-        },
-        "instance_type": "t3.medium",
-        "ssh_username": "admin",
-        "ami_name": "cyhy-reporter-hvm-{{timestamp}}-x86_64-ebs",
-        "ami_regions": [
-            "us-east-1",
-            "us-west-1",
-            "us-west-2"
-        ],
-
-        "ami_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "launch_block_device_mappings": [{
-            "device_name": "xvda",
-            "volume_size": 8,
-            "volume_type": "gp2",
-            "encrypted": true,
-            "delete_on_termination": true
-        }],
-
-        "tags": {
-            "Team": "NCATS OIS - Development",
-            "Application": "Cyber Hygiene",
-            "OS_Version": "Debian Stretch",
-            "Release": "Latest",
-            "Base_AMI_Name": "{{ .SourceAMIName }}"
-        }
-    }],
-
-    "provisioners": [
+  "builders": [
+    {
+      "ami_block_device_mappings": [
         {
-            "type": "ansible",
-            "playbook_file": "packer/ansible/playbook.yml",
-            "groups": [
-                "cyhy_reporter"
-            ]
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
         }
-    ]
+      ],
+      "ami_name": "cyhy-reporter-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "instance_type": "t3.medium",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "xvda",
+          "encrypted": true,
+          "volume_size": 8,
+          "volume_type": "gp2"
+        }
+      ],
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type": "ebs",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true,
+        "owners": [
+          "379101102735"
+        ]
+      },
+      "ssh_username": "admin",
+      "tags": {
+        "Application": "Cyber Hygiene",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "OS_Version": "Debian Stretch",
+        "Release": "Latest",
+        "Team": "NCATS OIS - Development"
+      },
+      "type": "amazon-ebs"
+    }
+  ],
+  "provisioners": [
+    {
+      "groups": [
+        "reporter"
+      ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "reporter"
+      ],
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
+      "groups": [
+        "cyhy_reporter"
+      ],
+      "playbook_file": "packer/ansible/playbook.yml",
+      "type": "ansible"
+    }
+  ]
 }

--- a/terraform_nessus_only/variables.tf
+++ b/terraform_nessus_only/variables.tf
@@ -13,7 +13,7 @@ variable "aws_availability_zone" {
 variable "tags" {
   type = map(string)
   default = {
-    Team        = "NCATS OIS - Development"
+    Team        = "VM Fusion - Development"
     Application = "Manual Cyber Hygiene"
   }
   description = "Tags to apply to all AWS resources created"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR updates the `bastion` instance AMI to build from Debian Buster instead of Debian Stretch.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

Currently our CyHy environment images are built on Debian Stretch because of a legacy requirement for Python 2. Any instances that can be migrated to Debian Buster should be for a variety of reasons. Since the `bastion` does not have any Python 2 requirements, migrating it to Buster is a straightforward update.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

I built and deployed a `bastion` AMI in a testing environment and ensured that expected functionality worked.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
