### PR TITLE
Fix pymongo Version and File Permission

### DIFF
--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -83,6 +83,7 @@
   get_url:
     url: "https://raw.githubusercontent.com/cisagov/cyhy-core/develop/extras/ADDL_CYHY_PLACES.txt"
     dest: /tmp/cyhy-places/extras/ADDL_CYHY_PLACES.txt
+    mode: 0644
 
 - name: Check if cyhy.conf already exists
   stat:

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -6,17 +6,9 @@
   register: checkifmongousers
   changed_when: false
 
-# HACK ALERT - Part 1: Install pymongo 3.5 in order to use the Ansible
-# mongodb_user module
-#
-# Note that pymongo > 3.5 will fail right now, so we have to enforce
-# an old version:
-# * https://jira.mongodb.org/browse/SERVER-34820
-# * https://github.com/ansible/ansible/issues/38998
-#
-# The forced installation of 3.5 should be removed once this issue
-# gets resolved.
-- name: Install pymongo 3.5.  This should be changed to install the latest once that is possible.
+# HACK ALERT - Part 1:
+# Install pymongo 3.6 in order to use the Ansible mongodb_user module.
+- name: Install pymongo 3.6
   pip:
     name: pymongo
     version: '3.6'
@@ -55,7 +47,8 @@
   # Loop over all the users *except* for admin
   loop: "{{ non_admin_users }}"
 
-# HACK ALERT - Part 2: Revert to older pymongo, needed for cyhy-core
+# HACK ALERT - Part 2:
+# Revert to older pymongo, needed for cyhy-core
 - name: Downgrade to pymongo 2.9.5
   pip:
     name: pymongo

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Install pymongo 3.5.  This should be changed to install the latest once that is possible.
   pip:
     name: pymongo
-    version: '3.5'
+    version: '3.6'
 
 - name: Create admin user in admin db (first user, no authentication)
   mongodb_user:


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR adds two small fixes I've needed to make for my testing code. They are
1. Change the temporary pymongo version installed from 3.5 to 3.6
1. Add explicit permissions for a file downloaded from GitHub
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

When attempting to deploy a new database instance when using Ansible 2.10 I ran into the following issue:
```console
failed: [10.10.10.122] (item=assessment-read) => {"ansible_loop_var": "item", "changed": false, "item": "assessment-read", "msg": "pymongo driver version and MongoDB version are incompatible: you must use pymongo 3.6+ with MongoDB >= 3.6"}
```
and similar for each attempt to use the `mongodb_user` module. I tested that bumping the installed version to 3.6 was a safe remedy.

I noticed when doing an initial deploy that there were issues with the places collection being updated because the `ADDL_CYHY_PLACES.txt` file did not have appropriate permissions.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

I was able to successfully deploy and use my testing environment with these changes in place.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
