### PR TITLE
Increase volume sizes on reporter instance

### DIFF
--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -82,7 +82,7 @@ resource "aws_instance" "cyhy_reporter" {
 
   root_block_device {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 50
     delete_on_termination = true
   }
 
@@ -141,7 +141,7 @@ module "cyhy_reporter_ansible_provisioner" {
 resource "aws_ebs_volume" "cyhy_reporter_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   type              = "io1"
-  size              = local.production_workspace ? 200 : 5
+  size              = local.production_workspace ? 500 : 5
   iops              = 100
   encrypted         = true
 


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR increases the size of the root volume and the report data volume on the reporter instance. 

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This was done because we ran out of disk space during the weekly reporting process.  We currently retain all reports and the number of reports generated each week continues to increase.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
After these changes were made, they were applied in production with:
```
terraform apply -var-file=prod-a.tfvars -target=aws_ebs_volume.cyhy_reporter_data -target=aws_instance.cyhy_reporter
```

After the Terraform apply completed successfully, I ssh'd to the reporter instance and ran through the [steps to grow the partition and file systems](https://github.com/cisagov/cyhy-system/wiki/Adjust-reporter-partition-and-filesystem-size) so that they took advantage of the larger volume sizes.
  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
