### PR TITLE
Add vulnscan (Re)Deploy Script

### DIFF
--- a/terraform/deploy_new_vulnscan_instance.sh
+++ b/terraform/deploy_new_vulnscan_instance.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# (Re)deploy vulnscan instances in the current Terraform environment.
+# Usage:
+# deploy_new_vulnscan_instance.sh region workspace_name instance_index
+# deploy_new_vulnscan_instance.sh region workspace_name first_index last_index
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Print usage information and exit.
+function usage {
+    echo "Usage:"
+    echo "  ${0##*/} region workspace_name instance_index"
+    echo "  ${0##*/} region workspace_name first_index last_index"
+    echo
+    echo "Notes:"
+    echo "  - When giving a first and last index the range is inclusive."
+    exit 1
+}
+
+# Check for required external programs. If any are missing output a list of all
+# requirements and then exit.
+function check_dependencies {
+    if [ -z "$(command -v terraform)" ] || \
+        [ -z "$(command -v aws)" ] || \
+        [ -z "$(command -v jq)" ]
+    then
+        echo "This script requires the following tools to run:"
+        echo "- terraform"
+        echo "- aws (AWS CLI)"
+        echo "- jq"
+        exit 1
+    fi
+}
+
+# Terminate running instances and (re)deploy their Terraform resources in the
+# given range of instance indices [first, last].
+function redeploy_instances {
+    tf_args=()
+    # Get all vulnscan instance IDs as a JSON array of dicts in the form:
+    # {
+    #   index: instance_index,
+    #   id: instance_id
+    # }
+    # Any previously removed instances are ignored (.deposed_key == null)
+    vulnscanner_ids_json=$(terraform show -json | \
+        jq '.values.root_module.resources[] | select(.address == "aws_instance.cyhy_nessus" and .deposed_key == null) | {index, id: .values.id}' \
+        | jq -n '[inputs]')
+    nessus_instance_ids=()
+
+    for index in $(seq "$1" "$2")
+    do
+        # Check the list of instances and get the ID of the index we are working
+        # on for this iteration
+        nessus_instance_ids+=("$(echo "$vulnscanner_ids_json" | jq --raw-output ".[] | select(.index == $index) | .id")")
+
+        tf_args+=("-target=aws_eip_association.cyhy_nessus_eip_assocs[$index]")
+        tf_args+=("-target=aws_instance.cyhy_nessus[$index]")
+        tf_args+=("-target=aws_route53_record.cyhy_vulnscan_A[$index]")
+        tf_args+=("-target=aws_route53_record.cyhy_rev_vulnscan_PTR[$index]")
+        tf_args+=("-target=aws_volume_attachment.nessus_cyhy_runner_data_attachment[$index]")
+        tf_args+=("-target=module.dyn_nessus.module.cyhy_nessus_ansible_provisioner_$index")
+    done
+
+    if [ ${#nessus_instance_ids[@]} -ne 0 ]
+    then
+        # Terminate the existing nessus instance
+        aws --region "$region" ec2 terminate-instances --instance-ids "${nessus_instance_ids[@]}"
+        aws --region "$region" ec2 wait instance-terminated --instance-ids "${nessus_instance_ids[@]}"
+    fi
+    terraform apply -var-file="$workspace.tfvars" "${tf_args[@]}"
+}
+
+if [ $# -eq 3 ]
+then
+    stop=$3
+elif [ $# -eq 4 ]
+then
+    stop=$4
+else
+    usage
+fi
+
+region=$1
+workspace=$2
+start=$3
+
+if [[ (! "$start" =~ ^[0-9]+$) || (! "$stop" =~ ^[0-9]+$) ]]
+then
+    usage
+fi
+
+if [ "$start" -gt "$stop" ]
+then
+    usage
+fi
+
+check_dependencies
+
+terraform workspace select "$workspace"
+redeploy_instances "$start" "$stop"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a helper script for (re)deploying `vulnscan` instances. This is a duplication of the `deploy_new_portscan_instance.sh` script with resources updated to reflect the `vulnscan` instance(s).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

Since other instance types have helper scripts, I thought it would be good to cover yet another type.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I have been using this in my testing environment with no issues. I was also able to successfully redeploy the production `vulnscan` instances using this script.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
