### PR TITLE
[HOLD] Migrate portscan and vulnscan Instances to Debian Buster

### DIFF
--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -93,7 +93,7 @@ class NessusController:
             # If we are already logged in, add the token to the
             # headers
             if self.token:
-                headers["X-Cookie"] = "token={!s}".format(self.token)
+                headers["X-Cookie"] = f"token={self.token}"
 
             if method == "GET":
                 response = requests.get(
@@ -106,7 +106,7 @@ class NessusController:
                 if files:
                     # This reassigning of headers is to remove the
                     # content type assignment
-                    headers = {"X-Cookie": "token={!s}".format(self.token)}
+                    headers = {"X-Cookie": f"token={self.token}"}
                     response = requests.post(
                         self.url + target,
                         headers=headers,

--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -178,26 +178,26 @@ class NessusController:
         )
         if response.status_code == OK_STATUS:
             return response.json()
-        raise Warning("Policy import failed; response={!r}".format(response.text))
+        raise Warning(f"Policy import failed; response={response.text}")
 
     def upload_file(self, files):
         response = self.__make_request(FILE_UPLOAD, "POST", files=files)
         if response.status_code == OK_STATUS:
             return response.json()
-        raise Warning("File upload failed; response={!r}".format(response.text))
+        raise Warning(f"File upload failed; response={response.text}")
 
     def policy_list(self):
         response = self.__make_request(POLICY_BASE, "GET")
         if response.status_code == OK_STATUS:
             return response.json()
-        raise Warning("Policy list failed; response={!r}".format(response.text))
+        raise Warning(f"Policy list failed; response={response.text}")
 
     def destroy_session(self):
         response = self.__make_request(LOGIN, "DELETE")
         if response.status_code == OK_STATUS:
             return response
         raise Warning(
-            "Session destruction failed; response={!r}".format(response.text)
+            f"Session destruction failed; response={response.text}"
         )
 
 

--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Standard Python Libraries
 import json
 import logging

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -83,7 +83,7 @@
   copy:
     src: nessus_base.py
     dest: /tmp/nessus_base.py
-    mode: 0744
+    mode: 0644
 
 - name: Configure nessus base policy to use nessus username
   lineinfile:
@@ -109,7 +109,7 @@
     port: 8834
 
 - name: Run nessus base policy import script
-  command: python /tmp/nessus_base.py
+  command: python3 /tmp/nessus_base.py
 
 #
 # Clean up

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -8,7 +8,7 @@
     - python
 
 # Any instances that are built on Debian Buster should have Python 2 removed
-- hosts: bastion
+- hosts: bastion,nessus,nmap
   name: Remove pip2/python2
   become: yes
   become_method: sudo

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -42,7 +42,7 @@
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Stretch",
+        "OS_Version": "Debian Buster",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -4,7 +4,7 @@
       "ami_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp2"
@@ -20,7 +20,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp2"
@@ -29,13 +29,13 @@
       "region": "us-east-2",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "name": "debian-10-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "379101102735"
+          "136693071363"
         ]
       },
       "ssh_username": "admin",

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -42,7 +42,7 @@
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Stretch",
+        "OS_Version": "Debian Buster",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -4,7 +4,7 @@
       "ami_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp2"
@@ -20,7 +20,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp2"
@@ -29,13 +29,13 @@
       "region": "us-east-2",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "name": "debian-10-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "379101102735"
+          "136693071363"
         ]
       },
       "ssh_username": "admin",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the Packer configurations to build the `portscan` and `vulnscan` AMIs (`nessus.json` and `nmap.json`) on Debian Buster.

This PR should only be merged along with the following PRs:
https://github.com/cisagov/cyhy-runner/pull/2
https://github.com/jsf9k/cyhy-commander/pull/17
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

Migrating [cisagov/cyhy-runner](https://github.com/cisagov/cyhy-runner) to Python 3 requires the instances it runs on to update to using Debian Buster.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I have used these updates to create AMIs that were deployed as part of testing the linked PRs.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
