### PR TITLE
Add a Fourth vulnscan Instance to the Production Environment

### DIFF
--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -18,7 +18,7 @@ database-name = cyhy
 jobs-per-nmap-host = 12
 jobs-per-nessus-host = 128
 nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72,portscan73,portscan74,portscan75,portscan76,portscan77,portscan78,portscan79,portscan80
-nessus-hosts = vulnscan1,vulnscan2,vulnscan3
+nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4
 
 [purge]
 # use to collect remaining jobs without creating new ones
@@ -34,7 +34,7 @@ jobs-per-nmap-host = 0
 jobs-per-nessus-host = 0
 shutdown-when-idle = false
 nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72,portscan73,portscan74,portscan75,portscan76,portscan77,portscan78,portscan79,portscan80
-nessus-hosts = vulnscan1,vulnscan2,vulnscan3
+nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4
 
 [purge-trash]
 # purge jobs from scanners

--- a/terraform/configure.py
+++ b/terraform/configure.py
@@ -30,21 +30,21 @@ assert sys.version_info >= (3, 7), "This script requires Python version 3.7 or n
 WORKSPACE_CONFIGS = {
     "production": {
         "nmap": 80,
-        "nessus": 3,
+        "nessus": 4,
         "mongo": 1,
         "mgmt_bastion": 0,
         "mgmt_nessus": 0,
     },
     "prod-a": {
         "nmap": 80,
-        "nessus": 3,
+        "nessus": 4,
         "mongo": 1,
         "mgmt_bastion": 0,
         "mgmt_nessus": 0,
     },
     "prod-b": {
         "nmap": 80,
-        "nessus": 3,
+        "nessus": 4,
         "mongo": 1,
         "mgmt_bastion": 0,
         "mgmt_nessus": 0,


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a fourth `vulnscan` instance to the CyHy environment.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

@dav3r mentioned wanting to add another Nessus scanner (`vulnscan` instance) to the environment. This will allow us to handle increased load, and look at lightening the per-instance load. We would need to update https://github.com/cisagov/cyhy_amis/blob/1dd200561bf7cdf7e083ed483cfa86a420557860/ansible/roles/cyhy_commander/files/commander.conf#L19 to adjust the load per instance if we wanted to go down that route. We could also look at the [cyhy-commander configuration for IPs per VULNSCAN](https://github.com/jsf9k/cyhy-commander/blob/f7574474498caf32261725b63735ebcc208b1409/cyhy_commander/commander.py#L108).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

No testing at this point, but since this is just an instance addition it should be a clean deployment using our existing tooling.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
