### PR TITLE
Account for Non-existent Instance IDs in Scanner Deploy Scripts

### DIFF
--- a/terraform/deploy_new_portscan_instance.sh
+++ b/terraform/deploy_new_portscan_instance.sh
@@ -53,8 +53,12 @@ function redeploy_instances {
   for index in $(seq "$1" "$2")
   do
     # Check the list of instances and get the ID of the index we are working
-    # on for this iteration
-    nmap_instance_ids+=("$(echo "$portscanner_ids_json" | jq --raw-output ".[] | select(.index == $index) | .id")")
+    # on for this iteration and add it to the array of IDs if found
+    instance_id="$(echo "$portscanner_ids_json" | jq --raw-output ".[] | select(.index == $index) | .id")"
+    if [ -n "$instance_id" ]
+    then
+      nmap_instance_ids+=("$instance_id")
+    fi
 
     tf_args+=("-target=aws_eip_association.cyhy_nmap_eip_assocs[$index]")
     tf_args+=("-target=aws_instance.cyhy_nmap[$index]")

--- a/terraform/deploy_new_portscan_instance.sh
+++ b/terraform/deploy_new_portscan_instance.sh
@@ -58,6 +58,8 @@ function redeploy_instances {
     if [ -n "$instance_id" ]
     then
       nmap_instance_ids+=("$instance_id")
+    else
+      echo "No instance ID found for portscan$(($index+1))"
     fi
 
     tf_args+=("-target=aws_eip_association.cyhy_nmap_eip_assocs[$index]")

--- a/terraform/deploy_new_vulnscan_instance.sh
+++ b/terraform/deploy_new_vulnscan_instance.sh
@@ -58,6 +58,8 @@ function redeploy_instances {
     if [ -n "$instance_id" ]
     then
       nessus_instance_ids+=("$instance_id")
+    else
+      echo "No instance ID found for vulnscan$(($index+1))"
     fi
 
     tf_args+=("-target=aws_eip_association.cyhy_nessus_eip_assocs[$index]")

--- a/terraform/deploy_new_vulnscan_instance.sh
+++ b/terraform/deploy_new_vulnscan_instance.sh
@@ -53,8 +53,12 @@ function redeploy_instances {
   for index in $(seq "$1" "$2")
   do
     # Check the list of instances and get the ID of the index we are working
-    # on for this iteration
-    nessus_instance_ids+=("$(echo "$vulnscanner_ids_json" | jq --raw-output ".[] | select(.index == $index) | .id")")
+    # on for this iteration and add it to the array of IDs if found
+    instance_id="$(echo "$vulnscanner_ids_json" | jq --raw-output ".[] | select(.index == $index) | .id")"
+    if [ -n "$instance_id" ]
+    then
+      nessus_instance_ids+=("$instance_id")
+    fi
 
     tf_args+=("-target=aws_eip_association.cyhy_nessus_eip_assocs[$index]")
     tf_args+=("-target=aws_instance.cyhy_nessus[$index]")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds some guardrails to account for missing instance IDs when running the `deploy_new_portscan_instance.sh` and `deploy_new_vulnscan_instance.sh` scripts.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I have encountered this before, but if an instance doesn't exist for a scanner index the script will fail when it attempts to run the `aws ec2 terminate-instances` command with the error:

```console
An error occurred (InvalidInstanceID.Malformed) when calling the TerminateInstances operation: Invalid id: "" (expecting "id-...")
```

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes. I used the modified scripts to perform deployments with missing instances in my testing environment.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
