### PR TITLE
Add ClamAV to CyHy Images

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -2,7 +2,7 @@
 # The instance types used for almost all the instances expose EBS
 # volumes as NVMe block devices, so that's why we need nvme here.
 - hosts: all
-  name: Update the base image, install python, add banner, persist journald
+  name: Install NVMe support, add banner, persist journald, and install ClamAV
   become: yes
   become_method: sudo
   roles:

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -9,6 +9,7 @@
     - nvme
     - banner
     - persist_journald
+    - clamav
 
 # The bastion should have as little installed as possible, since it's
 # exposed to the cruel world

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -1,5 +1,7 @@
 - src: https://github.com/cisagov/ansible-role-banner
   name: banner
+- src: https://github.com/cisagov/ansible-role-clamav
+  name: clamav
 - src: https://github.com/cisagov/ansible-role-client-cert-update
   name: client_cert_update
 - src: https://github.com/cisagov/ansible-role-code-gov-update

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -6,7 +6,7 @@
           "delete_on_termination": true,
           "device_name": "xvda",
           "encrypted": true,
-          "volume_size": 8,
+          "volume_size": 10,
           "volume_type": "gp2"
         }
       ],
@@ -22,7 +22,7 @@
           "delete_on_termination": true,
           "device_name": "xvda",
           "encrypted": true,
-          "volume_size": 8,
+          "volume_size": 10,
           "volume_type": "gp2"
         }
       ],


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the playbook for Packer to install [ClamAV](https://www.clamav.net/) on all images using [cisagov/ansible-role-clamav](https://github.com/cisagov/ansible-role-clamav).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is to resolve #313.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I was able to build all of the images and deploy them to my testing environment. When using the [cisagov/clamav-report](https://github.com/cisagov/clamav-report) tool I can see that scanning has occurred.

Inventory file:

```ini
[bod]
bastion.mcdonnnj.bod
docker.mcdonnnj.bod

[cyhy]
bastion.mcdonnnj.cyhy
dashboard.mcdonnnj.cyhy
database1.mcdonnnj.cyhy
portscan[1:4].mcdonnnj.cyhy
reporter.mcdonnnj.cyhy
vulnscan1.mcdonnnj.cyhy
```

Parsed results from the CSV in the format `COMPUTER_NAME :: LAST_SCAN_TIME`:

```log
bastion :: 03/11/2021 06:25:17
bastion :: 03/11/2021 06:25:15
docker :: 03/11/2021 06:25:12
dashboard :: 03/11/2021 06:41:57
database1 :: 03/11/2021 06:35:07
portscan2 :: 03/11/2021 06:32:22
portscan1 :: 03/11/2021 06:32:09
portscan3 :: 03/11/2021 06:32:06
portscan4 :: 03/11/2021 06:31:55
reporter :: 03/11/2021 06:25:12
vulnscan1 :: 03/11/2021 06:41:31
```

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
