### PR TITLE
Import public GPG key for NCPS Analytics Environment

### DIFF
--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -79,9 +79,10 @@
   vars:
     ansible_ssh_pipelining: yes
   loop:
-    - "{{ public_gpg_key }}"
-    - "{{ private_gpg_key }}"
+    - "{{ ncps_ae_public_gpg_key }}"
     - "{{ nsd_public_gpg_key }}"
+    - "{{ private_gpg_key }}"
+    - "{{ public_gpg_key }}"
   loop_control:
     label: "<key redacted>"
 

--- a/ansible/roles/cyhy_feeds/vars/main.yml
+++ b/ansible/roles/cyhy_feeds/vars/main.yml
@@ -10,6 +10,8 @@ public_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/public') }}"
 private_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/private') }}"
 # NSD public GPG key
 nsd_public_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/nsd_public') }}"
+# NCPS Analytics Environment public GPG key
+ncps_ae_public_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/ncps_ae_public') }}"
 
 # cyhy-feeds GPG trust
 gpg_trust: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/trust') }}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a new public GPG key for the NCPS Analytics Environment to the set of keys imported by the `cyhy_feeds` Ansible role.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The NCPS Analytics Environment wants access to our encrypted daily CyHy data feed.  In order to do that, we update our Ansible role to import their key so that it can be used when we encrypt the data.

In addition to the code changes in this PR, I also:
* Added one new SSM parameter `/cyhy/feeds/gpg/ncps_ae_public`, which contains their public GPG key
* Updated existing SSM parameter `/cyhy/feeds/config` so that it includes the GPG ID for the key above; this is how cyhy-feeds will know to encrypt the data with the new key. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I did not test this change.  I will verify that `cyhy-feeds` process continues to work as expected after it is deployed to Production.  I will also coordinate with a contact for the NCPS Analytics Environment to ensure that they are able to successfully decrypt our data.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.

## ✅ Post-Deployment Checklist ##
* [ ] Verify that `cyhy-feeds` process continues to work as expected
* [ ] Confirm that NCPS Analytics Environment team is able to successfully decrypt our data