### PR TITLE
Use the `python3.8` Runtime for the assessment-data-import λ

### DIFF
--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -156,7 +156,7 @@ resource "aws_lambda_function" "adi_lambda" {
   function_name = format("assessment_data_import-%s", terraform.workspace)
   role          = aws_iam_role.adi_lambda_role.arn
   handler       = "lambda_handler.handler"
-  runtime       = "python3.6"
+  runtime       = "python3.8"
   timeout       = 300
   memory_size   = 128
   description   = "Lambda function for importing assessment data"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the lambda configuration for [cisagov/assessment-data-import-lambda](https://github.com/cisagov/assessment-data-import-lambda) to use the `python3.8` runtime.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The last time this was deployed it was erroneously deployed using the `python3.8` runtime. Since it has been running on the `python3.8` runtime with no issues for the past ~nine months, it makes sense to update the configuration to use this runtime.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
The lambda has been processing using the `python3.8` runtime for a while now with no issues reported. Automated tests have no issue with the change in this repository.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
