### PR TITLE
Bump t3.micro Instance Usage to t3.small

### DIFF
--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -16,7 +16,7 @@
         "us-west-1",
         "us-west-2"
       ],
-      "instance_type": "t3.micro",
+      "instance_type": "t3.small",
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -16,7 +16,7 @@
         "us-west-1",
         "us-west-2"
       ],
-      "instance_type": "t3.micro",
+      "instance_type": "t3.small",
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -16,7 +16,7 @@
         "us-west-1",
         "us-west-2"
       ],
-      "instance_type": "t3.micro",
+      "instance_type": "t3.small",
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -16,7 +16,7 @@
         "us-west-1",
         "us-west-2"
       ],
-      "instance_type": "t3.micro",
+      "instance_type": "t3.small",
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -16,7 +16,7 @@
         "us-west-1",
         "us-west-2"
       ],
-      "instance_type": "t3.micro",
+      "instance_type": "t3.small",
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,

--- a/terraform/bod_bastion_ec2.tf
+++ b/terraform/bod_bastion_ec2.tf
@@ -1,7 +1,7 @@
 # The bastion EC2 instance
 resource "aws_instance" "bod_bastion" {
   ami               = data.aws_ami.bastion.id
-  instance_type     = "t3.micro"
+  instance_type     = "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the public subnet

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -122,7 +122,7 @@ resource "aws_iam_instance_profile" "bod_docker" {
 # The docker EC2 instance
 resource "aws_instance" "bod_docker" {
   ami               = data.aws_ami.bod_docker.id
-  instance_type     = local.production_workspace ? "r5.xlarge" : "t3.micro"
+  instance_type     = local.production_workspace ? "r5.xlarge" : "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the private subnet

--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -1,7 +1,7 @@
 # The bastion EC2 instance
 resource "aws_instance" "cyhy_bastion" {
   ami               = data.aws_ami.bastion.id
-  instance_type     = "t3.micro"
+  instance_type     = "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the public subnet

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -112,7 +112,7 @@ resource "aws_iam_instance_profile" "cyhy_mongo" {
 resource "aws_instance" "cyhy_mongo" {
   count                       = local.mongo_instance_count
   ami                         = data.aws_ami.cyhy_mongo.id
-  instance_type               = local.production_workspace ? "m5.12xlarge" : "t3.micro"
+  instance_type               = local.production_workspace ? "m5.12xlarge" : "t3.small"
   availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   subnet_id                   = aws_subnet.cyhy_private_subnet.id
   associate_public_ip_address = false

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -22,7 +22,7 @@ data "aws_ami" "nmap" {
 
 resource "aws_instance" "cyhy_nmap" {
   ami           = data.aws_ami.nmap.id
-  instance_type = local.production_workspace ? "t3.micro" : "t3.micro"
+  instance_type = local.production_workspace ? "t3.small" : "t3.small"
   count         = local.nmap_instance_count
 
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -73,7 +73,7 @@ resource "aws_iam_instance_profile" "cyhy_reporter" {
 
 resource "aws_instance" "cyhy_reporter" {
   ami               = data.aws_ami.reporter.id
-  instance_type     = local.production_workspace ? "c5.2xlarge" : "t3.micro"
+  instance_type     = local.production_workspace ? "c5.2xlarge" : "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the private subnet

--- a/terraform/mgmt_bastion_ec2.tf
+++ b/terraform/mgmt_bastion_ec2.tf
@@ -3,7 +3,7 @@ resource "aws_instance" "mgmt_bastion" {
   count = var.enable_mgmt_vpc ? 1 : 0
 
   ami               = data.aws_ami.bastion.id
-  instance_type     = "t3.micro"
+  instance_type     = "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the public subnet


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates any configuration that uses the `t3.micro` instance type to use a `t3.small` instance instead.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I was unable to successfully build a `bastion` instance when preparing to test for a redeployment. The problem was a timeout when waiting for the ClamAV base definitions file to be created. I tested with the `nmap` type with the same result. Upon investigating I found log messages with `Can't allocate memory` during the initial update. After conferring with @jsf9k he agreed that bumping the instance type for more memory was the likely solution. After changing the build instance for the `bastion` type to a `t3.small` I was able to successfully create an AMI with Packer.

The running instance types are also updated to prevent this issue from arising again while running.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
I was able to successfully build a `bastion` AMI once the change was made.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
