### PR TITLE
Fix Variable Usage in Shell Task

### DIFF
--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -74,7 +74,7 @@
 # The --batch flag makes sure that gpg2 doesn't attempt to do anything
 # interactive.
 - name: Import gpg keys
-  shell: "echo '{{ item }}' | gpg2 --trustdb-name /var/cyhy/.gnupg/trustdb.gpg --import --batch"
+  shell: "echo {{ item | quote }} | gpg2 --trustdb-name /var/cyhy/.gnupg/trustdb.gpg --import --batch"
   become_user: cyhy
   vars:
     ansible_ssh_pipelining: yes

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -87,7 +87,10 @@
     label: "<key redacted>"
 
 - name: Import gpg trust
-  shell: "echo {{ gpg_trust }} | gpg2 --import-ownertrust --batch"
+  # The value stored in the Parameter Store has a newline so we trim the value
+  # before quoting. A quoted newline causes a failure when gpg2 attempts to
+  # import the owner trust.
+  shell: "echo {{ gpg_trust | trim | quote }} | gpg2 --import-ownertrust --batch"
   become_user: cyhy
   vars:
     ansible_ssh_pipelining: yes


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes an issue with a task that uses the shell module. it quotes a variable that was previously unquoted and changes another to use the `quote` filter instead of manually used single quotes.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When attempting to deploy a new database instance in my testing environment the `cyhy_feeeds` role failed with the following output:

```console
"stderr_lines": ["/bin/sh: 2: Syntax error: \"|\" unexpected"]
```

After conferring with @jsf9k we determined that it needed to be quoted now. When testing that we were met with the following error:

```console
"stderr": "gpg: inserting ownertrust of 6\ngpg: error in '[stdin]': colon missing"
```

We verified that there was a newline in the value in SSM and added a `trim` filter to remove that before the `quote` filter.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
I verified I could redeploy the provisioner that uses this Ansible role successfully with the changes in place.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
