### PR TITLE
Bump up the reporter instance type from c5.2xlarge to c5.4xlarge

### DIFF
--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -73,7 +73,7 @@ resource "aws_iam_instance_profile" "cyhy_reporter" {
 
 resource "aws_instance" "cyhy_reporter" {
   ami               = data.aws_ami.reporter.id
-  instance_type     = local.production_workspace ? "c5.2xlarge" : "t3.small"
+  instance_type     = local.production_workspace ? "c5.4xlarge" : "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the private subnet


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the report instance type from `c5.2xlarge` to `c5.4xlarge`.

## 💭 Motivation and context ##

The `c5.2xlarge` instance type no longer has enough memory to generate the `CI_HEALTHCARE_AND_PUBLIC_HEALTH` report.

## 🧪 Testing ##

I manually bumped up the instance type in our production environment 

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
