### PR TITLE
Upgrade volumes to gp3 and io2

### DIFF
--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -7,7 +7,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "{{user `ami_prefix`}}-bastion-hvm-{{timestamp}}-x86_64-ebs",
@@ -23,7 +23,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "us-east-2",

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -7,7 +7,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "{{user `ami_prefix`}}-dashboard-hvm-{{timestamp}}-x86_64-ebs",
@@ -23,7 +23,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "us-east-2",

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -7,7 +7,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 10,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "{{user `ami_prefix`}}-docker-hvm-{{timestamp}}-x86_64-ebs",
@@ -23,7 +23,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 10,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "us-east-2",

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -7,7 +7,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "{{user `ami_prefix`}}-mongo-hvm-{{timestamp}}-x86_64-ebs",
@@ -23,7 +23,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "us-east-2",

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -7,7 +7,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "{{user `ami_prefix`}}-nessus-hvm-{{timestamp}}-x86_64-ebs",
@@ -23,7 +23,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "us-east-2",

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -7,7 +7,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "{{user `ami_prefix`}}-nmap-hvm-{{timestamp}}-x86_64-ebs",
@@ -23,7 +23,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "us-east-2",

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -7,7 +7,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 10,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "{{user `ami_prefix`}}-reporter-hvm-{{timestamp}}-x86_64-ebs",
@@ -23,7 +23,7 @@
           "device_name": "xvda",
           "encrypted": true,
           "volume_size": 10,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "us-east-2",

--- a/terraform/bod_bastion_ec2.tf
+++ b/terraform/bod_bastion_ec2.tf
@@ -9,9 +9,8 @@ resource "aws_instance" "bod_bastion" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 20
-    delete_on_termination = true
+    volume_size = 20
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -129,9 +129,8 @@ resource "aws_instance" "bod_docker" {
   subnet_id = aws_subnet.bod_docker_subnet.id
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 200
-    delete_on_termination = true
+    volume_size = 200
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -191,7 +191,7 @@ module "bod_docker_ansible_provisioner" {
 # (https://github.com/hashicorp/terraform/issues/3116).
 resource "aws_ebs_volume" "bod_report_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-  type              = "io1"
+  type              = "io2"
   size              = local.production_workspace ? 200 : 5
   iops              = 100
   encrypted         = true

--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -9,9 +9,8 @@ resource "aws_instance" "cyhy_bastion" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 20
-    delete_on_termination = true
+    volume_size = 20
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform/cyhy_dashboard_ec2.tf
+++ b/terraform/cyhy_dashboard_ec2.tf
@@ -31,9 +31,8 @@ resource "aws_instance" "cyhy_dashboard" {
   associate_public_ip_address = false
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = local.production_workspace ? 100 : 10
-    delete_on_termination = true
+    volume_size = local.production_workspace ? 100 : 10
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -118,9 +118,8 @@ resource "aws_instance" "cyhy_mongo" {
   associate_public_ip_address = false
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 100
-    delete_on_termination = true
+    volume_size = 100
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -182,7 +182,7 @@ module "cyhy_mongo_ansible_provisioner" {
 # (https://github.com/hashicorp/terraform/issues/3116).
 resource "aws_ebs_volume" "cyhy_mongo_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-  type              = "io1"
+  type              = "io2"
   size              = local.production_workspace ? 1024 : 20
   iops              = 1000
   encrypted         = true
@@ -196,7 +196,7 @@ resource "aws_ebs_volume" "cyhy_mongo_data" {
 
 resource "aws_ebs_volume" "cyhy_mongo_journal" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-  type              = "io1"
+  type              = "io2"
   size              = 8
   iops              = 250
   encrypted         = true
@@ -210,7 +210,7 @@ resource "aws_ebs_volume" "cyhy_mongo_journal" {
 
 resource "aws_ebs_volume" "cyhy_mongo_log" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-  type              = "io1"
+  type              = "io2"
   size              = 8
   iops              = 100
   encrypted         = true

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -29,9 +29,8 @@ resource "aws_instance" "cyhy_nessus" {
   subnet_id = aws_subnet.cyhy_vulnscanner_subnet.id
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = local.production_workspace ? 100 : 16
-    delete_on_termination = true
+    volume_size = local.production_workspace ? 100 : 16
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [
@@ -125,7 +124,7 @@ resource "aws_ebs_volume" "nessus_cyhy_runner_data" {
   count             = length(aws_instance.cyhy_nessus)
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
-  type      = "gp2"
+  type      = "gp3"
   size      = local.production_workspace ? 2 : 1
   encrypted = true
 

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -34,9 +34,8 @@ resource "aws_instance" "cyhy_nmap" {
   subnet_id = aws_subnet.cyhy_portscanner_subnet.id
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = local.production_workspace ? 20 : 8
-    delete_on_termination = true
+    volume_size = local.production_workspace ? 20 : 8
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [
@@ -128,7 +127,7 @@ resource "aws_ebs_volume" "nmap_cyhy_runner_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # availability_zone = "${element(data.aws_availability_zones.all.names, count.index)}"
-  type      = "gp2"
+  type      = "gp3"
   size      = local.production_workspace ? 2 : 1
   encrypted = true
 

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -81,9 +81,8 @@ resource "aws_instance" "cyhy_reporter" {
   associate_public_ip_address = false
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 50
-    delete_on_termination = true
+    volume_size = 50
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -138,7 +138,7 @@ module "cyhy_reporter_ansible_provisioner" {
 # (https://github.com/hashicorp/terraform/issues/3116).
 resource "aws_ebs_volume" "cyhy_reporter_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-  type              = "io1"
+  type              = "io2"
   size              = local.production_workspace ? 500 : 5
   iops              = 100
   encrypted         = true

--- a/terraform/mgmt_bastion_ec2.tf
+++ b/terraform/mgmt_bastion_ec2.tf
@@ -11,9 +11,8 @@ resource "aws_instance" "mgmt_bastion" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 20
-    delete_on_termination = true
+    volume_size = 20
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform/mgmt_nessus_ec2.tf
+++ b/terraform/mgmt_nessus_ec2.tf
@@ -8,9 +8,8 @@ resource "aws_instance" "mgmt_nessus" {
   subnet_id = aws_subnet.mgmt_private_subnet[0].id
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = local.production_workspace ? 100 : 16
-    delete_on_termination = true
+    volume_size = local.production_workspace ? 100 : 16
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -29,9 +29,8 @@ resource "aws_instance" "nessus" {
   subnet_id = aws_subnet.nessus_scanner_subnet.id
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = local.production_workspace ? 100 : 16
-    delete_on_termination = true
+    volume_size = local.production_workspace ? 100 : 16
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Upgrades volume types to from gp2 to gp3 and from io1 to io2
- Removes the `delete_on_termination` line from the root volume configuration

## 💭 Motivation and context ##

- gp3 is 20% cheaper, and the baseline configuration offers better performance than gp2 for volumes smaller than 2TB.  It also allows the volume size and IOPS to be configured separately, whereas the two are intertwined with gp2.
- io2 offers 100x more reliability than io1 at the same cost.
- `delete_on_termination = true` is the default, so there is no need to specify it.

## 🧪 Testing ##

@mcdonnnj did a `terraform plan` for the `terraform` directory and verified that all the volume changes would be done in place.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
