### PR TITLE
Fix Lambda logging functionality

### DIFF
--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -30,12 +30,23 @@ data "aws_iam_policy_document" "adi_lambda_cloudwatch_doc" {
 
     actions = [
       "logs:CreateLogGroup",
+    ]
+
+    resources = [
+      aws_cloudwatch_log_group.adi_lambda_logs.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]
 
     resources = [
-      aws_cloudwatch_log_group.adi_lambda_logs.arn,
+      "${aws_cloudwatch_log_group.adi_lambda_logs.arn}:*",
     ]
   }
 }

--- a/terraform/bod_lambdas.tf
+++ b/terraform/bod_lambdas.tf
@@ -32,12 +32,23 @@ data "aws_iam_policy_document" "lambda_cloudwatch_docs" {
 
     actions = [
       "logs:CreateLogGroup",
+    ]
+
+    resources = [
+      aws_cloudwatch_log_group.lambda_logs[count.index].arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]
 
     resources = [
-      aws_cloudwatch_log_group.lambda_logs[count.index].arn,
+      "${aws_cloudwatch_log_group.lambda_logs[count.index].arn}:*",
     ]
   }
 }

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -30,12 +30,23 @@ data "aws_iam_policy_document" "fdi_lambda_cloudwatch_doc" {
 
     actions = [
       "logs:CreateLogGroup",
+    ]
+
+    resources = [
+      aws_cloudwatch_log_group.fdi_lambda_logs.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]
 
     resources = [
-      aws_cloudwatch_log_group.fdi_lambda_logs.arn,
+      "${aws_cloudwatch_log_group.fdi_lambda_logs.arn}:*",
     ]
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adjusts the IAM policy documents for CloudWatch log group access used by lambdas in the main (`terraform/`) Terraform configuration. This adjustment brings them into alignment with the [AWS documentation](https://docs.aws.amazon.com/lambda/latest/operatorguide/access-logs.html) and restores functional logging for the lambdas in this configuration.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We noticed that logging from lambdas stopped working around the TF 0.13+ update (#336) performed earlier this year. During this update we also upgraded from v2 to v3 of the AWS provider. I can only surmise that something automatically handled in v2 was no longer done in v3. When checking the AWS documentation for this kind of policy I noticed that we did not match the example given in that only the ARN for the log group was used as a resource. We needed to at minimum update the resources for the policy to allow access to sub-resources of the main log group ARN (e.g. `arn:account:information:log-group:/aws/lambda/functionname -> arn:account:information:log-group:/aws/lambda/functionname:*`). I decided to update the policy to more closely follow the AWS example as part of the process.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. I did a targeted apply for the `adi` lambda's policy and verified that new log streams were created when it was run.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
