### PR TITLE
Update configuration to fix Packer image building

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,21 @@
 The AMIs are built like so:
 
 ```console
-ansible-galaxy install -r packer/ansible/requirements.yml
-packer build packer/bastion.json
-packer build packer/docker.json
-packer build packer/mongo.json
-packer build packer/nessus.json
-packer build packer/nmap.json
-AWS_MAX_ATTEMPTS=60 AWS_POLL_DELAY_SECONDS=60 packer build packer/reporter.json
-AWS_MAX_ATTEMPTS=60 AWS_POLL_DELAY_SECONDS=60 packer build packer/dashboard.json
+cd packer
+ansible-galaxy install --role-file ansible/requirements.yml
+packer build bastion.json
+packer build dashboard.json
+packer build docker.json
+packer build mongo.json
+packer build nessus.json
+packer build nmap.json
+packer build reporter.json
 ```
-
-Note the environment variables in the `packer` command lines
-corresponding to `feeds.json` and `reporter.json`.  They are present
-because the AMIs produced by those lines are large and need extra time
-to be copied, as discussed
-[here](https://github.com/hashicorp/packer/issues/6536#issuecomment-407925535).
 
 Also note that
 
 ```console
-ansible-galaxy install --force -r packer/ansible/requirements.yml
+ansible-galaxy install --force --role-file ansible/requirements.yml
 ```
 
 will update the roles that are being pulled from external sources.  This

--- a/packer/ansible.cfg
+++ b/packer/ansible.cfg
@@ -1,0 +1,12 @@
+# Options for SSH connections
+[ssh_connection]
+# OpenSSH 8.8 disables RSA signatures that use the SHA-1 hash algorithm
+# by default. Since this key type is used by Ansible when connecting to the
+# remote instance we must add it to the allowed algorithms. Please see the
+# OpenSSH 8,8 release notes for more information:
+# https://www.openssh.com/txt/release-8.8
+# The following issues are related to Packer's auto-generated SSH key using a
+# deprecated (disabled as of OpenSSH 8.8) key algorithm:
+# https://github.com/hashicorp/packer-plugin-ansible/issues/53
+# https://github.com/hashicorp/packer-plugin-ansible/issues/69
+ssh_args = -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -54,21 +54,21 @@
       "groups": [
         "bastion"
       ],
-      "playbook_file": "packer/ansible/upgrade.yml",
+      "playbook_file": "ansible/upgrade.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "bastion"
       ],
-      "playbook_file": "packer/ansible/python.yml",
+      "playbook_file": "ansible/python.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "bastion"
       ],
-      "playbook_file": "packer/ansible/playbook.yml",
+      "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
   ]

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -54,21 +54,21 @@
       "groups": [
         "dashboard"
       ],
-      "playbook_file": "packer/ansible/upgrade.yml",
+      "playbook_file": "ansible/upgrade.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "dashboard"
       ],
-      "playbook_file": "packer/ansible/python.yml",
+      "playbook_file": "ansible/python.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "cyhy_dashboard"
       ],
-      "playbook_file": "packer/ansible/playbook.yml",
+      "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
   ]

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -54,14 +54,14 @@
       "groups": [
         "docker"
       ],
-      "playbook_file": "packer/ansible/upgrade.yml",
+      "playbook_file": "ansible/upgrade.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "docker"
       ],
-      "playbook_file": "packer/ansible/python.yml",
+      "playbook_file": "ansible/python.yml",
       "type": "ansible"
     },
     {
@@ -70,7 +70,7 @@
         "code_gov",
         "client_cert"
       ],
-      "playbook_file": "packer/ansible/playbook.yml",
+      "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
   ]

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -54,14 +54,14 @@
       "groups": [
         "mongo"
       ],
-      "playbook_file": "packer/ansible/upgrade.yml",
+      "playbook_file": "ansible/upgrade.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "mongo"
       ],
-      "playbook_file": "packer/ansible/python.yml",
+      "playbook_file": "ansible/python.yml",
       "type": "ansible"
     },
     {
@@ -70,7 +70,7 @@
         "cyhy_commander",
         "cyhy_archive"
       ],
-      "playbook_file": "packer/ansible/playbook.yml",
+      "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
   ]

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -54,21 +54,21 @@
       "groups": [
         "nessus"
       ],
-      "playbook_file": "packer/ansible/upgrade.yml",
+      "playbook_file": "ansible/upgrade.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "nessus"
       ],
-      "playbook_file": "packer/ansible/python.yml",
+      "playbook_file": "ansible/python.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "nessus"
       ],
-      "playbook_file": "packer/ansible/playbook.yml",
+      "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
   ]

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -54,21 +54,21 @@
       "groups": [
         "nmap"
       ],
-      "playbook_file": "packer/ansible/upgrade.yml",
+      "playbook_file": "ansible/upgrade.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "nmap"
       ],
-      "playbook_file": "packer/ansible/python.yml",
+      "playbook_file": "ansible/python.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "nmap"
       ],
-      "playbook_file": "packer/ansible/playbook.yml",
+      "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
   ]

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -54,21 +54,21 @@
       "groups": [
         "reporter"
       ],
-      "playbook_file": "packer/ansible/upgrade.yml",
+      "playbook_file": "ansible/upgrade.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "reporter"
       ],
-      "playbook_file": "packer/ansible/python.yml",
+      "playbook_file": "ansible/python.yml",
       "type": "ansible"
     },
     {
       "groups": [
         "cyhy_reporter"
       ],
-      "playbook_file": "packer/ansible/playbook.yml",
+      "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
   ]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Packer configuration so AMIs can be built when building from systems running [OpenSSH 8.8]+. This is done by adding an Ansible configuration file (`ansible.cfg`) and updating the build directions.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In [OpenSSH 8.8] RSA signatures that use SHA-1 are now disabled by default. This breaks our Packer image building configuration because the temporary keys created by Packer's [Ansible provisioner] are RSA keys using SHA-1. Until the provisioner has been updated to use a newer key algorithm we need to support `ssh-rsa` connections to build images using Packer when using the [Ansible provisioner]. Although we can specify the necessary options in the provisioner configuration, it is onerous to put it in every [Ansible provisioner] block in this configuration. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I was able to successfully build all AMIs defined in our configuration.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

[OpenSSH 8.8]: https://www.openssh.com/txt/release-8.8
[Ansible provisioner]: https://github.com/hashicorp/packer-plugin-ansible