### PR TITLE
Add a script to update the MaxMind GeoIP2 database on a remote host

### DIFF
--- a/terraform/scripts/update_geoip.sh
+++ b/terraform/scripts/update_geoip.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+# update_geoip.sh - Update the MaxMind GeoIP2 database on a target system over
+#  Secure Shell (SSH).  This is done by downloading and verifying the database
+#  locally before using Secure Copy (SCP) to copy the database archive to the
+#  target system and extracting it to the appropriate path on the target system
+#  using SSH.
+#
+# NOTES:
+#  - This requires the following:
+#     * AWS CLI and SSH on the local system.
+#     * An appropriate SSH configuration to connect to the target system from
+#       the local system.
+#     * Ability to sudo on the target system from the account that is used to
+#       connect.
+#     * A valid MaxMind GeoIP2 license key stored in the AWS SSM Parameter
+#       Store in the `/cyhy/core/geoip/license_key` key.
+#     * An appropriate AWS IAM configuration allowing access to the
+#       aforementioned AWS SSM Parameter Store key.
+
 set -o nounset
 set -o errexit
 set -o pipefail

--- a/terraform/scripts/update_geoip.sh
+++ b/terraform/scripts/update_geoip.sh
@@ -71,6 +71,7 @@ if [ "$geoip_remote_md5" != "$geoip_local_md5" ]; then
   exit
 fi
 
+# Copy the file to the remote host while preserving the file's timestamps (-p)
 scp -p "$geoip_local_file" "$target_name":
 # Disable SC22029 "Note that, unescaped, this expands on the client side." check
 # because we are populating values from the client side to use on the remote

--- a/terraform/scripts/update_geoip.sh
+++ b/terraform/scripts/update_geoip.sh
@@ -71,7 +71,7 @@ if [ "$geoip_remote_md5" != "$geoip_local_md5" ]; then
   exit
 fi
 
-scp "$geoip_local_file" "$target_name":
+scp -p "$geoip_local_file" "$target_name":
 # Disable SC22029 "Note that, unescaped, this expands on the client side." check
 # because we are populating values from the client side to use on the remote
 # side.

--- a/terraform/scripts/update_geoip.sh
+++ b/terraform/scripts/update_geoip.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Print usage information and exit.
+function usage {
+  echo "Usage:"
+  echo "  ${0##*/} [options]"
+  echo
+  echo "Options:"
+  echo "  -h, --help         Show the help message."
+  echo "  -p, --remote-path  Path on the remote host to use."
+  echo "  -t, --target-host  Host to update."
+  exit "$1"
+}
+
+target_name="database1.prod-a.cyhy"
+target_path="/usr/local/share/GeoIP"
+
+while (("$#")); do
+  case "$1" in
+    -h | --help)
+      usage 0
+      ;;
+    -p | --remote-path)
+      target_path="$1"
+      shift 1
+      ;;
+    -t | --target-host)
+      target_name="$1"
+      shift 1
+      ;;
+    -*)
+      usage 1
+      ;;
+  esac
+done
+
+maxmind_url_format="%s?edition_id=%s&suffix=%s&license_key=%s"
+maxmind_url_base="https://download.maxmind.com/app/geoip_download"
+maxmind_edition="GeoIP2-City"
+maxmind_suffix_file="tar.gz"
+maxmind_suffix_checksum="tar.gz.md5"
+maxmind_license_key=$(aws ssm get-parameter \
+  --output text \
+  --name "/cyhy/core/geoip/license_key" \
+  --with-decryption \
+  | awk -F"\t" '{print $6;}')
+
+# Disable SC2059 "Don't use variables in the printf format string." check
+# because the variable contains a printf format string.
+# shellcheck disable=SC2059
+remote_url_md5sum=$(printf "$maxmind_url_format" "$maxmind_url_base" "$maxmind_edition" "$maxmind_suffix_checksum" "$maxmind_license_key")
+# shellcheck disable=SC2059
+remote_url_targz=$(printf "$maxmind_url_format" "$maxmind_url_base" "$maxmind_edition" "$maxmind_suffix_file" "$maxmind_license_key")
+
+geoip_remote_md5="$(curl -s "$remote_url_md5sum")"
+geoip_local_file="$(printf "%s.%s" "$maxmind_edition" "$maxmind_suffix_file")"
+
+curl -s --output "$geoip_local_file" "$remote_url_targz"
+
+geoip_local_md5=$(md5sum "$geoip_local_file" | awk '{print $1;}')
+
+if [ "$geoip_remote_md5" != "$geoip_local_md5" ]; then
+  echo "md5sum mismatch!"
+  echo "Remote md5sum: $geoip_remote_md5"
+  echo "Local File md5sum: $geoip_local_md5"
+  rm "$geoip_local_file"
+  exit
+fi
+
+scp "$geoip_local_file" "$target_name":
+# Disable SC22029 "Note that, unescaped, this expands on the client side." check
+# because we are populating values from the client side to use on the remote
+# side.
+# shellcheck disable=SC2029
+ssh "$target_name" "sudo cp $geoip_local_file $target_path; cd $target_path; sudo tar -xzf $geoip_local_file --strip-components=1"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a utility script that pulls the latest version of the [MaxMind GeoIP2 City database](https://www.maxmind.com/en/geoip2-city) locally and then pushes it to a remote host using SCP.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I've had this script laying around as a way to update the GeoIP2 database on a database instance between re-deployments. Since the `terraform/` configuration does not allow internet access for a deployed database instance this is a workaround method.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I've confirmed that this script works as intended.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
