### PR TITLE
Reorganize Terraform `variables.tf` files

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -614,11 +614,11 @@ terraform apply -var-file=<your_workspace>.tfvars
 | assessment\_data\_s3\_bucket | The name of the bucket where the assessment data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | `""` | no |
 | aws\_availability\_zone | The AWS availability zone to deploy into (e.g. a, b, c, etc.). | `string` | `"a"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
-| bod\_nat\_gateway\_eip | The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created.. | `string` | `""` | no |
+| bod\_nat\_gateway\_eip | The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created. | `string` | `""` | no |
 | create\_bod\_flow\_logs | Whether or not to create flow logs for the BOD 18-01 VPC. | `bool` | `false` | no |
 | create\_cyhy\_flow\_logs | Whether or not to create flow logs for the CyHy VPC. | `bool` | `false` | no |
 | create\_mgmt\_flow\_logs | Whether or not to create flow logs for the Management VPC. | `bool` | `false` | no |
-| cyhy\_archive\_bucket\_name | S3 bucket for storing compressed archive files created by cyhy-archive | `string` | `"ncats-cyhy-archive"` | no |
+| cyhy\_archive\_bucket\_name | S3 bucket for storing compressed archive files created by cyhy-archive. | `string` | `"ncats-cyhy-archive"` | no |
 | cyhy\_elastic\_ip\_cidr\_block | The CIDR block of elastic addresses available for use by CyHy scanner instances. | `string` | `""` | no |
 | cyhy\_portscan\_first\_elastic\_ip\_offset | The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy portscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first portscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional portscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available. | `number` | `0` | no |
 | cyhy\_vulnscan\_first\_elastic\_ip\_offset | The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy vulnscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first vulnscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional vulnscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available. | `number` | `1` | no |
@@ -641,23 +641,23 @@ terraform apply -var-file=<your_workspace>.tfvars
 | lambda\_function\_bucket | The name of the S3 bucket where the Lambda function zip files reside.  Terraform cannot access buckets that are not in the provider's region, so the region name will be appended to the bucket name to obtain the actual bucket where the zips are stored.  So if we are working in region us-west-1 and this variable has the value buckethead, then the zips will be looked for in the bucket buckethead-us-west-1. | `string` | n/a | yes |
 | lambda\_function\_keys | The keys (names) of the zip files for the Lambda functions inside the S3 bucket.  The keys for the map are the values in scan\_types. | `map(string)` | n/a | yes |
 | lambda\_function\_names | The names to use for the Lambda functions.  The keys are the values in scan\_types. | `map(string)` | n/a | yes |
-| mgmt\_nessus\_activation\_codes | A list of strings containing Nessus activation codes used in the management VPC | `list(string)` | n/a | yes |
+| mgmt\_nessus\_activation\_codes | A list of strings containing Nessus activation codes used in the management VPC. | `list(string)` | n/a | yes |
 | mgmt\_nessus\_instance\_count | The number of Nessus instances to create if a management environment is set to be created. | `number` | `1` | no |
-| mongo\_disks | n/a | `map(string)` | ```{ "data": "/dev/xvdb", "journal": "/dev/xvdc", "log": "/dev/xvdd" }``` | no |
+| mongo\_disks | The data volumes for the mongo instance(s). | `map(string)` | ```{ "data": "/dev/xvdb", "journal": "/dev/xvdc", "log": "/dev/xvdd" }``` | no |
 | mongo\_instance\_count | The number of Mongo instances to create. | `number` | `1` | no |
-| nessus\_activation\_codes | A list of strings containing Nessus activation codes | `list(string)` | n/a | yes |
-| nessus\_cyhy\_runner\_disk | The cyhy-runner data volume for the nessus instance(s) | `string` | `"/dev/xvdb"` | no |
+| nessus\_activation\_codes | A list of strings containing Nessus activation codes. | `list(string)` | n/a | yes |
+| nessus\_cyhy\_runner\_disk | The cyhy-runner data volume for the Nessus instance(s). | `string` | `"/dev/xvdb"` | no |
 | nessus\_instance\_count | The number of Nessus instances to create. | `number` | n/a | yes |
-| nmap\_cyhy\_runner\_disk | The cyhy-runner data volume for the nmap instance(s) | `string` | `"/dev/nvme1n1"` | no |
-| nmap\_instance\_count | The number of nmap instances to create. | `number` | n/a | yes |
-| remote\_ssh\_user | The username to use when sshing to the EC2 instances | `any` | n/a | yes |
+| nmap\_cyhy\_runner\_disk | The cyhy-runner data volume for the Nmap instance(s). | `string` | `"/dev/nvme1n1"` | no |
+| nmap\_instance\_count | The number of Nmap instances to create. | `number` | n/a | yes |
+| remote\_ssh\_user | The username to use when sshing to the EC2 instances. | `string` | n/a | yes |
 | reporter\_mailer\_override\_filename | This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer. | `string` | `"docker-compose.cyhy.yml"` | no |
 | scan\_types | The scan types that can be run. | `list(string)` | n/a | yes |
 | ses\_aws\_region | The AWS region where SES is configured. | `string` | `"us-east-1"` | no |
 | ses\_role\_arn | The ARN of the role that must be assumed in order to send emails. | `string` | n/a | yes |
-| tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
-| trusted\_ingress\_networks\_ipv4 | IPv4 CIDR blocks from which to allow ingress to the bastion server | `list(string)` | ```[ "0.0.0.0/0" ]``` | no |
-| trusted\_ingress\_networks\_ipv6 | IPv6 CIDR blocks from which to allow ingress to the bastion server | `list(string)` | ```[ "::/0" ]``` | no |
+| tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
+| trusted\_ingress\_networks\_ipv4 | IPv4 CIDR blocks from which to allow ingress to the bastion server. | `list(string)` | ```[ "0.0.0.0/0" ]``` | no |
+| trusted\_ingress\_networks\_ipv6 | IPv6 CIDR blocks from which to allow ingress to the bastion server. | `list(string)` | ```[ "::/0" ]``` | no |
 
 ## Outputs ##
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,68 +5,68 @@
 # ------------------------------------------------------------------------------
 
 variable "assessment_data_filename" {
-  type        = string
   description = "The name of the assessment data JSON file that can be found in the assessment_data_s3_bucket."
+  type        = string
 }
 
 variable "assessment_data_import_lambda_s3_bucket" {
-  type        = string
   description = "The name of the bucket where the assessment data import Lambda function can be found.  This bucket should be created with the cisagov/assessment-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+  type        = string
 }
 
 variable "assessment_data_import_lambda_s3_key" {
-  type        = string
   description = "The key (name) of the zip file for the assessment data import Lambda function inside the S3 bucket."
+  type        = string
 }
 
 variable "dmarc_import_es_role_arn" {
-  type        = string
   description = "The ARN of the role that must be assumed in order to read the dmarc-import Elasticsearch database."
+  type        = string
 }
 
 variable "findings_data_field_map" {
-  type        = string
   description = "The key for the file storing field name mappings in JSON format."
+  type        = string
 }
 
 variable "findings_data_import_lambda_s3_bucket" {
-  type        = string
   description = "The name of the bucket where the findings data import Lambda function can be found.  This bucket should be created with the cisagov/findings-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+  type        = string
 }
 
 variable "findings_data_import_lambda_s3_key" {
-  type        = string
   description = "The key (name) of the zip file for the findings data import Lambda function inside the S3 bucket."
+  type        = string
 }
 
 variable "findings_data_input_suffix" {
-  type        = string
   description = "The suffix used by files found in the findings_data_s3_bucket that contain findings data."
+  type        = string
 }
 
 variable "lambda_function_bucket" {
-  type        = string
   description = "The name of the S3 bucket where the Lambda function zip files reside.  Terraform cannot access buckets that are not in the provider's region, so the region name will be appended to the bucket name to obtain the actual bucket where the zips are stored.  So if we are working in region us-west-1 and this variable has the value buckethead, then the zips will be looked for in the bucket buckethead-us-west-1."
+  type        = string
 }
 
 variable "lambda_function_keys" {
-  type        = map(string)
   description = "The keys (names) of the zip files for the Lambda functions inside the S3 bucket.  The keys for the map are the values in scan_types."
+  type        = map(string)
 }
 
 variable "lambda_function_names" {
-  type        = map(string)
   description = "The names to use for the Lambda functions.  The keys are the values in scan_types."
+  type        = map(string)
 }
 
 variable "mgmt_nessus_activation_codes" {
-  type        = list(string)
   description = "A list of strings containing Nessus activation codes used in the management VPC"
+  type        = list(string)
 }
 
 variable "nessus_activation_codes" {
-  type        = list(string)
   description = "A list of strings containing Nessus activation codes"
+  type        = list(string)
 }
 
 variable "nessus_instance_count" {
@@ -81,16 +81,17 @@ variable "nmap_instance_count" {
 
 variable "remote_ssh_user" {
   description = "The username to use when sshing to the EC2 instances"
+  type        = string
 }
 
 variable "scan_types" {
-  type        = list(string)
   description = "The scan types that can be run."
+  type        = list(string)
 }
 
 variable "ses_role_arn" {
-  type        = string
   description = "The ARN of the role that must be assumed in order to send emails."
+  type        = string
 }
 
 # ------------------------------------------------------------------------------
@@ -100,104 +101,111 @@ variable "ses_role_arn" {
 # ------------------------------------------------------------------------------
 
 variable "assessment_data_import_db_hostname" {
-  type        = string
-  description = "The hostname that has the database to store the assessment data in."
   default     = ""
+  description = "The hostname that has the database to store the assessment data in."
+  type        = string
 }
 
 variable "assessment_data_import_db_port" {
-  type        = string
-  description = "The port that the database server is listening on."
   default     = ""
+  description = "The port that the database server is listening on."
+  type        = string
 }
 
 variable "assessment_data_import_ssm_db_name" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the name of the database to store the assessment data in."
   default     = ""
+  description = "The name of the parameter in AWS SSM that holds the name of the database to store the assessment data in."
+  type        = string
 }
 
 variable "assessment_data_import_ssm_db_password" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the assessment database."
   default     = ""
+  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the assessment database."
+  type        = string
 }
 
 variable "assessment_data_import_ssm_db_user" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the database username with write permission to the assessment database."
   default     = ""
+  description = "The name of the parameter in AWS SSM that holds the database username with write permission to the assessment database."
+  type        = string
 }
 
 variable "assessment_data_s3_bucket" {
-  type        = string
-  description = "The name of the bucket where the assessment data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
   default     = ""
+  description = "The name of the bucket where the assessment data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+  type        = string
 }
 
 variable "aws_availability_zone" {
-  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
   default     = "a"
+  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  type        = string
 }
 
 variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  type        = string
 }
 
 variable "bod_nat_gateway_eip" {
-  description = "The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created.."
   default     = ""
+  description = "The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created.."
+  type        = string
 }
 
 variable "create_bod_flow_logs" {
-  type        = bool
-  description = "Whether or not to create flow logs for the BOD 18-01 VPC."
   default     = false
+  description = "Whether or not to create flow logs for the BOD 18-01 VPC."
+  type        = bool
 }
 
 variable "create_cyhy_flow_logs" {
-  type        = bool
-  description = "Whether or not to create flow logs for the CyHy VPC."
   default     = false
+  description = "Whether or not to create flow logs for the CyHy VPC."
+  type        = bool
 }
 
 variable "create_mgmt_flow_logs" {
-  type        = bool
-  description = "Whether or not to create flow logs for the Management VPC."
   default     = false
+  description = "Whether or not to create flow logs for the Management VPC."
+  type        = bool
 }
 
 variable "cyhy_archive_bucket_name" {
-  description = "S3 bucket for storing compressed archive files created by cyhy-archive"
   default     = "ncats-cyhy-archive"
+  description = "S3 bucket for storing compressed archive files created by cyhy-archive"
+  type        = string
 }
 
 variable "cyhy_elastic_ip_cidr_block" {
-  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances."
   default     = ""
+  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances."
+  type        = string
 }
 
 variable "cyhy_portscan_first_elastic_ip_offset" {
-  type        = number
-  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy portscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first portscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional portscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available."
   default     = 0
+  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy portscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first portscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional portscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available."
+  type        = number
 }
 
 variable "cyhy_vulnscan_first_elastic_ip_offset" {
-  type        = number
-  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy vulnscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first vulnscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional vulnscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available."
   default     = 1
+  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy vulnscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first vulnscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional vulnscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available."
+  type        = number
 }
 
 variable "dmarc_import_aws_region" {
-  description = "The AWS region where the dmarc-import Elasticsearch database resides."
   default     = "us-east-1"
+  description = "The AWS region where the dmarc-import Elasticsearch database resides."
+  type        = string
 }
 
 variable "docker_mailer_override_filename" {
-  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the docker EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
   default     = "docker-compose.bod.yml"
+  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the docker EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
+  type        = string
 }
 
 # If additional VPCs are added in the future:
@@ -210,57 +218,57 @@ variable "docker_mailer_override_filename" {
 #  - cyhy_private_security_group_rules.tf
 #  - cyhy_private_acl_rules.tf
 variable "enable_mgmt_vpc" {
-  type        = bool
-  description = "Whether or not to enable unfettered access from the vulnerability scanner in the Management VPC to other VPCs (CyHy, BOD).  This should only be enabled while running security scans from the Management VPC."
   default     = false
+  description = "Whether or not to enable unfettered access from the vulnerability scanner in the Management VPC to other VPCs (CyHy, BOD).  This should only be enabled while running security scans from the Management VPC."
+  type        = bool
 }
 
 variable "findings_data_import_db_hostname" {
-  type        = string
-  description = "The hostname that has the database to store the findings data in."
   default     = ""
+  description = "The hostname that has the database to store the findings data in."
+  type        = string
 }
 
 variable "findings_data_import_db_port" {
-  type        = string
-  description = "The port that the database server is listening on."
   default     = ""
+  description = "The port that the database server is listening on."
+  type        = string
 }
 
 variable "findings_data_import_ssm_db_name" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the name of the database to store the findings data in."
   default     = ""
+  description = "The name of the parameter in AWS SSM that holds the name of the database to store the findings data in."
+  type        = string
 }
 
 variable "findings_data_import_ssm_db_password" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the findings database."
   default     = ""
+  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the findings database."
+  type        = string
 }
 
 variable "findings_data_import_ssm_db_user" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the database username with write permission to the findings database."
   default     = ""
+  description = "The name of the parameter in AWS SSM that holds the database username with write permission to the findings database."
+  type        = string
 }
 
 variable "findings_data_s3_bucket" {
-  type        = string
-  description = "The name of the bucket where the findings data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
   default     = ""
+  description = "The name of the bucket where the findings data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+  type        = string
 }
 
 variable "findings_data_save_failed" {
-  type        = bool
-  description = "Whether or not to save files for imports that have failed."
   default     = true
+  description = "Whether or not to save files for imports that have failed."
+  type        = bool
 }
 
 variable "findings_data_save_succeeded" {
-  type        = bool
-  description = "Whether or not to save files for imports that have succeeded."
   default     = false
+  description = "Whether or not to save files for imports that have succeeded."
+  type        = bool
 }
 
 variable "mgmt_nessus_instance_count" {
@@ -270,12 +278,13 @@ variable "mgmt_nessus_instance_count" {
 }
 
 variable "mongo_disks" {
-  type = map(string)
   default = {
     data    = "/dev/xvdb"
     journal = "/dev/xvdc"
     log     = "/dev/xvdd"
   }
+  description = "The data volumes for the mongo instance(s)."
+  type        = map(string)
 }
 
 variable "mongo_instance_count" {
@@ -285,41 +294,45 @@ variable "mongo_instance_count" {
 }
 
 variable "nessus_cyhy_runner_disk" {
-  description = "The cyhy-runner data volume for the nessus instance(s)"
   default     = "/dev/xvdb"
+  description = "The cyhy-runner data volume for the nessus instance(s)"
+  type        = string
 }
 
 variable "nmap_cyhy_runner_disk" {
-  description = "The cyhy-runner data volume for the nmap instance(s)"
   default     = "/dev/nvme1n1"
+  description = "The cyhy-runner data volume for the nmap instance(s)"
+  type        = string
 }
 
 variable "reporter_mailer_override_filename" {
-  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
   default     = "docker-compose.cyhy.yml"
+  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
+  type        = string
 }
 
 variable "ses_aws_region" {
-  description = "The AWS region where SES is configured."
   default     = "us-east-1"
+  description = "The AWS region where SES is configured."
+  type        = string
 }
 
 variable "tags" {
-  type        = map(string)
-  description = "Tags to apply to all AWS resources created"
   default     = {}
+  description = "Tags to apply to all AWS resources created"
+  type        = map(string)
 }
 
 # This should be overridden by a production.tfvars file,
 # most likely stored outside of version control
 variable "trusted_ingress_networks_ipv4" {
-  type        = list(string)
-  description = "IPv4 CIDR blocks from which to allow ingress to the bastion server"
   default     = ["0.0.0.0/0"]
+  description = "IPv4 CIDR blocks from which to allow ingress to the bastion server"
+  type        = list(string)
 }
 
 variable "trusted_ingress_networks_ipv6" {
-  type        = list(string)
-  description = "IPv6 CIDR blocks from which to allow ingress to the bastion server"
   default     = ["::/0"]
+  description = "IPv6 CIDR blocks from which to allow ingress to the bastion server"
+  type        = list(string)
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,48 +1,72 @@
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+#
+# You must provide a value for each of these parameters.
+# ------------------------------------------------------------------------------
+
+variable "assessment_data_filename" {
+  type        = string
+  description = "The name of the assessment data JSON file that can be found in the assessment_data_s3_bucket."
 }
 
-variable "aws_availability_zone" {
-  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
-  default     = "a"
+variable "assessment_data_import_lambda_s3_bucket" {
+  type        = string
+  description = "The name of the bucket where the assessment data import Lambda function can be found.  This bucket should be created with the cisagov/assessment-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
 }
 
-variable "tags" {
+variable "assessment_data_import_lambda_s3_key" {
+  type        = string
+  description = "The key (name) of the zip file for the assessment data import Lambda function inside the S3 bucket."
+}
+
+variable "dmarc_import_es_role_arn" {
+  type        = string
+  description = "The ARN of the role that must be assumed in order to read the dmarc-import Elasticsearch database."
+}
+
+variable "findings_data_field_map" {
+  type        = string
+  description = "The key for the file storing field name mappings in JSON format."
+}
+
+variable "findings_data_import_lambda_s3_bucket" {
+  type        = string
+  description = "The name of the bucket where the findings data import Lambda function can be found.  This bucket should be created with the cisagov/findings-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+}
+
+variable "findings_data_import_lambda_s3_key" {
+  type        = string
+  description = "The key (name) of the zip file for the findings data import Lambda function inside the S3 bucket."
+}
+
+variable "findings_data_input_suffix" {
+  type        = string
+  description = "The suffix used by files found in the findings_data_s3_bucket that contain findings data."
+}
+
+variable "lambda_function_bucket" {
+  type        = string
+  description = "The name of the S3 bucket where the Lambda function zip files reside.  Terraform cannot access buckets that are not in the provider's region, so the region name will be appended to the bucket name to obtain the actual bucket where the zips are stored.  So if we are working in region us-west-1 and this variable has the value buckethead, then the zips will be looked for in the bucket buckethead-us-west-1."
+}
+
+variable "lambda_function_keys" {
   type        = map(string)
-  description = "Tags to apply to all AWS resources created"
-  default     = {}
+  description = "The keys (names) of the zip files for the Lambda functions inside the S3 bucket.  The keys for the map are the values in scan_types."
 }
 
-variable "mgmt_nessus_instance_count" {
-  default     = 1
-  description = "The number of Nessus instances to create if a management environment is set to be created."
-  type        = number
+variable "lambda_function_names" {
+  type        = map(string)
+  description = "The names to use for the Lambda functions.  The keys are the values in scan_types."
 }
 
-variable "mongo_disks" {
-  type = map(string)
-  default = {
-    data    = "/dev/xvdb"
-    journal = "/dev/xvdc"
-    log     = "/dev/xvdd"
-  }
+variable "mgmt_nessus_activation_codes" {
+  type        = list(string)
+  description = "A list of strings containing Nessus activation codes used in the management VPC"
 }
 
-variable "mongo_instance_count" {
-  default     = 1
-  description = "The number of Mongo instances to create."
-  type        = number
-}
-
-variable "nmap_cyhy_runner_disk" {
-  description = "The cyhy-runner data volume for the nmap instance(s)"
-  default     = "/dev/nvme1n1"
-}
-
-variable "nessus_cyhy_runner_disk" {
-  description = "The cyhy-runner data volume for the nessus instance(s)"
-  default     = "/dev/xvdb"
+variable "nessus_activation_codes" {
+  type        = list(string)
+  description = "A list of strings containing Nessus activation codes"
 }
 
 variable "nessus_instance_count" {
@@ -55,43 +79,86 @@ variable "nmap_instance_count" {
   type        = number
 }
 
-# This should be overridden by a production.tfvars file,
-# most likely stored outside of version control
-variable "trusted_ingress_networks_ipv4" {
-  type        = list(string)
-  description = "IPv4 CIDR blocks from which to allow ingress to the bastion server"
-  default     = ["0.0.0.0/0"]
-}
-
-variable "trusted_ingress_networks_ipv6" {
-  type        = list(string)
-  description = "IPv6 CIDR blocks from which to allow ingress to the bastion server"
-  default     = ["::/0"]
-}
-
 variable "remote_ssh_user" {
   description = "The username to use when sshing to the EC2 instances"
 }
 
-variable "nessus_activation_codes" {
+variable "scan_types" {
   type        = list(string)
-  description = "A list of strings containing Nessus activation codes"
+  description = "The scan types that can be run."
 }
 
-variable "mgmt_nessus_activation_codes" {
-  type        = list(string)
-  description = "A list of strings containing Nessus activation codes used in the management VPC"
+variable "ses_role_arn" {
+  type        = string
+  description = "The ARN of the role that must be assumed in order to send emails."
 }
 
-variable "create_cyhy_flow_logs" {
-  type        = bool
-  description = "Whether or not to create flow logs for the CyHy VPC."
-  default     = false
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+#
+# These parameters have reasonable defaults.
+# ------------------------------------------------------------------------------
+
+variable "assessment_data_import_db_hostname" {
+  type        = string
+  description = "The hostname that has the database to store the assessment data in."
+  default     = ""
+}
+
+variable "assessment_data_import_db_port" {
+  type        = string
+  description = "The port that the database server is listening on."
+  default     = ""
+}
+
+variable "assessment_data_import_ssm_db_name" {
+  type        = string
+  description = "The name of the parameter in AWS SSM that holds the name of the database to store the assessment data in."
+  default     = ""
+}
+
+variable "assessment_data_import_ssm_db_password" {
+  type        = string
+  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the assessment database."
+  default     = ""
+}
+
+variable "assessment_data_import_ssm_db_user" {
+  type        = string
+  description = "The name of the parameter in AWS SSM that holds the database username with write permission to the assessment database."
+  default     = ""
+}
+
+variable "assessment_data_s3_bucket" {
+  type        = string
+  description = "The name of the bucket where the assessment data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+  default     = ""
+}
+
+variable "aws_availability_zone" {
+  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  default     = "a"
+}
+
+variable "aws_region" {
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  default     = "us-east-1"
+}
+
+variable "bod_nat_gateway_eip" {
+  description = "The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created.."
+  default     = ""
 }
 
 variable "create_bod_flow_logs" {
   type        = bool
   description = "Whether or not to create flow logs for the BOD 18-01 VPC."
+  default     = false
+}
+
+variable "create_cyhy_flow_logs" {
+  type        = bool
+  description = "Whether or not to create flow logs for the CyHy VPC."
   default     = false
 }
 
@@ -123,54 +190,9 @@ variable "cyhy_vulnscan_first_elastic_ip_offset" {
   default     = 1
 }
 
-variable "bod_nat_gateway_eip" {
-  description = "The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created.."
-  default     = ""
-}
-
-variable "scan_types" {
-  type        = list(string)
-  description = "The scan types that can be run."
-}
-
-variable "lambda_function_names" {
-  type        = map(string)
-  description = "The names to use for the Lambda functions.  The keys are the values in scan_types."
-}
-
-variable "lambda_function_bucket" {
-  type        = string
-  description = "The name of the S3 bucket where the Lambda function zip files reside.  Terraform cannot access buckets that are not in the provider's region, so the region name will be appended to the bucket name to obtain the actual bucket where the zips are stored.  So if we are working in region us-west-1 and this variable has the value buckethead, then the zips will be looked for in the bucket buckethead-us-west-1."
-}
-
-variable "lambda_function_keys" {
-  type        = map(string)
-  description = "The keys (names) of the zip files for the Lambda functions inside the S3 bucket.  The keys for the map are the values in scan_types."
-}
-
 variable "dmarc_import_aws_region" {
   description = "The AWS region where the dmarc-import Elasticsearch database resides."
   default     = "us-east-1"
-}
-
-variable "dmarc_import_es_role_arn" {
-  type        = string
-  description = "The ARN of the role that must be assumed in order to read the dmarc-import Elasticsearch database."
-}
-
-variable "ses_aws_region" {
-  description = "The AWS region where SES is configured."
-  default     = "us-east-1"
-}
-
-variable "ses_role_arn" {
-  type        = string
-  description = "The ARN of the role that must be assumed in order to send emails."
-}
-
-variable "reporter_mailer_override_filename" {
-  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
-  default     = "docker-compose.cyhy.yml"
 }
 
 variable "docker_mailer_override_filename" {
@@ -193,95 +215,6 @@ variable "enable_mgmt_vpc" {
   default     = false
 }
 
-variable "assessment_data_s3_bucket" {
-  type        = string
-  description = "The name of the bucket where the assessment data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
-  default     = ""
-}
-
-variable "assessment_data_filename" {
-  type        = string
-  description = "The name of the assessment data JSON file that can be found in the assessment_data_s3_bucket."
-}
-
-variable "assessment_data_import_lambda_s3_bucket" {
-  type        = string
-  description = "The name of the bucket where the assessment data import Lambda function can be found.  This bucket should be created with the cisagov/assessment-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
-}
-
-variable "assessment_data_import_lambda_s3_key" {
-  type        = string
-  description = "The key (name) of the zip file for the assessment data import Lambda function inside the S3 bucket."
-}
-
-variable "assessment_data_import_db_hostname" {
-  type        = string
-  description = "The hostname that has the database to store the assessment data in."
-  default     = ""
-}
-
-variable "assessment_data_import_db_port" {
-  type        = string
-  description = "The port that the database server is listening on."
-  default     = ""
-}
-
-variable "assessment_data_import_ssm_db_name" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the name of the database to store the assessment data in."
-  default     = ""
-}
-
-variable "assessment_data_import_ssm_db_user" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the database username with write permission to the assessment database."
-  default     = ""
-}
-
-variable "assessment_data_import_ssm_db_password" {
-  type        = string
-  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the assessment database."
-  default     = ""
-}
-
-variable "findings_data_s3_bucket" {
-  type        = string
-  description = "The name of the bucket where the findings data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
-  default     = ""
-}
-
-variable "findings_data_input_suffix" {
-  type        = string
-  description = "The suffix used by files found in the findings_data_s3_bucket that contain findings data."
-}
-
-variable "findings_data_field_map" {
-  type        = string
-  description = "The key for the file storing field name mappings in JSON format."
-}
-
-variable "findings_data_save_failed" {
-  type        = bool
-  description = "Whether or not to save files for imports that have failed."
-  default     = true
-}
-
-variable "findings_data_save_succeeded" {
-  type        = bool
-  description = "Whether or not to save files for imports that have succeeded."
-  default     = false
-}
-
-variable "findings_data_import_lambda_s3_bucket" {
-  type        = string
-  description = "The name of the bucket where the findings data import Lambda function can be found.  This bucket should be created with the cisagov/findings-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
-}
-
-variable "findings_data_import_lambda_s3_key" {
-  type        = string
-  description = "The key (name) of the zip file for the findings data import Lambda function inside the S3 bucket."
-}
-
 variable "findings_data_import_db_hostname" {
   type        = string
   description = "The hostname that has the database to store the findings data in."
@@ -300,14 +233,93 @@ variable "findings_data_import_ssm_db_name" {
   default     = ""
 }
 
+variable "findings_data_import_ssm_db_password" {
+  type        = string
+  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the findings database."
+  default     = ""
+}
+
 variable "findings_data_import_ssm_db_user" {
   type        = string
   description = "The name of the parameter in AWS SSM that holds the database username with write permission to the findings database."
   default     = ""
 }
 
-variable "findings_data_import_ssm_db_password" {
+variable "findings_data_s3_bucket" {
   type        = string
-  description = "The name of the parameter in AWS SSM that holds the database password for the user with write permission to the findings database."
+  description = "The name of the bucket where the findings data JSON file can be found.  Note that in production Terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
   default     = ""
+}
+
+variable "findings_data_save_failed" {
+  type        = bool
+  description = "Whether or not to save files for imports that have failed."
+  default     = true
+}
+
+variable "findings_data_save_succeeded" {
+  type        = bool
+  description = "Whether or not to save files for imports that have succeeded."
+  default     = false
+}
+
+variable "mgmt_nessus_instance_count" {
+  default     = 1
+  description = "The number of Nessus instances to create if a management environment is set to be created."
+  type        = number
+}
+
+variable "mongo_disks" {
+  type = map(string)
+  default = {
+    data    = "/dev/xvdb"
+    journal = "/dev/xvdc"
+    log     = "/dev/xvdd"
+  }
+}
+
+variable "mongo_instance_count" {
+  default     = 1
+  description = "The number of Mongo instances to create."
+  type        = number
+}
+
+variable "nessus_cyhy_runner_disk" {
+  description = "The cyhy-runner data volume for the nessus instance(s)"
+  default     = "/dev/xvdb"
+}
+
+variable "nmap_cyhy_runner_disk" {
+  description = "The cyhy-runner data volume for the nmap instance(s)"
+  default     = "/dev/nvme1n1"
+}
+
+variable "reporter_mailer_override_filename" {
+  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
+  default     = "docker-compose.cyhy.yml"
+}
+
+variable "ses_aws_region" {
+  description = "The AWS region where SES is configured."
+  default     = "us-east-1"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to all AWS resources created"
+  default     = {}
+}
+
+# This should be overridden by a production.tfvars file,
+# most likely stored outside of version control
+variable "trusted_ingress_networks_ipv4" {
+  type        = list(string)
+  description = "IPv4 CIDR blocks from which to allow ingress to the bastion server"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "trusted_ingress_networks_ipv6" {
+  type        = list(string)
+  description = "IPv6 CIDR blocks from which to allow ingress to the bastion server"
+  default     = ["::/0"]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,12 +60,12 @@ variable "lambda_function_names" {
 }
 
 variable "mgmt_nessus_activation_codes" {
-  description = "A list of strings containing Nessus activation codes used in the management VPC"
+  description = "A list of strings containing Nessus activation codes used in the management VPC."
   type        = list(string)
 }
 
 variable "nessus_activation_codes" {
-  description = "A list of strings containing Nessus activation codes"
+  description = "A list of strings containing Nessus activation codes."
   type        = list(string)
 }
 
@@ -75,12 +75,12 @@ variable "nessus_instance_count" {
 }
 
 variable "nmap_instance_count" {
-  description = "The number of nmap instances to create."
+  description = "The number of Nmap instances to create."
   type        = number
 }
 
 variable "remote_ssh_user" {
-  description = "The username to use when sshing to the EC2 instances"
+  description = "The username to use when sshing to the EC2 instances."
   type        = string
 }
 
@@ -150,7 +150,7 @@ variable "aws_region" {
 
 variable "bod_nat_gateway_eip" {
   default     = ""
-  description = "The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created.."
+  description = "The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created."
   type        = string
 }
 
@@ -174,7 +174,7 @@ variable "create_mgmt_flow_logs" {
 
 variable "cyhy_archive_bucket_name" {
   default     = "ncats-cyhy-archive"
-  description = "S3 bucket for storing compressed archive files created by cyhy-archive"
+  description = "S3 bucket for storing compressed archive files created by cyhy-archive."
   type        = string
 }
 
@@ -295,13 +295,13 @@ variable "mongo_instance_count" {
 
 variable "nessus_cyhy_runner_disk" {
   default     = "/dev/xvdb"
-  description = "The cyhy-runner data volume for the nessus instance(s)"
+  description = "The cyhy-runner data volume for the Nessus instance(s)."
   type        = string
 }
 
 variable "nmap_cyhy_runner_disk" {
   default     = "/dev/nvme1n1"
-  description = "The cyhy-runner data volume for the nmap instance(s)"
+  description = "The cyhy-runner data volume for the Nmap instance(s)."
   type        = string
 }
 
@@ -319,7 +319,7 @@ variable "ses_aws_region" {
 
 variable "tags" {
   default     = {}
-  description = "Tags to apply to all AWS resources created"
+  description = "Tags to apply to all AWS resources created."
   type        = map(string)
 }
 
@@ -327,12 +327,12 @@ variable "tags" {
 # most likely stored outside of version control
 variable "trusted_ingress_networks_ipv4" {
   default     = ["0.0.0.0/0"]
-  description = "IPv4 CIDR blocks from which to allow ingress to the bastion server"
+  description = "IPv4 CIDR blocks from which to allow ingress to the bastion server."
   type        = list(string)
 }
 
 variable "trusted_ingress_networks_ipv6" {
   default     = ["::/0"]
-  description = "IPv6 CIDR blocks from which to allow ingress to the bastion server"
+  description = "IPv6 CIDR blocks from which to allow ingress to the bastion server."
   type        = list(string)
 }

--- a/terraform_egress_pub/variables.tf
+++ b/terraform_egress_pub/variables.tf
@@ -24,24 +24,24 @@ variable "aws_region" {
 
 variable "distribution_domain" {
   default     = "rules.ncats.cyber.dhs.gov"
-  description = "The domain name of the cloudfront distribution and certificate."
+  description = "The domain name of the CloudFront distribution and certificate."
   type        = string
 }
 
 variable "root_object" {
   default     = "all.txt"
-  description = "The root object to serve when no path is provided, or an error occurs"
+  description = "The root object to serve when no path is provided, or an error occurs."
   type        = string
 }
 
 variable "rules_bucket_name" {
   default     = "s3-cdn.rules.ncats.cyber.dhs.gov"
-  description = "The name of the bucket to store egress IP addresses"
+  description = "The name of the bucket to store egress IP addresses."
   type        = string
 }
 
 variable "tags" {
   default     = {}
-  description = "Tags to apply to all AWS resources created"
+  description = "Tags to apply to all AWS resources created."
   type        = map(string)
 }

--- a/terraform_egress_pub/variables.tf
+++ b/terraform_egress_pub/variables.tf
@@ -11,32 +11,37 @@
 # ------------------------------------------------------------------------------
 
 variable "aws_availability_zone" {
-  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
   default     = "a"
+  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  type        = string
 }
 
 variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  type        = string
 }
 
 variable "distribution_domain" {
-  description = "The domain name of the cloudfront distribution and certificate."
   default     = "rules.ncats.cyber.dhs.gov"
+  description = "The domain name of the cloudfront distribution and certificate."
+  type        = string
 }
 
 variable "root_object" {
-  description = "The root object to serve when no path is provided, or an error occurs"
   default     = "all.txt"
+  description = "The root object to serve when no path is provided, or an error occurs"
+  type        = string
 }
 
 variable "rules_bucket_name" {
-  description = "The name of the bucket to store egress IP addresses"
   default     = "s3-cdn.rules.ncats.cyber.dhs.gov"
+  description = "The name of the bucket to store egress IP addresses"
+  type        = string
 }
 
 variable "tags" {
-  type        = map(string)
   default     = {}
   description = "Tags to apply to all AWS resources created"
+  type        = map(string)
 }

--- a/terraform_egress_pub/variables.tf
+++ b/terraform_egress_pub/variables.tf
@@ -1,22 +1,23 @@
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
-}
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+#
+# You must provide a value for each of these parameters.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+#
+# These parameters have reasonable defaults.
+# ------------------------------------------------------------------------------
 
 variable "aws_availability_zone" {
   description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
   default     = "a"
 }
 
-variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "Tags to apply to all AWS resources created"
-}
-
-variable "rules_bucket_name" {
-  description = "The name of the bucket to store egress IP addresses"
-  default     = "s3-cdn.rules.ncats.cyber.dhs.gov"
+variable "aws_region" {
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  default     = "us-east-1"
 }
 
 variable "distribution_domain" {
@@ -27,4 +28,15 @@ variable "distribution_domain" {
 variable "root_object" {
   description = "The root object to serve when no path is provided, or an error occurs"
   default     = "all.txt"
+}
+
+variable "rules_bucket_name" {
+  description = "The name of the bucket to store egress IP addresses"
+  default     = "s3-cdn.rules.ncats.cyber.dhs.gov"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to all AWS resources created"
 }

--- a/terraform_nessus_only/variables.tf
+++ b/terraform_nessus_only/variables.tf
@@ -5,12 +5,13 @@
 # ------------------------------------------------------------------------------
 
 variable "nessus_activation_codes" {
-  type        = list(string)
   description = "A list of strings containing Nessus activation codes"
+  type        = list(string)
 }
 
 variable "remote_ssh_user" {
   description = "The username to use when sshing to the EC2 instances"
+  type        = string
 }
 
 # ------------------------------------------------------------------------------
@@ -20,53 +21,56 @@ variable "remote_ssh_user" {
 # ------------------------------------------------------------------------------
 
 variable "aws_availability_zone" {
-  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
   default     = "a"
+  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  type        = string
 }
 
+# Currently we need to use us-east-1a because we are using a subnet in the
+# default VPC, and that subnet resides in us-east-1a
 variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
-  # Currently we need to use us-east-1a because we are using a subnet in the
-  # default VPC, and that subnet resides in us-east-1a
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  type        = string
 }
 
 variable "cyhy_elastic_ip_cidr_block" {
-  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances.  This is only used in Production workspaces."
   default     = ""
+  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances.  This is only used in Production workspaces."
+  type        = string
 }
 
 variable "nessus_first_elastic_ip_offset" {
-  type        = number
-  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* Nessus instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first Nessus address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional Nessus instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available.  This is only used in Production workspaces."
   default     = 1
+  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* Nessus instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first Nessus address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional Nessus instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available.  This is only used in Production workspaces."
+  type        = number
 }
 
 variable "nessus_instance_count" {
-  type        = number
-  description = "The number of Nessus instances to create."
   default     = 1
+  description = "The number of Nessus instances to create."
+  type        = number
 }
 
 variable "tags" {
-  type = map(string)
   default = {
     Team        = "VM Fusion - Development"
     Application = "Manual Cyber Hygiene"
   }
   description = "Tags to apply to all AWS resources created"
+  type        = map(string)
 }
 
 # This should be overridden by a production.tfvars file,
 # most-likely stored outside of version control
 variable "trusted_ingress_networks_ipv4" {
-  type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "Trusted IPv4 ingress networks"
+  type        = list(string)
 }
 
 variable "trusted_ingress_networks_ipv6" {
-  type        = list(string)
   default     = ["::/0"]
   description = "Trusted IPv6 ingress networks"
+  type        = list(string)
 }

--- a/terraform_nessus_only/variables.tf
+++ b/terraform_nessus_only/variables.tf
@@ -5,12 +5,12 @@
 # ------------------------------------------------------------------------------
 
 variable "nessus_activation_codes" {
-  description = "A list of strings containing Nessus activation codes"
+  description = "A list of strings containing Nessus activation codes."
   type        = list(string)
 }
 
 variable "remote_ssh_user" {
-  description = "The username to use when sshing to the EC2 instances"
+  description = "The username to use when sshing to the EC2 instances."
   type        = string
 }
 
@@ -36,13 +36,13 @@ variable "aws_region" {
 
 variable "cyhy_elastic_ip_cidr_block" {
   default     = ""
-  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances.  This is only used in Production workspaces."
+  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances.  This is only used in production workspaces."
   type        = string
 }
 
 variable "nessus_first_elastic_ip_offset" {
   default     = 1
-  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* Nessus instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first Nessus address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional Nessus instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available.  This is only used in Production workspaces."
+  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* Nessus instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first Nessus address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional Nessus instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available.  This is only used in production workspaces."
   type        = number
 }
 
@@ -57,7 +57,7 @@ variable "tags" {
     Team        = "VM Fusion - Development"
     Application = "Manual Cyber Hygiene"
   }
-  description = "Tags to apply to all AWS resources created"
+  description = "Tags to apply to all AWS resources created."
   type        = map(string)
 }
 
@@ -65,12 +65,12 @@ variable "tags" {
 # most-likely stored outside of version control
 variable "trusted_ingress_networks_ipv4" {
   default     = ["0.0.0.0/0"]
-  description = "Trusted IPv4 ingress networks"
+  description = "Trusted IPv4 ingress networks."
   type        = list(string)
 }
 
 variable "trusted_ingress_networks_ipv6" {
   default     = ["::/0"]
-  description = "Trusted IPv6 ingress networks"
+  description = "Trusted IPv6 ingress networks."
   type        = list(string)
 }

--- a/terraform_nessus_only/variables.tf
+++ b/terraform_nessus_only/variables.tf
@@ -1,3 +1,29 @@
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+#
+# You must provide a value for each of these parameters.
+# ------------------------------------------------------------------------------
+
+variable "nessus_activation_codes" {
+  type        = list(string)
+  description = "A list of strings containing Nessus activation codes"
+}
+
+variable "remote_ssh_user" {
+  description = "The username to use when sshing to the EC2 instances"
+}
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+#
+# These parameters have reasonable defaults.
+# ------------------------------------------------------------------------------
+
+variable "aws_availability_zone" {
+  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  default     = "a"
+}
+
 variable "aws_region" {
   description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
@@ -5,9 +31,21 @@ variable "aws_region" {
   # default VPC, and that subnet resides in us-east-1a
 }
 
-variable "aws_availability_zone" {
-  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
-  default     = "a"
+variable "cyhy_elastic_ip_cidr_block" {
+  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances.  This is only used in Production workspaces."
+  default     = ""
+}
+
+variable "nessus_first_elastic_ip_offset" {
+  type        = number
+  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* Nessus instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first Nessus address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional Nessus instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available.  This is only used in Production workspaces."
+  default     = 1
+}
+
+variable "nessus_instance_count" {
+  type        = number
+  description = "The number of Nessus instances to create."
+  default     = 1
 }
 
 variable "tags" {
@@ -31,30 +69,4 @@ variable "trusted_ingress_networks_ipv6" {
   type        = list(string)
   default     = ["::/0"]
   description = "Trusted IPv6 ingress networks"
-}
-
-variable "remote_ssh_user" {
-  description = "The username to use when sshing to the EC2 instances"
-}
-
-variable "nessus_instance_count" {
-  type        = number
-  description = "The number of Nessus instances to create."
-  default     = 1
-}
-
-variable "nessus_activation_codes" {
-  type        = list(string)
-  description = "A list of strings containing Nessus activation codes"
-}
-
-variable "cyhy_elastic_ip_cidr_block" {
-  description = "The CIDR block of elastic addresses available for use by CyHy scanner instances.  This is only used in Production workspaces."
-  default     = ""
-}
-
-variable "nessus_first_elastic_ip_offset" {
-  type        = number
-  description = "The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* Nessus instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first Nessus address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional Nessus instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available.  This is only used in Production workspaces."
-  default     = 1
 }

--- a/terraform_route_53/variables.tf
+++ b/terraform_route_53/variables.tf
@@ -11,17 +11,19 @@
 # ------------------------------------------------------------------------------
 
 variable "aws_availability_zone" {
-  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
   default     = "a"
+  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  type        = string
 }
 
 variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  type        = string
 }
 
 variable "tags" {
-  type        = map(string)
   default     = {}
   description = "Tags to apply to all AWS resources created"
+  type        = map(string)
 }

--- a/terraform_route_53/variables.tf
+++ b/terraform_route_53/variables.tf
@@ -24,6 +24,6 @@ variable "aws_region" {
 
 variable "tags" {
   default     = {}
-  description = "Tags to apply to all AWS resources created"
+  description = "Tags to apply to all AWS resources created."
   type        = map(string)
 }

--- a/terraform_route_53/variables.tf
+++ b/terraform_route_53/variables.tf
@@ -1,11 +1,23 @@
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
-}
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+#
+# You must provide a value for each of these parameters.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+#
+# These parameters have reasonable defaults.
+# ------------------------------------------------------------------------------
 
 variable "aws_availability_zone" {
   description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
   default     = "a"
+}
+
+variable "aws_region" {
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  default     = "us-east-1"
 }
 
 variable "tags" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull requests organizes each of the `variables.tf` files in this project to align with how we format `variables.tf` files. This included grouping them by required/optional status, sorting these groups alphabetically by variable name, and ensuring that each variable has an appropriate type and description.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is just another part of the effort to modernize some of the elements of this legacy configuration. as it is still in use.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
