### PR TITLE
Add variables to control the AMI prefix(es) used

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ packer build nmap.json
 packer build reporter.json
 ```
 
+If building a non-default image (for testing as an example) the prefix for the
+created AMI can be changed from the default value of `cyhy` like so:
+
+```console
+packer build -var ami_prefix=testing bastion.json
+```
+
 Also note that
 
 ```console

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -10,7 +10,7 @@
           "volume_type": "gp2"
         }
       ],
-      "ami_name": "cyhy-bastion-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_name": "{{user `ami_prefix`}}-bastion-hvm-{{timestamp}}-x86_64-ebs",
       "ami_regions": [
         "us-east-1",
         "us-west-1",
@@ -71,5 +71,8 @@
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
-  ]
+  ],
+  "variables": {
+    "ami_prefix": "cyhy"
+  }
 }

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -10,7 +10,7 @@
           "volume_type": "gp2"
         }
       ],
-      "ami_name": "cyhy-dashboard-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_name": "{{user `ami_prefix`}}-dashboard-hvm-{{timestamp}}-x86_64-ebs",
       "ami_regions": [
         "us-east-1",
         "us-west-1",
@@ -71,5 +71,8 @@
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
-  ]
+  ],
+  "variables": {
+    "ami_prefix": "cyhy"
+  }
 }

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -10,7 +10,7 @@
           "volume_type": "gp2"
         }
       ],
-      "ami_name": "cyhy-docker-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_name": "{{user `ami_prefix`}}-docker-hvm-{{timestamp}}-x86_64-ebs",
       "ami_regions": [
         "us-east-1",
         "us-west-1",
@@ -73,5 +73,8 @@
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
-  ]
+  ],
+  "variables": {
+    "ami_prefix": "cyhy"
+  }
 }

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -10,7 +10,7 @@
           "volume_type": "gp2"
         }
       ],
-      "ami_name": "cyhy-mongo-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_name": "{{user `ami_prefix`}}-mongo-hvm-{{timestamp}}-x86_64-ebs",
       "ami_regions": [
         "us-east-1",
         "us-west-1",
@@ -73,5 +73,8 @@
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
-  ]
+  ],
+  "variables": {
+    "ami_prefix": "cyhy"
+  }
 }

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -10,7 +10,7 @@
           "volume_type": "gp2"
         }
       ],
-      "ami_name": "cyhy-nessus-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_name": "{{user `ami_prefix`}}-nessus-hvm-{{timestamp}}-x86_64-ebs",
       "ami_regions": [
         "us-east-1",
         "us-west-1",
@@ -71,5 +71,8 @@
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
-  ]
+  ],
+  "variables": {
+    "ami_prefix": "cyhy"
+  }
 }

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -10,7 +10,7 @@
           "volume_type": "gp2"
         }
       ],
-      "ami_name": "cyhy-nmap-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_name": "{{user `ami_prefix`}}-nmap-hvm-{{timestamp}}-x86_64-ebs",
       "ami_regions": [
         "us-east-1",
         "us-west-1",
@@ -71,5 +71,8 @@
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
-  ]
+  ],
+  "variables": {
+    "ami_prefix": "cyhy"
+  }
 }

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -10,7 +10,7 @@
           "volume_type": "gp2"
         }
       ],
-      "ami_name": "cyhy-reporter-hvm-{{timestamp}}-x86_64-ebs",
+      "ami_name": "{{user `ami_prefix`}}-reporter-hvm-{{timestamp}}-x86_64-ebs",
       "ami_regions": [
         "us-east-1",
         "us-west-1",
@@ -71,5 +71,8 @@
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible"
     }
-  ]
+  ],
+  "variables": {
+    "ami_prefix": "cyhy"
+  }
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -603,6 +603,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| ami\_prefixes | An object whose keys are the types of Packer images (defined in the `packer/` directory in the root of the repository) and whose values are the prefix to use for the corresponding AMI. The default for all images is "cyhy". | `object({ bastion = string, dashboard = string, docker = string, mongo = string, nessus = string, nmap = string, reporter = string })` | ```{ "bastion": "cyhy", "dashboard": "cyhy", "docker": "cyhy", "mongo": "cyhy", "nessus": "cyhy", "nmap": "cyhy", "reporter": "cyhy" }``` | no |
 | assessment\_data\_filename | The name of the assessment data JSON file that can be found in the assessment\_data\_s3\_bucket. | `string` | n/a | yes |
 | assessment\_data\_import\_db\_hostname | The hostname that has the database to store the assessment data in. | `string` | `""` | no |
 | assessment\_data\_import\_db\_port | The port that the database server is listening on. | `string` | `""` | no |

--- a/terraform/bastion_ami.tf
+++ b/terraform/bastion_ami.tf
@@ -3,7 +3,7 @@ data "aws_ami" "bastion" {
   filter {
     name = "name"
     values = [
-      "cyhy-bastion-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.bastion}-bastion-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -3,7 +3,7 @@ data "aws_ami" "bod_docker" {
   filter {
     name = "name"
     values = [
-      "cyhy-docker-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.docker}-docker-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform/cyhy_dashboard_ec2.tf
+++ b/terraform/cyhy_dashboard_ec2.tf
@@ -3,7 +3,7 @@ data "aws_ami" "dashboard" {
   filter {
     name = "name"
     values = [
-      "cyhy-dashboard-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.dashboard}-dashboard-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -2,7 +2,7 @@ data "aws_ami" "cyhy_mongo" {
   filter {
     name = "name"
     values = [
-      "cyhy-mongo-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.mongo}-mongo-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -2,7 +2,7 @@ data "aws_ami" "nessus" {
   filter {
     name = "name"
     values = [
-      "cyhy-nessus-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.nessus}-nessus-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -2,7 +2,7 @@ data "aws_ami" "nmap" {
   filter {
     name = "name"
     values = [
-      "cyhy-nmap-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.nmap}-nmap-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -3,7 +3,7 @@ data "aws_ami" "reporter" {
   filter {
     name = "name"
     values = [
-      "cyhy-reporter-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.reporter}-reporter-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -100,6 +100,20 @@ variable "ses_role_arn" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "ami_prefixes" {
+  default = {
+    bastion   = "cyhy",
+    dashboard = "cyhy",
+    docker    = "cyhy",
+    mongo     = "cyhy",
+    nessus    = "cyhy",
+    nmap      = "cyhy",
+    reporter  = "cyhy",
+  }
+  description = "An object whose keys are the types of Packer images (defined in the `packer/` directory in the root of the repository) and whose values are the prefix to use for the corresponding AMI. The default for all images is \"cyhy\"."
+  type        = object({ bastion = string, dashboard = string, docker = string, mongo = string, nessus = string, nmap = string, reporter = string })
+}
+
 variable "assessment_data_import_db_hostname" {
   default     = ""
   description = "The hostname that has the database to store the assessment data in."

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -2,7 +2,7 @@ data "aws_ami" "nessus" {
   filter {
     name = "name"
     values = [
-      "cyhy-nessus-hvm-*-x86_64-ebs",
+      "${var.ami_prefix}-nessus-hvm-*-x86_64-ebs",
     ]
   }
 

--- a/terraform_nessus_only/variables.tf
+++ b/terraform_nessus_only/variables.tf
@@ -20,6 +20,12 @@ variable "remote_ssh_user" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "ami_prefix" {
+  default     = "cyhy"
+  description = "The prefix for the AMI that is used for the manual Nessus instance."
+  type        = string
+}
+
 variable "aws_availability_zone" {
   default     = "a"
   description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds variables to control the prefixes that are used to interact with the AMIs that are created in the `packer/` configuration.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When testing this environment it is necessary at times to create testing AMIs and we have historically changed the prefix from `cyhy` to another value (the Terraform workspace typically). This has required manually changing the value(s) in the corresponding Packer configuration and Terraform file to build and use the appropriate image.

I believe that using variables to control this behavior is cleaner and less likely to result in accidental usage of the incorrect image.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the variable for Packer works as expected to build an image and modifying the appropriate variable in the `terraform/` configuration uses the corresponding AMI.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
