### PR TITLE
Add a new page for the STRIGA IPs

### DIFF
--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -56,6 +56,29 @@ qualys_was_ips = (
     "64.39.108.104/29",
     "64.39.108.112/28",
 )
+# The following CIDR blocks are where the STRIGA traffic originates
+# from:
+striga_ips = (
+    "3.210.85.203/32",
+    "3.213.50.150/32",
+    "3.221.55.63/32",
+    "3.224.90.16/32",
+    "3.229.208.240/32",
+    "18.214.120.80/32",
+    "18.234.81.132/32",
+    "34.194.139.213/32",
+    "34.200.127.160/32",
+    "34.232.73.230/32",
+    "34.233.244.247/32",
+    "34.234.104.81/32",
+    "44.196.3.157/32",
+    "44.199.219.43/32",
+    "52.2.88.50/32",
+    "52.20.114.134/32",
+    "54.173.213.152/32",
+    "54.205.21.104/32",
+)
+
 FILE_CONFIGS = [
     {
         "filename": "all.txt",
@@ -80,6 +103,12 @@ FILE_CONFIGS = [
         "app_regex": re.compile("Web Application Scanning$"),
         "static_ips": qualys_was_ips,
         "description": "This file contains a list of all IPs used for Web Application Scanning.",
+    },
+    {
+        "filename": "striga.txt",
+        "app_regex": re.compile("STRIGA$"),
+        "static_ips": striga_ips,
+        "description": "This file contains a consolidated list of all the IP addresses that VM is currently using for STRIGA external testing.",
     },
 ]
 


### PR DESCRIPTION

## 🗣 Description ##

This pull request adds [this page](https://rules.ncats.cyber.dhs.gov/striga.txt) to the `rules.ncats.cyber.dhs.gov` site.  Note that the STRIGA IPs _are not_ being added to the `all.txt` page.

This is a temporary measure.  Soon we will create a separate `rules.striga.cyber.dhs.gov` site that the STRIGA team can manage themselves, as is described in #391.

## 💭 Motivation and context ##

Resolves #391.

## 🧪 Testing ##

I deployed these changes and utilized my ocular orbs to verify that [this page](https://rules.ncats.cyber.dhs.gov/striga.txt) appeared correct.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.