### PR TITLE
Add an Ansible task to install a cyhy-kevsync cron job

### DIFF
--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -158,3 +158,14 @@
     minute: '15'
     user: cyhy
     job: /usr/local/bin/cyhy-nvdsync --use-network 2>&1 | /usr/bin/logger -t cyhy-nvdsync
+
+#
+# Run cyhy-kevsync daily at 0845 (UTC) as cyhy user
+#
+- name: Set up nightly cron job to sync KEV data
+  cron:
+    name: Nightly cyhy-kevsync
+    hour: '8'
+    minute: '45'
+    user: cyhy
+    job: /usr/local/bin/cyhy-kevsync 2>&1 | /usr/bin/logger -t cyhy-kevsync


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an Ansible task to install a `cyhy-kevsync` `cron` job.

## 💭 Motivation and context ##

Resolves #390.

See also:
- cisagov/cyhy_amis/pull/394
- cisagov/cyhy-core#67
- cisagov/cyhy_amis#397

## 🧪 Testing ##

Eyeballz!

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.