### PR TITLE
Increase Nessus production root disk size to 200 GB

### DIFF
--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -29,7 +29,7 @@ resource "aws_instance" "cyhy_nessus" {
   subnet_id = aws_subnet.cyhy_vulnscanner_subnet.id
 
   root_block_device {
-    volume_size = local.production_workspace ? 100 : 16
+    volume_size = local.production_workspace ? 200 : 16
     volume_type = "gp3"
   }
 


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR increases the Nessus production root disk size to 200 GB.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

More disk means more uptime without running out of space.  We just had to deal with an instance that ran out of disk space and it's something we'd prefer to avoid.

This change has already been applied in Production.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran a targeted apply in Production and verified that everything worked as intended.  Note that I had to follow [steps similar to these](https://github.com/cisagov/cyhy-system/wiki/Adjust-reporter-partition-and-filesystem-size) in order to get the instances to recognize the larger disks.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
