### PR TITLE
Add automatic security updates to AMIs

### DIFF
--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -1,5 +1,7 @@
 - src: https://github.com/cisagov/ansible-role-amazon-ssm-agent
   name: amazon_ssm_agent
+- src: https://github.com/cisagov/ansible-role-apt-over-https
+  name: apt_over_https
 - src: https://github.com/cisagov/ansible-role-automated-security-updates
   name: automated_security_updates
 - src: https://github.com/cisagov/ansible-role-banner

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -1,5 +1,7 @@
 - src: https://github.com/cisagov/ansible-role-amazon-ssm-agent
   name: amazon_ssm_agent
+- src: https://github.com/cisagov/ansible-role-automated-security-updates
+  name: automated_security_updates
 - src: https://github.com/cisagov/ansible-role-banner
   name: banner
 - src: https://github.com/cisagov/ansible-role-clamav

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -5,3 +5,11 @@
   become_method: sudo
   roles:
     - upgrade
+
+# Any instances that have internet access should install security updates
+- hosts: bastion,docker,nessus,nmap
+  name: Enable automated security updates
+  become: yes
+  become_method: sudo
+  roles:
+    - automated_security_updates

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -1,15 +1,11 @@
 ---
 - hosts: all
-  name: Upgrade base image
+  name: >
+    Set up apt over HTTPS, upgrade base image, and enable automated security
+    updates
   become: yes
   become_method: sudo
   roles:
+    - apt_over_https
     - upgrade
-
-# Any instances that have internet access should install security updates
-- hosts: bastion,docker,nessus,nmap
-  name: Enable automated security updates
-  become: yes
-  become_method: sudo
-  roles:
     - automated_security_updates


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates our Packer configurations to do two things:
 
- Include automatic security updates.
- Use HTTPS for apt repositories.

This closes #325.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Automatic security updates will help ensure that our instances are as secure as possible during extended periods between deployments. Switching the apt repositories to use HTTPS has some security benefit, but it's most important reason is that we have restriction on HTTP (port 80) egress but allow HTTPS (port 443) egress. This should allow all of our instances to get security updates even if they are not more public-facing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that instances were able to perform an `apt update` with the HTTPS repositories. I also confirmed that the automatic security updates were running by checking the `/var/log/unattended-upgrades/unattended-upgrades.log` file and verifying the `apt` configuration..
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
