### PR TITLE
Add cisagov/ansible-role-geoip2 to the Packer configuration

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -77,6 +77,8 @@
   become_method: sudo
   roles:
     - cyhy_commander
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key', region='us-east-1') }}"
 
 - hosts: cyhy_reporter
   name: Install and configure cyhy-reports
@@ -86,6 +88,8 @@
     - xfs
     - cyhy_reports
     - cyhy_mailer
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key', region='us-east-1') }}"
 
 - hosts: cyhy_dashboard
   name: Install and configure cyhy-dashboard
@@ -95,6 +99,8 @@
     - ncats_webd
     - ncats_webui
     - docker
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key', region='us-east-1') }}"
 
 - hosts: cyhy_archive
   name: Install cyhy-archive helper script
@@ -102,3 +108,5 @@
   become_method: sudo
   roles:
     - cyhy_archive
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key', region='us-east-1') }}"

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -36,6 +36,8 @@
   name: disable_thp
 - src: https://github.com/cisagov/ansible-role-docker
   name: docker
+- src: https://github.com/cisagov/ansible-role-geoip2
+  name: geoip2
 - src: https://github.com/cisagov/ansible-role-htop
   name: htop
 - src: https://github.com/cisagov/ansible-role-mongo


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds [cisagov/ansible-role-geoip2] as an Ansible requirement for our Packer configurations and alters the usage of [cisagov/ansible-role-cyhy-core] to pass the MaxMind GeoIP2 license as a role variable.

**Note**: This requires https://github.com/cisagov/ansible-role-cyhy-core/pull/54 to be merged first.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This puts [cisagov/ansible-role-cyhy-core] in line with our development practices to take a role variable instead of looking up a value itself. This is also part of the move to separate the MaxMind GeoIP2 database installation into its own role for separate use.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes. I have this used to build and AMIs in my testing workspace and I have verified that it works as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/ansible-role-cyhy-core]: https://github.com/cisagov/ansible-role-cyhy-core
[cisagov/ansible-role-geoip2]: https://github.com/cisagov/ansible-role-geoip2 