### PR TITLE
Fix bug in CloudWatch metric alarm code

### DIFF
--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
 
 # Alarm each time syslog indicates a failure in the KEV sync cron job.
 resource "aws_cloudwatch_metric_alarm" "kevsync_failure" {
-  for_each = aws_cloudwatch_log_metric_filter.kevsync_failure
+  for_each = local.db_instances
 
   alarm_actions             = [aws_sns_topic.kevsync_failure_alarm.arn, aws_sns_topic.cloudwatch_alarm.arn]
   alarm_description         = "Monitor KEV sync failures"
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "kevsync_failure" {
     id = "kevsync_failure_count_${each.value.hostname}"
     metric {
       dimensions = {
-        InstanceId = each.value
+        InstanceId = each.key
       }
       metric_name = "kevsync_failure_count_${each.value.hostname}"
       namespace   = "DataIngestion"

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
 
 # Alarm each time syslog indicates a failure in the NVD sync cron job.
 resource "aws_cloudwatch_metric_alarm" "nvdsync_failure" {
-  for_each = aws_cloudwatch_log_metric_filter.nvdsync_failure
+  for_each = local.db_instances
 
   alarm_actions             = [aws_sns_topic.cloudwatch_alarm.arn, ]
   alarm_description         = "Monitor NVD sync failures"
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "nvdsync_failure" {
     id = "nvdsync_failure_count_${each.value.hostname}"
     metric {
       dimensions = {
-        InstanceId = each.value
+        InstanceId = each.key
       }
       metric_name = "nvdsync_failure_count_${each.value.hostname}"
       namespace   = "DataIngestion"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes a bug from #394, which resulted in invalid Terraform that could not be applied.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Before this bugfix, attempting to apply this Terraform resulted in a group of errors like this:
```
│ Error: Unsupported attribute
│ 
│   on nvdsync_failure_alarms.tf line 32, in resource "aws_cloudwatch_metric_alarm" "nvdsync_failure":
│   32:   alarm_name                = format("nvdsync_failure_%s_%s", each.value.hostname, local.production_workspace ? "production" : terraform.workspace)
│     ├────────────────
│     │ each.value is object with 5 attributes
│ 
│ This object does not have an attribute named "hostname".
```

With the code change in this PR, errors like the one above are resolved.  

Unfortunately, there is still another problem that is preventing this code from being successfully applied in my test environment.  I get the following errors:
```
╷
│ Error: Creating/Updating CloudWatch Log Metric Filter failed: ResourceNotFoundException: The specified log group does not exist.
│ 
│   with aws_cloudwatch_log_metric_filter.kevsync_failure["i-1234567890abcdef"],
│   on kevsync_failure_alarms.tf line 3, in resource "aws_cloudwatch_log_metric_filter" "kevsync_failure":
│    3: resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
│ 
╵
╷
│ Error: failed creating CloudWatch Metric Alarm (kevsync_failure_database1.cyhy_dav3r): ValidationError: Invalid metrics list
│ 	status code: 400, request id: ed4cf508-6d2a-4cc7-b33d-51077f4d858b
│ 
│   with aws_cloudwatch_metric_alarm.kevsync_failure["i-1234567890abcdef"],
│   on kevsync_failure_alarms.tf line 27, in resource "aws_cloudwatch_metric_alarm" "kevsync_failure":
│   27: resource "aws_cloudwatch_metric_alarm" "kevsync_failure" {
│ 
╵
╷
│ Error: Creating/Updating CloudWatch Log Metric Filter failed: ResourceNotFoundException: The specified log group does not exist.
│ 
│   with aws_cloudwatch_log_metric_filter.nvdsync_failure["i-1234567890abcdef"],
│   on nvdsync_failure_alarms.tf line 3, in resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure":
│    3: resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
│ 
╵
╷
│ Error: failed creating CloudWatch Metric Alarm (nvdsync_failure_database1.cyhy_dav3r): ValidationError: Invalid metrics list
│ 	status code: 400, request id: 9e173c85-c891-4a02-9fde-32733d815fcd
│ 
│   with aws_cloudwatch_metric_alarm.nvdsync_failure["i-1234567890abcdef"],
│   on nvdsync_failure_alarms.tf line 27, in resource "aws_cloudwatch_metric_alarm" "nvdsync_failure":
│   27: resource "aws_cloudwatch_metric_alarm" "nvdsync_failure" {
```

After discussing with @mcdonnnj, we believe there are (at least) two issues here:

1. The necessary log groups have not been created because the AMI I'm testing with does not have the CloudWatch agent included yet (the changes from https://github.com/cisagov/cyhy_amis/pull/410).  @mcdonnnj is going to work on creating a fresh AMI that I can use for testing.
2. Once we have an up-to-date (with respect to the CloudWatch agent code) AMI, the log groups that are being created are not being named with the internal hostnames (e.g. `/instance-logs/database1.cyhy`) - they are instead using the private IP address (e.g. `/instance-logs/ip-10-10-10-123`).  I verified this by looking at a Production environment whose Guacamole AMI includes [our latest CloudWatch agent code](https://github.com/cisagov/ansible-role-cloudwatch-agent/pull/34) and I can see log groups like `/instance-logs/ip-10-10-10-123`.  Until we resolve that, this code will not work as intended: https://github.com/cisagov/cyhy_amis/blob/0fe51547ae55c23c43f64b358d9e75539e4a2af4/terraform/kevsync_failure_alarms.tf#L17

After discussing this with @mcdonnnj and @jsf9k, we agreed that a solution to the log group issue will be pursued outside of this PR.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this, I temporarily modified the `aws_cloudwatch_log_metric_filter` code to use an existing log group in order to overcome the error mentioned above.  Once I did that, I was able to successfully Terraform the `aws_cloudwatch_log_metric_filter` and `aws_cloudwatch_metric_alarm` resources in my development environment.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
