### PR TITLE
Fix broken NVD and KEV sync failure alarm code

### DIFF
--- a/terraform/cloudwatch_alarm_sns_topic.tf
+++ b/terraform/cloudwatch_alarm_sns_topic.tf
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_sns_topic" "cloudwatch_alarm" {
-  name         = "cloudwatch-alarms"
+  name         = format("cloudwatch-alarms_%s", local.production_workspace ? "production" : terraform.workspace)
   display_name = "cloudwatch_alarms"
 }
 

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -37,8 +37,22 @@ resource "aws_instance" "cyhy_mongo" {
     aws_security_group.cyhy_private_sg.id,
   ]
 
-  # The cyhy-commander needs these instances available to pull/push work
   depends_on = [
+    # The CloudWatch Agent running on these instances will create
+    # these log groups when they start up, but the CloudWatch log
+    # metric filters we create for detecting NVD and KEV sync failures
+    # require that they exist; therefore we create the log groups via
+    # Terraform.  At the same time, we want to avoid a race condition
+    # where these instances start up and create the log groups before
+    # the Terraform code can; hence, we add the log group resources to
+    # the depends_on clause for the instances.
+    #
+    # Instead of coming up with a clever way to isolate the particular
+    # log group that each instance depends on, I just list the whole
+    # set here.  The effect is the same.
+    aws_cloudwatch_log_group.instance_logs,
+    # The cyhy-commander needs these instances available to pull/push
+    # work
     aws_instance.cyhy_nessus,
     aws_instance.cyhy_nmap,
   ]

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -18,7 +18,7 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
   pattern = "\"cyhy-kevsync\" ERROR"
   # The instances' CloudWatch Agent's configurations define what the
   # log group name looks like.
-  log_group_name = "/instance-logs/${each.value.hostname}/syslog"
+  log_group_name = "/instance-logs/${each.value.hostname}"
 
   metric_transformation {
     # See below for explanation of the following substitution.

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -1,9 +1,9 @@
 # Create a log metric filter that bumps a metric when a syslog
 # message indicates a failure in the KEV sync cron job.
 resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
-  for_each = local.db_instances
+  for_each = local.db_instance_hostnames
 
-  name = "KEV Sync Failure Count - ${each.value.hostname}"
+  name = "KEV Sync Failure Count - ${each.value}"
   # Note that this pattern relies on:
   # 1. A logging.exception() call for any uncaught exceptions in the
   #    main() method of the cyhy-kevsync script in cisagov/cyhy-core
@@ -21,12 +21,12 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
   #
   # We have to account for the fact that the local hostname on the
   # instance drops the local domain name.
-  log_group_name = "/instance-logs/${split(".", each.value.hostname)[0]}"
+  log_group_name = "/instance-logs/${split(".", each.value)[0]}"
 
   metric_transformation {
     default_value = 0
     # See below for explanation of the following substitution.
-    name      = replace("kevsync_failure_count_${each.value.hostname}", ".", "_")
+    name      = replace("kevsync_failure_count_${each.value}", ".", "_")
     namespace = "DataIngestion"
     value     = 1
   }
@@ -34,28 +34,28 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
 
 # Alarm each time syslog indicates a failure in the KEV sync cron job.
 resource "aws_cloudwatch_metric_alarm" "kevsync_failure" {
-  for_each = local.db_instances
+  for_each = local.db_instance_hostnames
 
   alarm_actions             = [aws_sns_topic.kevsync_failure_alarm.arn, aws_sns_topic.cloudwatch_alarm.arn]
   alarm_description         = "Monitor KEV sync failures"
-  alarm_name                = format("kevsync_failure_%s_%s", each.value.hostname, local.production_workspace ? "production" : terraform.workspace)
+  alarm_name                = format("kevsync_failure_%s_%s", each.value, local.production_workspace ? "production" : terraform.workspace)
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = 1
   insufficient_data_actions = [aws_sns_topic.cloudwatch_alarm.arn]
   metric_query {
     # Replace periods in the hostname with underscores in order to avoid
     # "ValidationError: Invalid metrics list" errors.
-    id          = replace("kevsync_failure_rate_${each.value.hostname}", ".", "_")
-    expression  = replace("RATE(kevsync_failure_count_${each.value.hostname})", ".", "_")
-    label       = "KEV Sync Failure Rate of Change - ${each.value.hostname}"
+    id          = replace("kevsync_failure_rate_${each.value}", ".", "_")
+    expression  = replace("RATE(kevsync_failure_count_${each.value})", ".", "_")
+    label       = "KEV Sync Failure Rate of Change - ${each.value}"
     return_data = true
   }
   metric_query {
     # Replace periods in the hostname with underscores in order to avoid
     # "ValidationError: Invalid metrics list" errors.
-    id = replace("kevsync_failure_count_${each.value.hostname}", ".", "_")
+    id = replace("kevsync_failure_count_${each.value}", ".", "_")
     metric {
-      metric_name = replace("kevsync_failure_count_${each.value.hostname}", ".", "_")
+      metric_name = replace("kevsync_failure_count_${each.value}", ".", "_")
       namespace   = "DataIngestion"
       period      = 60
       stat        = "Maximum"

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -18,7 +18,10 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
   pattern = "\"cyhy-kevsync\" ERROR"
   # The instances' CloudWatch Agent's configurations define what the
   # log group name looks like.
-  log_group_name = "/instance-logs/${each.value.hostname}"
+  #
+  # We have to account for the fact that the local hostname on the
+  # instance drops the local domain name.
+  log_group_name = "/instance-logs/${split(".", each.value.hostname)}"
 
   metric_transformation {
     # See below for explanation of the following substitution.

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -11,7 +11,11 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
   #    into the system logger with the tag "cyhy-kevsync" when that
   #    script is run, similar to what is done for the cyhy-nvdsync script here:
   #    https://github.com/cisagov/cyhy_amis/blob/0f5974229edd909befc90ff5f4cf639327d373d8/ansible/roles/cyhy_commander/tasks/main.yml#L160
-  pattern = "cyhy-kevsync ERROR"
+  #
+  # The quotes around cyhy-kevsync are necessary because the hyphen is
+  # a special character in the log metric filter syntax:
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
+  pattern = "\"cyhy-kevsync\" ERROR"
   # The instances' CloudWatch Agent's configurations define what the
   # log group name looks like.
   log_group_name = "/instance-logs/${each.value.hostname}/syslog"

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
   #
   # We have to account for the fact that the local hostname on the
   # instance drops the local domain name.
-  log_group_name = "/instance-logs/${split(".", each.value.hostname)}"
+  log_group_name = "/instance-logs/${split(".", each.value.hostname)[0]}"
 
   metric_transformation {
     default_value = 0

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -55,9 +55,6 @@ resource "aws_cloudwatch_metric_alarm" "kevsync_failure" {
     # "ValidationError: Invalid metrics list" errors.
     id = replace("kevsync_failure_count_${each.value.hostname}", ".", "_")
     metric {
-      dimensions = {
-        InstanceId = each.key
-      }
       metric_name = replace("kevsync_failure_count_${each.value.hostname}", ".", "_")
       namespace   = "DataIngestion"
       period      = 60

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -24,6 +24,7 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
   log_group_name = "/instance-logs/${split(".", each.value.hostname)}"
 
   metric_transformation {
+    default_value = 0
     # See below for explanation of the following substitution.
     name      = replace("kevsync_failure_count_${each.value.hostname}", ".", "_")
     namespace = "DataIngestion"

--- a/terraform/kevsync_failure_alarms.tf
+++ b/terraform/kevsync_failure_alarms.tf
@@ -15,13 +15,8 @@ resource "aws_cloudwatch_log_metric_filter" "kevsync_failure" {
   # The quotes around cyhy-kevsync are necessary because the hyphen is
   # a special character in the log metric filter syntax:
   # https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
-  pattern = "\"cyhy-kevsync\" ERROR"
-  # The instances' CloudWatch Agent's configurations define what the
-  # log group name looks like.
-  #
-  # We have to account for the fact that the local hostname on the
-  # instance drops the local domain name.
-  log_group_name = "/instance-logs/${split(".", each.value)[0]}"
+  pattern        = "\"cyhy-kevsync\" ERROR"
+  log_group_name = aws_cloudwatch_log_group.instance_logs[each.value].name
 
   metric_transformation {
     default_value = 0

--- a/terraform/kevsync_failure_sns_topic.tf
+++ b/terraform/kevsync_failure_sns_topic.tf
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_sns_topic" "kevsync_failure_alarm" {
-  name         = "kevsync-failure-alarms"
+  name         = format("kevsync-failure-alarms_%s", local.production_workspace ? "production" : terraform.workspace)
   display_name = "kevsync_failure_alarms"
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -125,10 +125,8 @@ locals {
   # the order of the database instances.  On the other hand, we _do_
   # need to use the index of the instance into aws_instance.cyhy_mongo
   # to reconstruct the hostname.
-  db_instances = {
+  db_instance_hostnames = [
     for index, instance in aws_instance.cyhy_mongo :
-    instance.id => {
-      hostname = "database${index + 1}.${aws_route53_zone.cyhy_private_zone.name}",
-    }
-  }
+    "database${index + 1}.${aws_route53_zone.cyhy_private_zone.name}"
+  ]
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -126,7 +126,7 @@ locals {
   # need to use the index of the instance into aws_instance.cyhy_mongo
   # to reconstruct the hostname.
   db_instance_hostnames = toset([
-    for index, instance in aws_instance.cyhy_mongo :
+    for index in range(var.mongo_instance_count) :
     "database${index + 1}.${aws_route53_zone.cyhy_private_zone.name}"
   ])
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -125,8 +125,8 @@ locals {
   # the order of the database instances.  On the other hand, we _do_
   # need to use the index of the instance into aws_instance.cyhy_mongo
   # to reconstruct the hostname.
-  db_instance_hostnames = [
+  db_instance_hostnames = toset([
     for index, instance in aws_instance.cyhy_mongo :
     "database${index + 1}.${aws_route53_zone.cyhy_private_zone.name}"
-  ]
+  ])
 }

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -18,7 +18,10 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
   pattern = "\"cyhy-nvdsync\" ERROR"
   # The instances' CloudWatch Agent's configurations define what the
   # log group name looks like.
-  log_group_name = "/instance-logs/${each.value.hostname}"
+  #
+  # We have to account for the fact that the local hostname on the
+  # instance drops the local domain name.
+  log_group_name = "/instance-logs/${split(".", each.value.hostname)}"
 
   metric_transformation {
     # See below for explanation of the following substitution.

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -1,9 +1,9 @@
 # Create a log metric filter that bumps a metric when a syslog
 # message indicates a failure in the NVD sync cron job.
 resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
-  for_each = local.db_instances
+  for_each = local.db_instance_hostnames
 
-  name = "NVD Sync Failure Count - ${each.value.hostname}"
+  name = "NVD Sync Failure Count - ${each.value}"
   # Note that this pattern relies on:
   # 1. A logging.exception() call for any uncaught exceptions in the
   #    main() method of the cyhy-nvdsync script in cisagov/cyhy-core
@@ -21,12 +21,12 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
   #
   # We have to account for the fact that the local hostname on the
   # instance drops the local domain name.
-  log_group_name = "/instance-logs/${split(".", each.value.hostname)[0]}"
+  log_group_name = "/instance-logs/${split(".", each.value)[0]}"
 
   metric_transformation {
     default_value = 0
     # See below for explanation of the following substitution.
-    name      = replace("nvdsync_failure_count_${each.value.hostname}", ".", "_")
+    name      = replace("nvdsync_failure_count_${each.value}", ".", "_")
     namespace = "DataIngestion"
     value     = 1
   }
@@ -34,28 +34,28 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
 
 # Alarm each time syslog indicates a failure in the NVD sync cron job.
 resource "aws_cloudwatch_metric_alarm" "nvdsync_failure" {
-  for_each = local.db_instances
+  for_each = local.db_instance_hostnames
 
   alarm_actions             = [aws_sns_topic.cloudwatch_alarm.arn, ]
   alarm_description         = "Monitor NVD sync failures"
-  alarm_name                = format("nvdsync_failure_%s_%s", each.value.hostname, local.production_workspace ? "production" : terraform.workspace)
+  alarm_name                = format("nvdsync_failure_%s_%s", each.value, local.production_workspace ? "production" : terraform.workspace)
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = 1
   insufficient_data_actions = [aws_sns_topic.cloudwatch_alarm.arn, ]
   metric_query {
     # Replace periods in the hostname with underscores in order to avoid
     # "ValidationError: Invalid metrics list" errors.
-    id          = replace("nvdsync_failure_rate_${each.value.hostname}", ".", "_")
-    expression  = replace("RATE(nvdsync_failure_count_${each.value.hostname})", ".", "_")
-    label       = "NVD Sync Failure Rate of Change - ${each.value.hostname}"
+    id          = replace("nvdsync_failure_rate_${each.value}", ".", "_")
+    expression  = replace("RATE(nvdsync_failure_count_${each.value})", ".", "_")
+    label       = "NVD Sync Failure Rate of Change - ${each.value}"
     return_data = true
   }
   metric_query {
     # Replace periods in the hostname with underscores in order to avoid
     # "ValidationError: Invalid metrics list" errors.
-    id = replace("nvdsync_failure_count_${each.value.hostname}", ".", "_")
+    id = replace("nvdsync_failure_count_${each.value}", ".", "_")
     metric {
-      metric_name = replace("nvdsync_failure_count_${each.value.hostname}", ".", "_")
+      metric_name = replace("nvdsync_failure_count_${each.value}", ".", "_")
       namespace   = "DataIngestion"
       period      = 60
       stat        = "Maximum"

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
   #
   # We have to account for the fact that the local hostname on the
   # instance drops the local domain name.
-  log_group_name = "/instance-logs/${split(".", each.value.hostname)}"
+  log_group_name = "/instance-logs/${split(".", each.value.hostname)[0]}"
 
   metric_transformation {
     default_value = 0

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -18,7 +18,7 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
   pattern = "\"cyhy-nvdsync\" ERROR"
   # The instances' CloudWatch Agent's configurations define what the
   # log group name looks like.
-  log_group_name = "/instance-logs/${each.value.hostname}/syslog"
+  log_group_name = "/instance-logs/${each.value.hostname}"
 
   metric_transformation {
     # See below for explanation of the following substitution.

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -24,6 +24,7 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
   log_group_name = "/instance-logs/${split(".", each.value.hostname)}"
 
   metric_transformation {
+    default_value = 0
     # See below for explanation of the following substitution.
     name      = replace("nvdsync_failure_count_${each.value.hostname}", ".", "_")
     namespace = "DataIngestion"

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -55,9 +55,6 @@ resource "aws_cloudwatch_metric_alarm" "nvdsync_failure" {
     # "ValidationError: Invalid metrics list" errors.
     id = replace("nvdsync_failure_count_${each.value.hostname}", ".", "_")
     metric {
-      dimensions = {
-        InstanceId = each.key
-      }
       metric_name = replace("nvdsync_failure_count_${each.value.hostname}", ".", "_")
       namespace   = "DataIngestion"
       period      = 60

--- a/terraform/nvdsync_failure_alarms.tf
+++ b/terraform/nvdsync_failure_alarms.tf
@@ -11,7 +11,11 @@ resource "aws_cloudwatch_log_metric_filter" "nvdsync_failure" {
   #    into the system logger with the tag "cyhy-nvdsync" when that
   #    script is run, as is done in
   #    https://github.com/cisagov/cyhy_amis/blob/0f5974229edd909befc90ff5f4cf639327d373d8/ansible/roles/cyhy_commander/tasks/main.yml#L160
-  pattern = "cyhy-nvdsync ERROR"
+  #
+  # The quotes around cyhy-nvdsync are necessary because the hyphen is
+  # a special character in the log metric filter syntax:
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
+  pattern = "\"cyhy-nvdsync\" ERROR"
   # The instances' CloudWatch Agent's configurations define what the
   # log group name looks like.
   log_group_name = "/instance-logs/${each.value.hostname}/syslog"


### PR DESCRIPTION
## 🗣 Description ##

This code fixes a few bugs having to do with the Terraform code that generates alarms when the NVD or KEV sync processes fail.  These fixes should have been included as part of #394 but that PR was not sufficiently tested before merging.  (Mea culpa.)

## 💭 Motivation and context ##

This functionality is required for BOD22-01.  Resolves cisagov/cyhy-system#37.

## 🧪 Testing ##

@dav3r and @mcdonnnj were kind enough to test these changes in their CyHy development environments.  In particular, @dav3r ran `cyhy-kevsync` and forced it to fail.  It took a few iterations, but his testing eventually succeeded - to great acclaim!

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.