### PR TITLE
Add public A and PTR records for `vulnscan` instances

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -394,6 +394,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_route53_record.cyhy_bastion_pub_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cyhy_dashboard_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cyhy_database_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.cyhy_nessus_pub_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cyhy_ns_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cyhy_portscan_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cyhy_reporter_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -156,6 +156,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | aws | ~> 3.38 |
 | aws.public\_dns | ~> 3.38 |
 | cloudinit | ~> 2.0 |
+| null | n/a |
 | terraform | n/a |
 
 ## Modules ##
@@ -566,6 +567,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_vpc_peering_connection_options.bod_mgmt_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) | resource |
 | [aws_vpc_peering_connection_options.cyhy_bod_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) | resource |
 | [aws_vpc_peering_connection_options.cyhy_mgmt_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) | resource |
+| [null_resource.cyhy_nessus_pub_PTR](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_ami.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.bod_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.cyhy_mongo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -85,30 +85,11 @@ resource "aws_eip" "cyhy_nessus_random_eips" {
 }
 
 # Associate the appropriate Elastic IPs above with the CyHy Nessus
-# instances.  Since our elastic IPs are handled differently in
-# production vs. non-production workspaces, their corresponding
-# terraform resources (data.aws_eip.cyhy_nessus_eips,
-# data.aws_eip.cyhy_nessus_random_eips) may or may not be created.  To
-# handle that, we use "splat syntax" (the *), which resolves to either
-# an empty list (if the resource is not present in the current
-# workspace) or a valid list (if the resource is present).  Then we
-# use coalescelist() to choose the (non-empty) list containing the
-# valid eip.id. Finally, we use element() to choose the appropriate
-# element in that non-empty list, which is the allocation_id of our
-# elastic IP.  See
-# https://github.com/hashicorp/terraform/issues/11566#issuecomment-289417805
-#
-# VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
+# instances.
 resource "aws_eip_association" "cyhy_nessus_eip_assocs" {
-  count       = length(aws_instance.cyhy_nessus)
-  instance_id = aws_instance.cyhy_nessus[count.index].id
-  allocation_id = element(
-    coalescelist(
-      data.aws_eip.cyhy_nessus_eips[*].id,
-      aws_eip.cyhy_nessus_random_eips[*].id,
-    ),
-    count.index,
-  )
+  count         = length(aws_instance.cyhy_nessus)
+  instance_id   = aws_instance.cyhy_nessus[count.index].id
+  allocation_id = local.nessus_public_ips[count.index].id
 }
 
 # Note that the EBS volume contains production data. Therefore we need

--- a/terraform/cyhy_nessus_route53.tf
+++ b/terraform/cyhy_nessus_route53.tf
@@ -1,3 +1,17 @@
+# Public DNS records
+resource "aws_route53_record" "cyhy_nessus_pub_A" {
+  count    = var.nessus_instance_count
+  provider = aws.public_dns
+
+  zone_id = data.terraform_remote_state.dns.outputs.cyber_dhs_gov_zone.id
+  name    = "vulnscan${count.index + 1}.${terraform.workspace}.${local.cyhy_public_subdomain}${data.terraform_remote_state.dns.outputs.cyber_dhs_gov_zone.name}"
+  type    = "A"
+  ttl     = 30
+  records = [
+    local.nessus_public_ips[count.index],
+  ]
+}
+
 # Private DNS records
 resource "aws_route53_record" "cyhy_vulnscan_A" {
   count   = local.count_vuln_scanner

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -91,14 +91,11 @@ locals {
   # production vs. non-production workspaces, their corresponding
   # Terraform resources (data.aws_eip.cyhy_nessus_eips,
   # data.aws_eip.cyhy_nessus_random_eips) may or may not be created.  To
-  # handle that, we use "splat syntax" (the *), which resolves to either
-  # an empty list (if the resource is not present in the current
-  # workspace) or a valid list (if the resource is present).  Then we
-  # use coalescelist() to choose the (non-empty) list containing the
-  # valid eip.public_ips.
+  # handle that, we use coalescelist() to choose the (non-empty) list
+  # containing the valid eip objects.
   nessus_public_ips = coalescelist(
-    data.aws_eip.cyhy_nessus_eips[*].public_ip,
-    aws_eip.cyhy_nessus_random_eips[*].public_ip,
+    data.aws_eip.cyhy_nessus_eips,
+    aws_eip.cyhy_nessus_random_eips,
   )
 
   # domain names to use for internal DNS

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -86,6 +86,21 @@ locals {
     "egress",
   ]
 
+  # Get the public IPs associated with our nessus instances.
+  # Since our elastic IPs are handled differently in
+  # production vs. non-production workspaces, their corresponding
+  # Terraform resources (data.aws_eip.cyhy_nessus_eips,
+  # data.aws_eip.cyhy_nessus_random_eips) may or may not be created.  To
+  # handle that, we use "splat syntax" (the *), which resolves to either
+  # an empty list (if the resource is not present in the current
+  # workspace) or a valid list (if the resource is present).  Then we
+  # use coalescelist() to choose the (non-empty) list containing the
+  # valid eip.public_ips.
+  nessus_public_ips = coalescelist(
+    data.aws_eip.cyhy_nessus_eips[*].public_ip,
+    aws_eip.cyhy_nessus_random_eips[*].public_ip,
+  )
+
   # domain names to use for internal DNS
   cyhy_private_domain = "cyhy"
   bod_private_domain  = "bod"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds public A and PTR records for the `vulnscan` instances.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We need live A and PTR records to help our `vulnscan` instances look legitimate. This is part of an effort to update our Nessus SMTP configuration for scanning to avoid our `vulnscan` instances getting put on spamlists (such as [Spamhaus](https://www.spamhaus.org/)).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I also verified that deploying and redeploying a `vulnscan` instances in my testing environment successfully created and updated both public records.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
