### PR TITLE
Configure SMTP settings for the CyHy base policy for Nessus

### DIFF
--- a/ansible/roles/nessus/templates/cyhy-base-nessus8-policy.xml.j2
+++ b/ansible/roles/nessus/templates/cyhy-base-nessus8-policy.xml.j2
@@ -485,7 +485,7 @@
 <preferenceType>entry</preferenceType>
 <preferenceName>To address :</preferenceName>
 <preferenceValues>postmaster@[AUTO_REPLACED_IP]</preferenceValues>
-<selectedValue>postmaster@[AUTO_REPLACED_IP]</selectedValue>
+<selectedValue>CyHyTesting@[AUTO_REPLACED_IP]</selectedValue>
 </item>
 <item>
 <pluginId>11038</pluginId>
@@ -494,7 +494,7 @@
 <preferenceType>entry</preferenceType>
 <preferenceName>From address :</preferenceName>
 <preferenceValues>nobody@example.edu</preferenceValues>
-<selectedValue>nobody@example.com</selectedValue>
+<selectedValue>CyHyTesting@{{ smtp_hostname }}</selectedValue>
 </item>
 <item>
 <pluginId>11038</pluginId>
@@ -503,7 +503,7 @@
 <preferenceType>entry</preferenceType>
 <preferenceName>Third party domain :</preferenceName>
 <preferenceValues>example.edu</preferenceValues>
-<selectedValue>example.com</selectedValue>
+<selectedValue>{{ smtp_hostname }}</selectedValue>
 </item>
 <item>
 <pluginId>11149</pluginId>

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -154,7 +154,8 @@ module "cyhy_nessus_ansible_provisioner" {
     "host=${length(aws_instance.cyhy_nessus[*].private_ip) > 0 ? element(aws_instance.cyhy_nessus[*].private_ip, count.index) : ""}",
     "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_runner,nessus",
-    "nessus_activation_code=${var.nessus_activation_codes[count.index]}"
+    "nessus_activation_code=${var.nessus_activation_codes[count.index]}",
+    "smtp_hostname=${aws_route53_record.cyhy_nessus_pub_A[count.index].name}"
   ]
   playbook = "../ansible/playbook.yml"
   dry_run  = false


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the base policy we load into Nessus in our `vulnscan` instances. The SMTP settings are updated to use the public A record for each isntance.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Now that the `vulnscan` instances have public A and PTR records (as of #425) we can leverage those to configure Nessus appropriately. This will allow our Nessus scanners to look more legitimate and to hopefully prevent the EIPs our instances use from being flagged by third parties such as [Spamhaus](https://www.spamhaus.org/).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes. I verified this was deployed as expected in my testing environment. I also verified these changes looked in-line with the artisanal implementation in the current production workspace.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
