### PR TITLE
Fix EBS volume destruction

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -146,15 +146,15 @@ terraform apply -var-file=<your_workspace>.tfvars
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 3.38 |
+| aws | ~> 3.62 |
 | cloudinit | ~> 2.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.38 |
-| aws.public\_dns | ~> 3.38 |
+| aws | ~> 3.62 |
+| aws.public\_dns | ~> 3.62 |
 | cloudinit | ~> 2.0 |
 | terraform | n/a |
 

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -88,7 +88,7 @@ resource "aws_volume_attachment" "bod_report_data_attachment" {
   volume_id   = aws_ebs_volume.bod_report_data.id
   instance_id = aws_instance.bod_docker.id
 
-  skip_destroy = true
+  stop_instance_before_detaching = true
 }
 
 # Note that the EBS volumes contain production data. Therefore we need

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -39,8 +39,10 @@ resource "aws_instance" "bod_docker" {
     aws_security_group.bod_docker_sg.id,
   ]
 
-  # BOD 18-01 scanning needs the BOD Lambdas and the database available to function
   depends_on = [
+    # This volume is needed for BOD 18-01 scanning output
+    aws_ebs_volume.bod_report_data,
+    # BOD 18-01 scanning needs the BOD Lambdas and the database available to function
     aws_instance.cyhy_mongo,
     aws_lambda_function.lambdas,
   ]

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -130,7 +130,7 @@ resource "aws_volume_attachment" "cyhy_mongo_data_attachment" {
   volume_id   = aws_ebs_volume.cyhy_mongo_data.id
   instance_id = aws_instance.cyhy_mongo[0].id
 
-  skip_destroy = true
+  stop_instance_before_detaching = true
 }
 
 resource "aws_volume_attachment" "cyhy_mongo_journal_attachment" {
@@ -138,7 +138,7 @@ resource "aws_volume_attachment" "cyhy_mongo_journal_attachment" {
   volume_id   = aws_ebs_volume.cyhy_mongo_journal.id
   instance_id = aws_instance.cyhy_mongo[0].id
 
-  skip_destroy = true
+  stop_instance_before_detaching = true
 }
 
 resource "aws_volume_attachment" "cyhy_mongo_log_attachment" {
@@ -146,7 +146,7 @@ resource "aws_volume_attachment" "cyhy_mongo_log_attachment" {
   volume_id   = aws_ebs_volume.cyhy_mongo_log.id
   instance_id = aws_instance.cyhy_mongo[0].id
 
-  skip_destroy = true
+  stop_instance_before_detaching = true
 }
 
 # Provision the mongo EC2 instance via Ansible

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -51,8 +51,11 @@ resource "aws_instance" "cyhy_mongo" {
     # log group that each instance depends on, I just list the whole
     # set here.  The effect is the same.
     aws_cloudwatch_log_group.instance_logs,
-    # The cyhy-commander needs these instances available to pull/push
-    # work
+    # These volumes are needed for MongoDB to function
+    aws_ebs_volume.cyhy_mongo_data,
+    aws_ebs_volume.cyhy_mongo_journal,
+    aws_ebs_volume.cyhy_mongo_log,
+    # The cyhy-commander needs these instances available to pull/push work
     aws_instance.cyhy_nessus,
     aws_instance.cyhy_nmap,
   ]

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -142,7 +142,7 @@ resource "aws_volume_attachment" "nessus_cyhy_runner_data_attachment" {
   volume_id   = aws_ebs_volume.nessus_cyhy_runner_data[count.index].id
   instance_id = aws_instance.cyhy_nessus[count.index].id
 
-  skip_destroy = true
+  stop_instance_before_detaching = true
 }
 
 # Provision a Nessus EC2 instance via Ansible

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -37,6 +37,11 @@ resource "aws_instance" "cyhy_nessus" {
     aws_security_group.cyhy_scanner_sg.id,
   ]
 
+  depends_on = [
+    # This volume is needed for cyhy-runner jobs
+    aws_ebs_volume.nessus_cyhy_runner_data,
+  ]
+
   user_data_base64     = data.cloudinit_config.cyhy_nessus_cloud_init_tasks[count.index].rendered
   iam_instance_profile = aws_iam_instance_profile.cyhy_nessus.name
 

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "cyhy_nessus" {
 # EIPs can be created via dhs-ncats/elastic-ips-terraform or manually,
 # and are intended to be a public IP address that rarely changes.
 data "aws_eip" "cyhy_nessus_eips" {
-  count = local.production_workspace ? length(aws_instance.cyhy_nessus) : 0
+  count = local.production_workspace ? var.nessus_instance_count : 0
   public_ip = cidrhost(
     var.cyhy_elastic_ip_cidr_block,
     var.cyhy_vulnscan_first_elastic_ip_offset + count.index,
@@ -76,7 +76,7 @@ data "aws_eip" "cyhy_nessus_eips" {
 # These EIPs are only created in *non-production* workspaces and are
 # randomly-assigned public IP address for temporary use.
 resource "aws_eip" "cyhy_nessus_random_eips" {
-  count = local.production_workspace ? 0 : length(aws_instance.cyhy_nessus)
+  count = local.production_workspace ? 0 : var.nessus_instance_count
   vpc   = true
   tags = {
     "Name"           = format("CyHy Nessus EIP %d", count.index + 1)
@@ -100,7 +100,7 @@ resource "aws_eip" "cyhy_nessus_random_eips" {
 #
 # VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
 resource "aws_eip_association" "cyhy_nessus_eip_assocs" {
-  count       = length(aws_instance.cyhy_nessus)
+  count       = var.nessus_instance_count
   instance_id = aws_instance.cyhy_nessus[count.index].id
   allocation_id = element(
     coalescelist(
@@ -122,7 +122,7 @@ resource "aws_eip_association" "cyhy_nessus_eip_assocs" {
 # inside of the lifecycle block
 # (https://github.com/hashicorp/terraform/issues/3116).
 resource "aws_ebs_volume" "nessus_cyhy_runner_data" {
-  count             = length(aws_instance.cyhy_nessus)
+  count             = var.nessus_instance_count
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   type      = "gp3"
@@ -137,7 +137,7 @@ resource "aws_ebs_volume" "nessus_cyhy_runner_data" {
 }
 
 resource "aws_volume_attachment" "nessus_cyhy_runner_data_attachment" {
-  count       = length(aws_instance.cyhy_nessus)
+  count       = var.nessus_instance_count
   device_name = "/dev/xvdb"
   volume_id   = aws_ebs_volume.nessus_cyhy_runner_data[count.index].id
   instance_id = aws_instance.cyhy_nessus[count.index].id

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -145,7 +145,7 @@ resource "aws_volume_attachment" "nmap_cyhy_runner_data_attachment" {
   volume_id   = aws_ebs_volume.nmap_cyhy_runner_data[count.index].id
   instance_id = aws_instance.cyhy_nmap[count.index].id
 
-  skip_destroy = true
+  stop_instance_before_detaching = true
 }
 
 # Provision an nmap EC2 instance via Ansible

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -42,6 +42,11 @@ resource "aws_instance" "cyhy_nmap" {
     aws_security_group.cyhy_scanner_sg.id,
   ]
 
+  depends_on = [
+    # This volume is needed for cyhy-runner jobs
+    aws_ebs_volume.nmap_cyhy_runner_data,
+  ]
+
   user_data_base64     = data.cloudinit_config.cyhy_nmap_cloud_init_tasks[count.index].rendered
   iam_instance_profile = aws_iam_instance_profile.cyhy_nmap.name
 

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -39,8 +39,10 @@ resource "aws_instance" "cyhy_reporter" {
     aws_security_group.cyhy_private_sg.id,
   ]
 
-  # Reporting needs the database available to function
   depends_on = [
+    # This volume is needed for cyhy-reports data
+    aws_ebs_volume.cyhy_reporter_data,
+    # Reporting needs the database available to function
     aws_instance.cyhy_mongo,
   ]
 

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -87,7 +87,7 @@ resource "aws_volume_attachment" "cyhy_reporter_data_attachment" {
   volume_id   = aws_ebs_volume.cyhy_reporter_data.id
   instance_id = aws_instance.cyhy_reporter.id
 
-  skip_destroy = true
+  stop_instance_before_detaching = true
 }
 
 # Provision the reporter EC2 instance via Ansible

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,12 +7,14 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 3.62.0 of the Terraform AWS provider adds the
+    # `stop_instance_before_detaching` argument to the `aws_volume_attachment`
+    # resource.
+    # https://github.com/hashicorp/terraform-provider-aws/pull/21144
+    # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3620-october-08-2021
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.62"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does three things:
1. Switch from the `skip_destroy` argument to the `stop_instance_before_detaching` argument for `aws_volume_attachment` resources.
1. Change to using the `*_instance_count` variables for the `count` argument in the `nmap` and `nessus` related resources.
1. Make each instance type depend on any EBS volumes it uses.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Changing the argument used is to help ensure volume detachment proceeds smoothly. We can swap them like this only because the volume attachments we use are designed to be for the life of the instance. Removing the explicit dependency of using `length(aws_instance.<instance_type>)` not only allows the EBS volumes that do not have any implicit dependencies to be created in parallel, but also allows the instances to be destroyed in the same way. Without this change the instances will not be destroyed until after the EBS volumes are destroyed, but the EBS volumes cannot be destroyed while the instances are live. Lastly since the EBS volumes used by each instance are necessary for regular functions we make each instance `depends_on` the EBS volumes it uses. This should guarantee they are available for attachment as soon as the respective instance is created.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I was able to successfully tear down an existing deployment, perform a greenfield apply, and then destroy that deployment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
