### PR TITLE
Add an EBS volume to store VDP output

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -196,6 +196,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_ebs_volume.cyhy_reporter_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
 | [aws_ebs_volume.nessus_cyhy_runner_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
 | [aws_ebs_volume.nmap_cyhy_runner_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
+| [aws_ebs_volume.vdp_report_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
 | [aws_eip.bod_nonproduction_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_eip.cyhy_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_eip.cyhy_nessus_random_eips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
@@ -550,6 +551,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_volume_attachment.cyhy_reporter_data_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_volume_attachment.nessus_cyhy_runner_data_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_volume_attachment.nmap_cyhy_runner_data_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
+| [aws_volume_attachment.vdp_report_data_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_vpc.bod_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc.cyhy_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc.mgmt_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |

--- a/terraform/bod_docker_cloud_init.tf
+++ b/terraform/bod_docker_cloud_init.tf
@@ -19,10 +19,23 @@ data "cloudinit_config" "bod_docker_cloud_init_tasks" {
       label         = "report_data"
       mount_options = "defaults"
       mount_point   = "/var/cyhy/orchestrator/output"
-      num_disks     = 2
+      num_disks     = 3
     })
     content_type = "text/x-shellscript"
     filename     = "orchestrator_disk_setup.sh"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/disk_setup.tpl.sh", {
+      device_name   = "/dev/xvdc"
+      fs_type       = "xfs"
+      label         = "vdp_data"
+      mount_options = "defaults"
+      mount_point   = "/var/cyhy/vdp/output"
+      num_disks     = 3
+    })
+    content_type = "text/x-shellscript"
+    filename     = "vdp_disk_setup.sh"
   }
 
   part {

--- a/terraform/scripts/deploy_new_docker_ami.sh
+++ b/terraform/scripts/deploy_new_docker_ami.sh
@@ -34,4 +34,5 @@ terraform apply -var-file="$workspace.tfvars" \
   -target=aws_route53_record.bod_docker_A \
   -target=aws_route53_record.bod_rev_docker_PTR \
   -target=aws_volume_attachment.bod_report_data_attachment \
+  -target=aws_volume_attachment.vdp_report_data_attachment \
   -target=module.bod_docker_ansible_provisioner


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds an EBS volume, attachment, and mounting cloud-init to the BOD docker instance. This will ensure that the output of the BOD 20-01 VDP scanning is preserved.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This aligns the VDP scanning with the way data is preserved for the BOD 18-01 scanning.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I ensured that after when my testing environment was deployed I saw the appropriate mount points.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
