### PR TITLE
Ensure `mongo` instance cloud-init scripts run in the necessary order

### DIFF
--- a/terraform/cyhy_mongo_cloud_init.tf
+++ b/terraform/cyhy_mongo_cloud_init.tf
@@ -24,13 +24,13 @@ data "cloudinit_config" "cyhy_mongo_cloud_init_tasks" {
       num_disks     = 4
     })
     content_type = "text/x-shellscript"
-    filename     = "mongo_data_disk_setup.sh"
+    filename     = "01_mongo_data_disk_setup.sh"
   }
 
   part {
     content      = file("${path.module}/cloud-init/mongo_journal_mountpoint_setup.sh")
     content_type = "text/x-shellscript"
-    filename     = "mongo_journal_mountpoint_setup.sh"
+    filename     = "02_mongo_journal_mountpoint_setup.sh"
   }
 
   part {
@@ -45,7 +45,7 @@ data "cloudinit_config" "cyhy_mongo_cloud_init_tasks" {
       num_disks     = 4
     })
     content_type = "text/x-shellscript"
-    filename     = "mongo_journal_disk_setup.sh"
+    filename     = "03_mongo_journal_disk_setup.sh"
   }
 
   part {
@@ -58,13 +58,13 @@ data "cloudinit_config" "cyhy_mongo_cloud_init_tasks" {
       num_disks     = 4
     })
     content_type = "text/x-shellscript"
-    filename     = "mongo_log_disk_setup.sh"
+    filename     = "04_mongo_log_disk_setup.sh"
   }
 
   part {
     content      = file("${path.module}/cloud-init/mongo_dir_setup.sh")
     content_type = "text/x-shellscript"
-    filename     = "mongo_dir_setup.sh"
+    filename     = "05_mongo_dir_setup.sh"
   }
 
   part {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the local names for the `cloud-init` shellscripts to ensure that they run in the desired order.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In #424 I refactored the `cloud-init` configurations for each of the instances, but in the case of the `mongo` instances I neglected to account for the fact that `cloud-init` runs them in the order given by the Python `sorted()` function. This resulted in the journal shellscript running before the data shellscript, which is a problem because the journal is in a subdirectory of the data directory. As a result `cloud-init` failed while running and MongoDB could not successfully start.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I ensured that redeploying with this change in place resulted in the `mongod` service successfully starting instead of failing a `RequiresMountsFor` check.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
