### PR TITLE
Increase volume sizes on reporter and vulnscan instances

### DIFF
--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -29,7 +29,7 @@ resource "aws_instance" "cyhy_nessus" {
   subnet_id = aws_subnet.cyhy_vulnscanner_subnet.id
 
   root_block_device {
-    volume_size = local.production_workspace ? 200 : 16
+    volume_size = local.production_workspace ? 200 : 32
     volume_type = "gp3"
   }
 

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -75,7 +75,7 @@ resource "aws_instance" "cyhy_reporter" {
 resource "aws_ebs_volume" "cyhy_reporter_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   type              = "io2"
-  size              = local.production_workspace ? 500 : 5
+  size              = local.production_workspace ? 1000 : 5
   iops              = 100
   encrypted         = true
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR increases the size of two volumes:
* The data volume for Production reporter instances
* The root volume for non-Production vulnscan instances

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The Production reporter volume was almost 90% full, so it made sense to expand it since we are now adding about 5 GB of reports each week.

The non-Production vulnscan root volume needed to be expanded because it kept filling up during my most recent round of testing.  This is likely a combination of the ever-growing number of vulnerability plugins that must be downloaded, as well as the general hunger for more disk space as newer operating system software is added.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The reporter change has been applied in Production and verified.
The vulnscan change has been applied in a non-Production environment and verified.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
