### PR TITLE
Adjust the `cloud-init` that `chown`s directories

### DIFF
--- a/terraform/bod_docker_cloud_init.tf
+++ b/terraform/bod_docker_cloud_init.tf
@@ -25,6 +25,28 @@ data "cloudinit_config" "bod_docker_cloud_init_tasks" {
   }
 
   part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_docker_chown_cyhy_directory.sh"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/log/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_docker_chown_cyhy_log_directory.sh"
+  }
+
+  part {
     content = templatefile("${path.module}/cloud-init/disk_setup.tpl.sh", {
       device_name   = "/dev/xvdb"
       fs_type       = "xfs"
@@ -34,7 +56,7 @@ data "cloudinit_config" "bod_docker_cloud_init_tasks" {
       num_disks     = 3
     })
     content_type = "text/x-shellscript"
-    filename     = "00_orchestrator_disk_setup.sh"
+    filename     = "01_orchestrator_disk_setup.sh"
   }
 
   part {
@@ -45,18 +67,7 @@ data "cloudinit_config" "bod_docker_cloud_init_tasks" {
       path           = "/var/cyhy/orchestrator/output"
     })
     content_type = "text/x-shellscript"
-    filename     = "01_cyhy_docker_chown_orchestrator_output_directory.sh"
-  }
-
-  part {
-    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
-      group          = "cyhy"
-      is_mount_point = false
-      owner          = "cyhy"
-      path           = "/var/cyhy"
-    })
-    content_type = "text/x-shellscript"
-    filename     = "02_cyhy_docker_chown_cyhy_directory.sh"
+    filename     = "02_cyhy_docker_chown_orchestrator_output_directory.sh"
   }
 
   part {

--- a/terraform/cloud-init/chown_directory.tpl.sh
+++ b/terraform/cloud-init/chown_directory.tpl.sh
@@ -24,6 +24,14 @@ if "${is_mount_point}"; then
   done
 fi
 
+# ensure the path exists
+#
+# This is a Terraform template file, and the path variable is passed
+# in via templatefile().
+#
+# shellcheck disable=SC2154
+mkdir --parents "${path}"
+
 # chown the path
 #
 # This is a Terraform template file, and the group, owner, and path

--- a/terraform/cyhy_dashboard_cloud_init.tf
+++ b/terraform/cyhy_dashboard_cloud_init.tf
@@ -12,17 +12,6 @@ data "cloudinit_config" "cyhy_dashboard_cloud_init_tasks" {
   }
 
   part {
-    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
-      group          = "cyhy"
-      is_mount_point = false
-      owner          = "cyhy"
-      path           = "/var/cyhy"
-    })
-    content_type = "text/x-shellscript"
-    filename     = "cyhy_dashboard_chown_cyhy_directory.sh"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/set_hostname.tpl.yml", {
       # Note that the hostname here is identical to what is set in
       # the corresponding DNS A record.
@@ -32,5 +21,27 @@ data "cloudinit_config" "cyhy_dashboard_cloud_init_tasks" {
     content_type = "text/cloud-config"
     filename     = "set_hostname.yml"
     merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_dashboard_chown_cyhy_directory.sh"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/log/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_dashboard_chown_cyhy_log_directory.sh"
   }
 }

--- a/terraform/cyhy_nessus_cloud_init.tf
+++ b/terraform/cyhy_nessus_cloud_init.tf
@@ -27,6 +27,28 @@ data "cloudinit_config" "cyhy_nessus_cloud_init_tasks" {
   }
 
   part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_nessus_chown_cyhy_directory.sh"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/log/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_nessus_chown_cyhy_log_directory.sh"
+  }
+
+  part {
     content = templatefile("${path.module}/cloud-init/disk_setup.tpl.sh", {
       device_name   = "/dev/xvdb"
       fs_type       = "ext4"
@@ -36,7 +58,7 @@ data "cloudinit_config" "cyhy_nessus_cloud_init_tasks" {
       num_disks     = 2
     })
     content_type = "text/x-shellscript"
-    filename     = "00_cyhy_runner_disk_setup.sh"
+    filename     = "01_cyhy_runner_disk_setup.sh"
   }
 
   part {
@@ -47,17 +69,6 @@ data "cloudinit_config" "cyhy_nessus_cloud_init_tasks" {
       path           = "/var/cyhy/runner"
     })
     content_type = "text/x-shellscript"
-    filename     = "01_cyhy_nessus_chown_runner_directory.sh"
-  }
-
-  part {
-    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
-      group          = "cyhy"
-      is_mount_point = false
-      owner          = "cyhy"
-      path           = "/var/cyhy"
-    })
-    content_type = "text/x-shellscript"
-    filename     = "02_cyhy_nessus_chown_cyhy_directory.sh"
+    filename     = "02_cyhy_nessus_chown_runner_directory.sh"
   }
 }

--- a/terraform/cyhy_nmap_cloud_init.tf
+++ b/terraform/cyhy_nmap_cloud_init.tf
@@ -27,6 +27,28 @@ data "cloudinit_config" "cyhy_nmap_cloud_init_tasks" {
   }
 
   part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_nmap_chown_cyhy_directory.sh"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = false
+      owner          = "cyhy"
+      path           = "/var/log/cyhy"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "00_cyhy_nmap_chown_cyhy_log_directory.sh"
+  }
+
+  part {
     content = templatefile("${path.module}/cloud-init/disk_setup.tpl.sh", {
       device_name   = "/dev/xvdb"
       fs_type       = "ext4"
@@ -36,7 +58,7 @@ data "cloudinit_config" "cyhy_nmap_cloud_init_tasks" {
       num_disks     = 2
     })
     content_type = "text/x-shellscript"
-    filename     = "00_cyhy_runner_disk_setup.sh"
+    filename     = "01_cyhy_runner_disk_setup.sh"
   }
 
   part {
@@ -47,17 +69,6 @@ data "cloudinit_config" "cyhy_nmap_cloud_init_tasks" {
       path           = "/var/cyhy/runner"
     })
     content_type = "text/x-shellscript"
-    filename     = "01_cyhy_nmap_chown_runner_directory.sh"
-  }
-
-  part {
-    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
-      group          = "cyhy"
-      is_mount_point = false
-      owner          = "cyhy"
-      path           = "/var/cyhy"
-    })
-    content_type = "text/x-shellscript"
-    filename     = "02_cyhy_nmap_chown_cyhy_directory.sh"
+    filename     = "02_cyhy_nmap_chown_runner_directory.sh"
   }
 }

--- a/terraform/cyhy_reporter_cloud_init.tf
+++ b/terraform/cyhy_reporter_cloud_init.tf
@@ -25,30 +25,6 @@ data "cloudinit_config" "cyhy_reporter_cloud_init_tasks" {
   }
 
   part {
-    content = templatefile("${path.module}/cloud-init/disk_setup.tpl.sh", {
-      device_name   = "/dev/xvdb"
-      fs_type       = "xfs"
-      label         = "report_data"
-      mount_options = "defaults"
-      mount_point   = "/var/cyhy/reports/output"
-      num_disks     = 2
-    })
-    content_type = "text/x-shellscript"
-    filename     = "00_cyhy_reports_disk_setup.sh"
-  }
-
-  part {
-    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
-      group          = "cyhy"
-      is_mount_point = true
-      owner          = "cyhy"
-      path           = "/var/cyhy/reports/output"
-    })
-    content_type = "text/x-shellscript"
-    filename     = "01_cyhy_reports_chown_reports_output_directory.sh"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
       group          = "cyhy"
       is_mount_point = false
@@ -56,7 +32,7 @@ data "cloudinit_config" "cyhy_reporter_cloud_init_tasks" {
       path           = "/var/cyhy"
     })
     content_type = "text/x-shellscript"
-    filename     = "02_cyhy_reports_chown_cyhy_directory.sh"
+    filename     = "00_cyhy_reports_chown_cyhy_directory.sh"
   }
 
   part {
@@ -67,6 +43,30 @@ data "cloudinit_config" "cyhy_reporter_cloud_init_tasks" {
       path           = "/var/log/cyhy"
     })
     content_type = "text/x-shellscript"
-    filename     = "03_cyhy_reports_chown_cyhy_log_directory.sh"
+    filename     = "00_cyhy_reports_chown_cyhy_log_directory.sh"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/disk_setup.tpl.sh", {
+      device_name   = "/dev/xvdb"
+      fs_type       = "xfs"
+      label         = "report_data"
+      mount_options = "defaults"
+      mount_point   = "/var/cyhy/reports/output"
+      num_disks     = 2
+    })
+    content_type = "text/x-shellscript"
+    filename     = "01_cyhy_reports_disk_setup.sh"
+  }
+
+  part {
+    content = templatefile("${path.module}/cloud-init/chown_directory.tpl.sh", {
+      group          = "cyhy"
+      is_mount_point = true
+      owner          = "cyhy"
+      path           = "/var/cyhy/reports/output"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "02_cyhy_reports_chown_reports_output_directory.sh"
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request is focused on fixing an oversight from #436 regarding the `cloud-init` for `cyhy_mongo` instances as well as updating the `cloud-init` configurations used to better reflect the functionality of the local Ansible role removed in #436.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We neglected to add `cloud-init` to `chown` the `/var/cyhy` directory on `cyhy_mongo` instances in #436. Additionally the local Ansible role that was removed was designed to `chown` the `/var/log/cyhy` directory in addition to the `/var/cyhy` directory as well as create them if they did not exist.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I confirmed after deploying my instances with this branch's changes included that the two directories (`/var/cyhy` and `/var/log/cyhy`) existed and had appropriate permissions on the non-bastion hosts. I then checked that this was the same configuration seen on production instances to verify that we were aligned with existing behavior.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
