### PR TITLE
Install Python 2 where appropriate, and remove it elsewhere

### DIFF
--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all:
+- hosts: all
   name: Install Python and Pip
   become: yes
   become_method: sudo

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -1,15 +1,47 @@
 ---
-- hosts: all
-  name: Install pip3/python3
+- hosts: all:
+  name: Install Python and Pip
   become: yes
   become_method: sudo
   roles:
-    - pip
-    - python
+    - role: pip
+      vars:
+        # Install and pip2 for all instances that will run Python 2
+        # CyHy code.  Right now this is all instances other than the
+        # bastion, nessus, and nmap instances.
+        #
+        # Note that we are joining the hostnames via a pipe character,
+        # which is a disallowed character in a hostname; therefore, if
+        # search() finds a match we know that it matches one of the
+        # strings in the list.  In other words, there is no chance
+        # that a hostname could match the end of one string, plus a
+        # pipe, plus the beginning of the next string.  This is what
+        # allows us to do the search in one fell swoop as opposed to
+        # writing multiple checks against individual hostnames.
+        install_pip2: {{ inventory_hostname_short is not search(["bastion", "nessus", "nmap"] | join("|")) }}
+    - role: python
+      vars:
+        # Install Python 2 for all instances that will run Python 2
+        # CyHy code.  Right now this is all instances other than the
+        # bastion, nessus, and nmap instances.
+        #
+        # Note that we are joining the hostnames via a pipe character,
+        # which is a disallowed character in a hostname; therefore, if
+        # search() finds a match we know that it matches one of the
+        # strings in the list.  In other words, there is no chance
+        # that a hostname could match the end of one string, plus a
+        # pipe, plus the beginning of the next string.  This is what
+        # allows us to do the search in one fell swoop as opposed to
+        # writing multiple checks against individual hostnames.
+        install_python2: {{ inventory_hostname_short is not search(["bastion", "nessus", "nmap"] | join("|")) }}
 
-# Any instances that are built on Debian Buster should have Python 2 removed
+# Any instances that are not built on Amazon Linux 2 and don't require
+# Python 2 should have it removed.
+#
+# Amazon Linux 2 is antiquated and requires Python2 to function, and
+# the remove_python2 Ansible role is a no-op on that platform.
 - hosts: bastion,nessus,nmap
-  name: Remove pip2/python2
+  name: Remove Python 2
   become: yes
   become_method: sudo
   roles:

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -6,34 +6,14 @@
   roles:
     - role: pip
       vars:
-        # Install pip2 for all instances that will run Python 2
-        # CyHy code.  Right now this is all instances other than the
-        # bastion, docker, nessus, and nmap instances.
-        #
-        # Note that we are joining the hostnames via a pipe character,
-        # which is a disallowed character in a hostname; therefore, if
-        # search() finds a match we know that it matches one of the
-        # strings in the list.  In other words, there is no chance
-        # that a hostname could match the end of one string, plus a
-        # pipe, plus the beginning of the next string.  This is what
-        # allows us to do the search in one fell swoop as opposed to
-        # writing multiple checks against individual hostnames.
-        install_pip2: inventory_hostname_short is not search({{ ["bastion", "docker", "nessus", "nmap"] | join("|") }})
+        # Install pip2 for all images that will run Python 2 CyHy code.
+        # Right now these are the dashboard, mongo, and reporter AMIs.
+        install_pip2: "{{ inventory_hostname_short is in ['dashboard', 'mongo', 'reporter'] }}"
     - role: python
       vars:
-        # Install Python 2 for all instances that will run Python 2
-        # CyHy code.  Right now this is all instances other than the
-        # bastion, docker, nessus, and nmap instances.
-        #
-        # Note that we are joining the hostnames via a pipe character,
-        # which is a disallowed character in a hostname; therefore, if
-        # search() finds a match we know that it matches one of the
-        # strings in the list.  In other words, there is no chance
-        # that a hostname could match the end of one string, plus a
-        # pipe, plus the beginning of the next string.  This is what
-        # allows us to do the search in one fell swoop as opposed to
-        # writing multiple checks against individual hostnames.
-        install_python2: inventory_hostname_short is not search({{ ["bastion", "docker", "nessus", "nmap"] | join("|") }})
+        # Install Python 2 for images that will run Python 2 CyHy code.
+        # Right now these are the dashboard, mongo, and reporter AMIs.
+        install_python2: "{{ inventory_hostname_short is in ['dashboard', 'mongo', 'reporter'] }}"
 
 # Any instances that are not built on Amazon Linux 2 and don't require
 # Python 2 should have it removed.

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -38,7 +38,7 @@
 # Any instances that are not built on Amazon Linux 2 and don't require
 # Python 2 should have it removed.
 #
-# Amazon Linux 2 is antiquated and requires Python2 to function, and
+# Amazon Linux 2 is antiquated and requires Python 2 to function, and
 # the remove_python2 Ansible role is a no-op on that platform.
 - hosts: bastion,docker,nessus,nmap
   name: Remove Python 2

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -8,7 +8,7 @@
       vars:
         # Install and pip2 for all instances that will run Python 2
         # CyHy code.  Right now this is all instances other than the
-        # bastion, nessus, and nmap instances.
+        # bastion, docker, nessus, and nmap instances.
         #
         # Note that we are joining the hostnames via a pipe character,
         # which is a disallowed character in a hostname; therefore, if
@@ -18,12 +18,12 @@
         # pipe, plus the beginning of the next string.  This is what
         # allows us to do the search in one fell swoop as opposed to
         # writing multiple checks against individual hostnames.
-        install_pip2: inventory_hostname_short is not search({{ ["bastion", "nessus", "nmap"] | join("|") }})
+        install_pip2: inventory_hostname_short is not search({{ ["bastion", "docker", "nessus", "nmap"] | join("|") }})
     - role: python
       vars:
         # Install Python 2 for all instances that will run Python 2
         # CyHy code.  Right now this is all instances other than the
-        # bastion, nessus, and nmap instances.
+        # bastion, docker, nessus, and nmap instances.
         #
         # Note that we are joining the hostnames via a pipe character,
         # which is a disallowed character in a hostname; therefore, if
@@ -33,14 +33,14 @@
         # pipe, plus the beginning of the next string.  This is what
         # allows us to do the search in one fell swoop as opposed to
         # writing multiple checks against individual hostnames.
-        install_python2: inventory_hostname_short is not search({{ ["bastion", "nessus", "nmap"] | join("|") }})
+        install_python2: inventory_hostname_short is not search({{ ["bastion", "docker", "nessus", "nmap"] | join("|") }})
 
 # Any instances that are not built on Amazon Linux 2 and don't require
 # Python 2 should have it removed.
 #
 # Amazon Linux 2 is antiquated and requires Python2 to function, and
 # the remove_python2 Ansible role is a no-op on that platform.
-- hosts: bastion,nessus,nmap
+- hosts: bastion,docker,nessus,nmap
   name: Remove Python 2
   become: yes
   become_method: sudo

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -6,7 +6,7 @@
   roles:
     - role: pip
       vars:
-        # Install and pip2 for all instances that will run Python 2
+        # Install pip2 for all instances that will run Python 2
         # CyHy code.  Right now this is all instances other than the
         # bastion, docker, nessus, and nmap instances.
         #

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -18,7 +18,7 @@
         # pipe, plus the beginning of the next string.  This is what
         # allows us to do the search in one fell swoop as opposed to
         # writing multiple checks against individual hostnames.
-        install_pip2: {{ inventory_hostname_short is not search(["bastion", "nessus", "nmap"] | join("|")) }}
+        install_pip2: inventory_hostname_short is not search({{ ["bastion", "nessus", "nmap"] | join("|") }})
     - role: python
       vars:
         # Install Python 2 for all instances that will run Python 2
@@ -33,7 +33,7 @@
         # pipe, plus the beginning of the next string.  This is what
         # allows us to do the search in one fell swoop as opposed to
         # writing multiple checks against individual hostnames.
-        install_python2: {{ inventory_hostname_short is not search(["bastion", "nessus", "nmap"] | join("|")) }}
+        install_python2: inventory_hostname_short is not search({{ ["bastion", "nessus", "nmap"] | join("|") }})
 
 # Any instances that are not built on Amazon Linux 2 and don't require
 # Python 2 should have it removed.

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -64,10 +64,8 @@
   name: persist_journald
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
-  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-remove-python2
   name: remove_python2
   version: improvement/remove_python2_on_all_platforms

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -68,7 +68,6 @@
   name: python
 - src: https://github.com/cisagov/ansible-role-remove-python2
   name: remove_python2
-  version: improvement/remove_python2_on_all_platforms
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade
 - src: https://github.com/cisagov/ansible-role-vdp-scanner

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -64,8 +64,10 @@
   name: persist_journald
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
+  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-remove-python2
   name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -70,6 +70,7 @@
   version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-remove-python2
   name: remove_python2
+  version: improvement/remove_python2_on_all_platforms
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade
 - src: https://github.com/cisagov/ansible-role-vdp-scanner


### PR DESCRIPTION
## 🗣 Description ##

This pull request forces the installation of Python 2 on any instance that will be running Python 2 CyHy code and removes it from any instances that will not.

Note that I have added the `blocked` label because this PR should be merged along with:
- cisagov/ansible-role-pip#50
- cisagov/ansible-role-python#46
- cisagov/ansible-role-remove-python2#39

## 💭 Motivation and context ##

Two of the PRs referenced in the previous section force a minor change to this repo's packer code in order to cause Python 2 to be installed where needed.

## 🧪 Testing ##

Automated tests pass.

**Edit by @mcdonnnj**
I used this branch in my [testing branch](https://github.com/cisagov/cyhy_amis/tree/testing/redeployment_updates) and checked the status of Python 2 once the new images were deployed:

```console
bastion
bash: line 1: python: command not found
dashboard
Python 2.7.16
database1
Python 2.7.16
portscan1
bash: line 1: python: command not found
portscan2
bash: line 1: python: command not found
portscan3
bash: line 1: python: command not found
portscan4
bash: line 1: python: command not found
reporter
Python 2.7.16
vulnscan1
bash: line 1: python: command not found
```

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Build and test staging AMIs created via these changes.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.

## ✅ Post-merge checklist ##

- [ ] Build new production AMIs.
