### PR TITLE
Update the version of Nessus installed on `nessus` AMIs

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -45,7 +45,7 @@
   become_method: sudo
   roles:
     - cyhy_runner
-    - {role: nessus, package_bucket: ncats-3rd-party-packages}
+    - {role: nessus, package_bucket: ncats-3rd-party-packages, version: "8.15.5"}
     - more_ephemeral_ports
 
 - hosts: bod

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -45,9 +45,10 @@
   become_method: sudo
   roles:
     - cyhy_runner
-    - package_bucket: ncats-3rd-party-packages
-      role: nessus
-      version: "8.15.5"
+    - role: nessus
+      vars:
+        package_bucket: ncats-3rd-party-packages
+        version: "8.15.5"
     - more_ephemeral_ports
 
 - hosts: bod

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -45,7 +45,9 @@
   become_method: sudo
   roles:
     - cyhy_runner
-    - {role: nessus, package_bucket: ncats-3rd-party-packages, version: "8.15.5"}
+    - package_bucket: ncats-3rd-party-packages
+      role: nessus
+      version: "8.15.5"
     - more_ephemeral_ports
 
 - hosts: bod


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request explicitly states and updates the version of Nessus installed on `nessus` AMI types. It also changes the arguments to [cisagov/ansible-role-nessus] to use a block-style map instead of flow-style.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We haven't updated the version of Nessus installed in quite some time and we need a minimum version of `8.14` to get Vulnerability Priority Rating (VPR) support. Since we need to update the version and instead of relying on an obfuscated software version installed as a default for the Ansible role we're using it makes sense to explicitly set the version we want used in `nessus` AMIs. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that when deployed as a `vulnscanner` instance scanning ran without issue.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/ansible-role-nessus]: https://github.com/cisagov/ansible-role-nessus
