### PR TITLE
Update code to use the "docker compose" syntax vice "docker-compose"

### DIFF
--- a/ansible/roles/client_cert_update/tasks/main.yml
+++ b/ansible/roles/client_cert_update/tasks/main.yml
@@ -43,7 +43,7 @@
     - name: Create a cron job for updating the list of hosts that require client certs
       ansible.builtin.cron:
         hour: '5'
-        job: cd /var/cyhy/client-cert-update && docker-compose up -d 2>&1 | /usr/bin/logger -t client-cert-update
+        job: cd /var/cyhy/client-cert-update && docker compose up -d 2>&1 | /usr/bin/logger -t client-cert-update
         minute: '0'
         name: "client cert update"
         user: cyhy

--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -44,7 +44,7 @@
     - name: Create a cron job for updating the code.gov JSON
       ansible.builtin.cron:
         hour: '0'
-        job: cd /var/cyhy/code-gov-update && docker-compose up -d 2>&1 | /usr/bin/logger -t code-gov-update
+        job: cd /var/cyhy/code-gov-update && docker compose up -d 2>&1 | /usr/bin/logger -t code-gov-update
         minute: '0'
         name: "code.gov update"
         user: cyhy

--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -5,8 +5,8 @@
 # cyhy-mailer secrets
 #
 # The cyhy-mailer container does not run as root, so the creds files
-# need to be globally readable.  The Docker composition does allow one
-# to specify the uid, gid, and mode of the secrets files, but that
+# need to be globally readable.  The Compose specification does allow
+# one to specify the uid, gid, and mode of the secrets files, but that
 # only works in swarm mode.
 #
 - name: Create the secrets directory for cyhy-mailer

--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -5,9 +5,9 @@
 # cyhy-mailer secrets
 #
 # The cyhy-mailer container does not run as root, so the creds files
-# need to be globally readable.  docker-compose does allow one to
-# specify the uid, gid, and mode of the secrets files, but that only
-# works in swarm mode.
+# need to be globally readable.  The Docker composition does allow one
+# to specify the uid, gid, and mode of the secrets files, but that
+# only works in swarm mode.
 #
 - name: Create the secrets directory for cyhy-mailer
   ansible.builtin.file:
@@ -33,13 +33,13 @@
     owner: cyhy
     src: aws_config.j2
 
-# docker-compose will automatically use docker-compose.yml and
+# docker compose will automatically use docker-compose.yml and
 # docker-compose.override.yml, so this is a way for us to tune
-# docker-compose's behavior to the particular machine.
+# docker compose's behavior to the particular machine.
 #
 # In our case we want to send the BOD 18-01 reports on the BOD docker
 # instance and the CyHy-related reports on the reporter instance.
-- name: Create a symlink for the docker-compose override file
+- name: Create a symlink for the docker compose override file
   ansible.builtin.file:
     group: cyhy
     mode: 0664
@@ -63,7 +63,7 @@
 #     - name: Create a cron job for sending BOD 18-01 reports
 #       ansible.builtin.cron:
 #         hour: 12
-#         job: cd /var/cyhy/cyhy-mailer && docker-compose up -d 2>&1 | /usr/bin/logger -t cyhy-mailer
+#         job: cd /var/cyhy/cyhy-mailer && docker compose up -d 2>&1 | /usr/bin/logger -t cyhy-mailer
 #         minute: 0
 #         name: "Sending BOD 18-01 reports"
 #         user: cyhy

--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -33,9 +33,9 @@
     owner: cyhy
     src: aws_config.j2
 
-# docker compose will automatically use docker-compose.yml and
+# The compose command will automatically use docker-compose.yml and
 # docker-compose.override.yml, so this is a way for us to tune
-# docker compose's behavior to the particular machine.
+# compose's behavior to the particular machine.
 #
 # In our case we want to send the BOD 18-01 reports on the BOD docker
 # instance and the CyHy-related reports on the reporter instance.

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -64,7 +64,7 @@
     - name: Create a cron job for BOD 18-01 scanning
       ansible.builtin.cron:
         hour: '0'
-        job: cd /var/cyhy/orchestrator && docker-compose up -d 2>&1 | /usr/bin/logger -t orchestrator
+        job: cd /var/cyhy/orchestrator && docker compose up -d 2>&1 | /usr/bin/logger -t orchestrator
         minute: '0'
         name: "BOD 18-01 scanning"
         user: cyhy

--- a/ansible/roles/vdp_scanner/tasks/main.yml
+++ b/ansible/roles/vdp_scanner/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Create a cron job for BOD 20-01 (VDP) scanning
   ansible.builtin.cron:
     hour: '0'
-    job: cd /var/cyhy/vdp && docker-compose up -d 2>&1 | /usr/bin/logger -t vdp-scanner
+    job: cd /var/cyhy/vdp && docker compose up -d 2>&1 | /usr/bin/logger -t vdp-scanner
     minute: '0'
     name: "BOD 20-01 (VDP) scanning"
     user: cyhy

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -653,7 +653,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | cyhy\_vulnscan\_first\_elastic\_ip\_offset | The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy vulnscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first vulnscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional vulnscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available. | `number` | `1` | no |
 | dmarc\_import\_aws\_region | The AWS region where the dmarc-import Elasticsearch database resides. | `string` | `"us-east-1"` | no |
 | dmarc\_import\_es\_role\_arn | The ARN of the role that must be assumed in order to read the dmarc-import Elasticsearch database. | `string` | n/a | yes |
-| docker\_mailer\_override\_filename | This file is used to add/override any docker-compose settings for cyhy-mailer for the docker EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer. | `string` | `"docker-compose.bod.yml"` | no |
+| docker\_mailer\_override\_filename | This file is used to add/override any Docker composition settings for cyhy-mailer for the docker EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer. | `string` | `"docker-compose.bod.yml"` | no |
 | enable\_mgmt\_vpc | Whether or not to enable unfettered access from the vulnerability scanner in the Management VPC to other VPCs (CyHy, BOD).  This should only be enabled while running security scans from the Management VPC. | `bool` | `false` | no |
 | findings\_data\_field\_map | The key for the file storing field name mappings in JSON format. | `string` | n/a | yes |
 | findings\_data\_import\_db\_hostname | The hostname that has the database to store the findings data in. | `string` | `""` | no |
@@ -683,7 +683,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | nmap\_cyhy\_runner\_disk | The cyhy-runner data volume for the Nmap instance(s). | `string` | `"/dev/nvme1n1"` | no |
 | nmap\_instance\_count | The number of Nmap instances to create. | `number` | n/a | yes |
 | remote\_ssh\_user | The username to use when sshing to the EC2 instances. | `string` | n/a | yes |
-| reporter\_mailer\_override\_filename | This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer. | `string` | `"docker-compose.cyhy.yml"` | no |
+| reporter\_mailer\_override\_filename | This file is used to add/override any Docker composition settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer. | `string` | `"docker-compose.cyhy.yml"` | no |
 | scan\_types | The scan types that can be run. | `list(string)` | n/a | yes |
 | ses\_aws\_region | The AWS region where SES is configured. | `string` | `"us-east-1"` | no |
 | ses\_role\_arn | The ARN of the role that must be assumed in order to send emails. | `string` | n/a | yes |

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -238,7 +238,7 @@ variable "dmarc_import_aws_region" {
 
 variable "docker_mailer_override_filename" {
   default     = "docker-compose.bod.yml"
-  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the docker EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
+  description = "This file is used to add/override any Docker composition settings for cyhy-mailer for the docker EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
   type        = string
 }
 
@@ -362,7 +362,7 @@ variable "nmap_cyhy_runner_disk" {
 
 variable "reporter_mailer_override_filename" {
   default     = "docker-compose.cyhy.yml"
-  description = "This file is used to add/override any docker-compose settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
+  description = "This file is used to add/override any Docker composition settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer."
   type        = string
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the code to use the `docker compose` syntax instead of the `docker-compose` syntax.

## 💭 Motivation and context ##

The `docker compose` syntax is the preferred (and only correct) syntax after the changes in cisagov/ansible-role-docker#60.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.