### PR TITLE
Reduce to 6 vulnscan instances in `commander.conf`

### DIFF
--- a/ansible/roles/cyhy_commander/files/commander.conf
+++ b/ansible/roles/cyhy_commander/files/commander.conf
@@ -18,7 +18,7 @@ database-name = cyhy
 jobs-per-nmap-host = 12
 jobs-per-nessus-host = 128
 nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72,portscan73,portscan74,portscan75,portscan76,portscan77,portscan78,portscan79,portscan80
-nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4
+nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4,vulnscan5,vulnscan6
 
 [purge]
 # use to collect remaining jobs without creating new ones
@@ -34,7 +34,7 @@ jobs-per-nmap-host = 0
 jobs-per-nessus-host = 0
 shutdown-when-idle = false
 nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72,portscan73,portscan74,portscan75,portscan76,portscan77,portscan78,portscan79,portscan80
-nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4,vulnscan5,vulnscan6,vulnscan7,vulnscan8
+nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4,vulnscan5,vulnscan6
 
 [purge-trash]
 # purge jobs from scanners


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes two vulnscan instances in `commander.conf`, bringing us to six.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When we ramped up to eight instances in #471, that turned out to be more than we needed.

Note that this also corrects an error from #471, where the only the "purge-production" section was updated, and not the "production" section that we primarily use.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was verified by manually editing this file in Production and restarting the commander after the 2 unneeded vulnscan instances were destroyed.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
