### PR TITLE
Use larger, compute-optimized vulnscanner instances

### DIFF
--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -22,7 +22,7 @@ data "aws_ami" "nessus" {
 
 resource "aws_instance" "cyhy_nessus" {
   ami               = data.aws_ami.nessus.id
-  instance_type     = local.production_workspace ? "m5.2xlarge" : "m5.large"
+  instance_type     = local.production_workspace ? "c5.9xlarge" : "m5.large"
   count             = var.nessus_instance_count
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR changes our Production vulnscan instance types from `m5.2xlarge` to `c5.9xlarge`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have been seeing an uptick in scan job failures recently, so we decided to throw some more hardware at this problem, which has helped somewhat.  We still have to test some other Nessus Pro config settings to take full advantage of these large instances.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was made in Production about a month ago and no issues have arisen.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

