### PR TITLE
Configure advanced vulnscan settings

### DIFF
--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -16,13 +16,14 @@ BASE_POLICY_NAME = "cyhy-base"
 BASE_POLICY_FILE_NAME = "/tmp/cyhy-base-nessus8-policy.xml"  # nosec
 
 DEBUG = False
+FILE_UPLOAD = "/file/upload"
 LOGIN = "/session"
 POLICY_BASE = "/policies"
-FILE_UPLOAD = "/file/upload"
 POLICY_IMPORT = "/policies/import"
-OK_STATUS = 200
-NOT_FOUND_STATUS = 404
+
 INVALID_CREDS_STATUS = 401
+NOT_FOUND_STATUS = 404
+OK_STATUS = 200
 
 LOGGER_FORMAT = "%(asctime)-15s %(levelname)s %(message)s"
 LOGGER_LEVEL = logging.INFO

--- a/ansible/roles/nessus/files/nessus_base.py
+++ b/ansible/roles/nessus/files/nessus_base.py
@@ -16,6 +16,14 @@ BASE_POLICY_NAME = "cyhy-base"
 BASE_POLICY_FILE_NAME = "/tmp/cyhy-base-nessus8-policy.xml"  # nosec
 
 DEBUG = False
+
+ADVANCED_SETTINGS = "/settings/advanced"
+ADVANCED_SETTINGS_DICT = {
+    "orphaned_scan_cleanup_days": "7",
+    "report_cleanup_threshold_days": "7",
+    "scan_history_expiration_days": "7",
+}
+
 FILE_UPLOAD = "/file/upload"
 LOGIN = "/session"
 POLICY_BASE = "/policies"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR further configures our Nessus vulnscanner instances by modifying some settings that will limit the amount of disk usage over time.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolves #510 - refer to that issue for more context and background information.  Note that these settings have already been manually implemented in Production; this PR simply codifies them.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran the updated `nessus_base.py` on a test Nessus instance and verified that the advanced settings were correctly modified as expected.  

Note: I tried a variety of ways to force a failure at the `/settings/advanced` API endpoint, but I was unsuccessful (Tenable's API is pretty relaxed here), so my error-handling code has not been fully tested here.  Given the simplicity of these changes, I am not too concerned about this.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.