### PR TITLE
Use a file to store the configuration to access the Nessus API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,14 +85,16 @@ repos:
     rev: 1.7.4
     hooks:
       - id: bandit
+        additional_dependencies:
+          - importlib-metadata<5
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,6 +107,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-requests
+          - types-PyYAML
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.31.1
     hooks:

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -78,6 +78,22 @@
         state: started
   when: registered.rc != 0 or not matching_key|default(false)|bool
 
+- name: Create /etc/cyhy directory
+  file:
+    path: /etc/cyhy
+    state: directory
+    owner: cyhy
+    group: cyhy
+    mode: 0750
+
+- name: Create the configuration file for Nessus API access
+  template:
+    src: nessus_api.yml.j2
+    dest: /etc/cyhy/nessus_api.yml
+    owner: cyhy
+    group: cyhy
+    mode: 0640
+
 # Copy the nessus_base.py to tmp
 - name: Copy the nessus_base python file for importing the base nessus policy
   copy:

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -94,14 +94,13 @@
     group: cyhy
     mode: 0640
 
-# Copy the nessus_base.py to tmp
-- name: Copy the nessus_base python file for importing the base nessus policy
+- name: Copy the nessus_base.py Python file for configuring Nessus
   copy:
     src: nessus_base.py
     dest: /tmp/nessus_base.py
     mode: 0644
 
-- name: Copy base nessus scan policy to instance tmp
+- name: Copy base Nessus scan policy to instance tmp
   template:
     src: cyhy-base-nessus8-policy.xml.j2
     dest: /tmp/cyhy-base-nessus8-policy.xml
@@ -110,7 +109,7 @@
   wait_for:
     port: 8834
 
-- name: Run nessus base policy import script
+- name: Run Nessus configuration script
   command: python3 /tmp/nessus_base.py
 
 #

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -101,20 +101,6 @@
     dest: /tmp/nessus_base.py
     mode: 0644
 
-- name: Configure nessus base policy to use nessus username
-  lineinfile:
-    dest: /tmp/nessus_base.py
-    regexp: 'USER = ""'
-    state: present
-    line: 'USER = "{{ username }}"'
-
-- name: Configure nessus base policy to use nessus password
-  lineinfile:
-    dest: /tmp/nessus_base.py
-    regexp: 'PASSWORD = ""'
-    state: present
-    line: 'PASSWORD = "{{ password }}"'
-
 - name: Copy base nessus scan policy to instance tmp
   template:
     src: cyhy-base-nessus8-policy.xml.j2

--- a/ansible/roles/nessus/templates/nessus_api.yml.j2
+++ b/ansible/roles/nessus/templates/nessus_api.yml.j2
@@ -2,3 +2,7 @@
 credentials:
     password: {{ password }}
     username: {{ username }}
+policy:
+    name: cyhy-base
+    source: /tmp/cyhy-base-nessus8-policy.xml
+url: https://localhost:8834

--- a/ansible/roles/nessus/templates/nessus_api.yml.j2
+++ b/ansible/roles/nessus/templates/nessus_api.yml.j2
@@ -1,0 +1,4 @@
+---
+credentials:
+    password: {{ password }}
+    username: {{ username }}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request creates a file that contains information for interacting with Nessus on any instances that run the `nessus` Ansible role defined in this repository (the `vulnscan` instances in our Terraform configuration). The Python script that does some post-deployment configuration of Nessus is updated to use this file instead of having information templated into it by the Ansible role.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We are looking to make changes to jobs that are pushed to `vulnscan` instances that require the configuration information to be available on the instance somewhere. Since we need this information available it makes sense to store them in a static location on the instance and to update the configuration Python script to use this file.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this in my testing environment and verified that Nessus was configured as it should be post deployment and that the configuration file was on the instance.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
