### PR TITLE
Use the next size up instance type for the `reporter` instance

### DIFF
--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -23,7 +23,7 @@ data "aws_ami" "reporter" {
 
 resource "aws_instance" "cyhy_reporter" {
   ami               = data.aws_ami.reporter.id
-  instance_type     = local.production_workspace ? "c5.4xlarge" : "t3.small"
+  instance_type     = local.production_workspace ? "c5.9xlarge" : "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the private subnet


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the instance type for production `reporter` instances from `c5.4xlarge` to `c5.9xlarge`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have seen a specific organization fail to generate weekly reports due to running out of memory on the instance. This is due in part to the way our report generation process occurs (initial memory + fork means that using close to half the instance memory will cause a report to fail to generate when it attempts to fork). We bumped the instance type in production manually and have not seen report generation failures since.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This change was made in production over a month ago and no problems have arisen.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
