### PR TITLE
Dynamically populate the nmap and nessus hosts in the commander configuration

### DIFF
--- a/ansible/roles/cyhy_commander/templates/commander.conf.j2
+++ b/ansible/roles/cyhy_commander/templates/commander.conf.j2
@@ -17,8 +17,8 @@ nessus-hosts = vulnscan1
 database-name = cyhy
 jobs-per-nmap-host = 12
 jobs-per-nessus-host = 128
-nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72,portscan73,portscan74,portscan75,portscan76,portscan77,portscan78,portscan79,portscan80
-nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4,vulnscan5,vulnscan6
+nmap-hosts = {{ nmap_hosts }}
+nessus-hosts = {{ nessus_hosts }}
 
 [purge]
 # use to collect remaining jobs without creating new ones
@@ -33,8 +33,8 @@ database-name = cyhy
 jobs-per-nmap-host = 0
 jobs-per-nessus-host = 0
 shutdown-when-idle = false
-nmap-hosts = portscan1,portscan2,portscan3,portscan4,portscan5,portscan6,portscan7,portscan8,portscan9,portscan10,portscan11,portscan12,portscan13,portscan14,portscan15,portscan16,portscan17,portscan18,portscan19,portscan20,portscan21,portscan22,portscan23,portscan24,portscan25,portscan26,portscan27,portscan28,portscan29,portscan30,portscan31,portscan32,portscan33,portscan34,portscan35,portscan36,portscan37,portscan38,portscan39,portscan40,portscan41,portscan42,portscan43,portscan44,portscan45,portscan46,portscan47,portscan48,portscan49,portscan50,portscan51,portscan52,portscan53,portscan54,portscan55,portscan56,portscan57,portscan58,portscan59,portscan60,portscan61,portscan62,portscan63,portscan64,portscan65,portscan66,portscan67,portscan68,portscan69,portscan70,portscan71,portscan72,portscan73,portscan74,portscan75,portscan76,portscan77,portscan78,portscan79,portscan80
-nessus-hosts = vulnscan1,vulnscan2,vulnscan3,vulnscan4,vulnscan5,vulnscan6
+nmap-hosts = {{ nmap_hosts }}
+nessus-hosts = {{ nessus_hosts }}
 
 [purge-trash]
 # purge jobs from scanners

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -179,6 +179,8 @@ module "cyhy_mongo_ansible_provisioner" {
     "aws_region=${var.aws_region}",
     "dmarc_import_aws_region=${var.dmarc_import_aws_region}",
     "dmarc_import_es_role=${var.dmarc_import_es_role_arn}",
+    "nmap_hosts=${join(",", formatlist("portscan%d", range(1, var.nmap_instance_count + 1)))}",
+    "nessus_hosts=${join(",", formatlist("vulnscan%d", range(1, var.nessus_instance_count + 1)))}",
   ]
   playbook = "../ansible/playbook.yml"
   dry_run  = false


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the way the `commander.conf` file is generated on `database` instances. The Ansible role (`cyhy_commander`) that populates this file now uses two variables to populate the expected fields instead of the values being hard-coded. The Terraform configuration formats the appropriate values and passes them to the Ansible provisioner.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The counts for `portscan` and `vulnscan` instances are controlled in the Terraform code so it makes sense that this configuration file is generated dynamically based on those values. This will allow the Terraform configuration to always correctly set up the `commander.conf` file regardless of what instance counts are used.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I updated my [testing branch](https://github.com/cisagov/cyhy_amis/tree/testing/redeployment_updates) and when I redeployed my `database` instance the `commander.conf` file was correctly configured to reflect the counts in my Terraform configuration's tfvars file.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
