### PR TITLE
Increase texmf buffer size for reporter

### DIFF
--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -7,5 +7,7 @@
     - xfs
     - cyhy_reports
     - cyhy_mailer
+  vars:
+    texmf_buffer_size: 1000000
   vars_files:
     - vars/maxmind_license_key.yml

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -30,7 +30,6 @@
   name: cyhy_mailer
 - src: https://github.com/cisagov/ansible-role-cyhy-reports
   name: cyhy_reports
-  version: improvement/increase-texmf-buffer-size
 - src: https://github.com/cisagov/ansible-role-cyhy-runner
   name: cyhy_runner
 - src: https://github.com/cisagov/ansible-role-dev-ssh-access

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -30,6 +30,7 @@
   name: cyhy_mailer
 - src: https://github.com/cisagov/ansible-role-cyhy-reports
   name: cyhy_reports
+  version: improvement/increase-texmf-buffer-size
 - src: https://github.com/cisagov/ansible-role-cyhy-runner
   name: cyhy_runner
 - src: https://github.com/cisagov/ansible-role-dev-ssh-access


### PR DESCRIPTION
## 🗣 Description ##

This pull request increases the `texmf` buffer size for the CyHy reporter instance.

## 💭 Motivation and context ##

TeX uses the buffer to contain input lines, but macro expansion works by writing material into the buffer and re-parsing the line. As a consequence, certain constructs require the buffer to be very large. As distributed by the OS package, the size is 200,000, which is more than sufficient for most documents; however, we have recently seen a lengthy CyHy report that required a value greater than 500,000. This is why this change is necessary.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.