### PR TITLE
Explicitly set the id for the `cyhy` user and group

### DIFF
--- a/terraform/cloud-init/cyhy_user_ssh_setup.yml
+++ b/terraform/cloud-init/cyhy_user_ssh_setup.yml
@@ -1,8 +1,9 @@
-#cloud-config
+---
 
 users:
-  - name: cyhy
+  - homedir: /var/cyhy
+    name: cyhy
     shell: /bin/bash
-    homedir: /var/cyhy
     ssh-authorized-keys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy
+    uid: "2048"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the [cloud-init] configuration that sets up the `cyhy` user (and implicitly sets up the `cyhy` group) to use an explicitly defined id number. 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is necessary to allow Docker images that use secrets with permissions restricted to the `cyhy` user to use a known UID in their configuration so that they are able to access those secrets when they are mounted into a running container. This also establishes known values for the `cyhy` uid/gid much like we do for some of the instance user accounts used in the COOL.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I confirmed after redeploying my test environment that the `cyhy` user has the expected uid on all instances that use this [cloud-init] configuration.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cloud-init]: https://cloud-init.io/