### PR TITLE
Upgrade Lambda runtime and Terraform module

### DIFF
--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -44,7 +44,7 @@ module "security_header_lambda" {
   description            = "Adds HSTS and other security headers to the response"
   lambda_code_source_dir = "${path.root}/add_security_headers"
   name                   = "add_security_headers"
-  runtime                = "nodejs14.x"
+  runtime                = "nodejs16.x"
   s3_artifact_bucket     = aws_s3_bucket.lambda_artifact_bucket.id
   tags                   = { "Application" = "Egress Publish" }
 }

--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -39,7 +39,7 @@ resource "aws_s3_bucket_public_access_block" "lambda_artifact_bucket" {
 # A Lambda@Edge for injecting security headers
 module "security_header_lambda" {
   source  = "transcend-io/lambda-at-edge/aws"
-  version = "0.4.0"
+  version = "0.5.0"
 
   description            = "Adds HSTS and other security headers to the response"
   lambda_code_source_dir = "${path.root}/add_security_headers"


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Upgrades the Lambda runtime to Node 16.x
- Upgrades the [`transcend-io/lambda-at-edge/aws` Terraform module](https://registry.terraform.io/modules/transcend-io/lambda-at-edge/aws) to the latest release

## 💭 Motivation and context ##

- The Node 12.x runtime will soon be deprecated, and we were previously on Node 14.x, so jumping to Node 16.x ensures we won't be left twisting in the wind anytime soon
- Updated runtimes are often more efficient, so it makes sense to run on the newest one we can
- Upgrading the Terraform module requires no code changes and does not modify any resources in our case, so it makes sense to stay current.

Note that a Node 18.x runtime is available, but our AWS Terraform provider is too old to support it.

## 🧪 Testing ##

All automated tests pass.  These changes are already deployed to CyHy production.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.