### PR TITLE
Update `adi` and `fdi` lambda configurations

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -181,6 +181,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_cloudwatch_log_group.bod_flow_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.cyhy_flow_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.fdi_lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.instance_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.mgmt_flow_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_metric_filter.kevsync_failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
@@ -631,6 +632,8 @@ terraform apply -var-file=<your_workspace>.tfvars
 | assessment\_data\_filename | The name of the assessment data JSON file that can be found in the assessment\_data\_s3\_bucket. | `string` | n/a | yes |
 | assessment\_data\_import\_db\_hostname | The hostname that has the database to store the assessment data in. | `string` | `""` | no |
 | assessment\_data\_import\_db\_port | The port that the database server is listening on. | `string` | `""` | no |
+| assessment\_data\_import\_lambda\_description | The description to associate with the assessment-data-import Lambda function. | `string` | `"Lambda function for importing assessment data."` | no |
+| assessment\_data\_import\_lambda\_handler | The entrypoint for the assessment-data-import Lambda. | `string` | `"lambda_handler.handler"` | no |
 | assessment\_data\_import\_lambda\_s3\_bucket | The name of the bucket where the assessment data import Lambda function can be found.  This bucket should be created with the cisagov/assessment-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | n/a | yes |
 | assessment\_data\_import\_lambda\_s3\_key | The key (name) of the zip file for the assessment data import Lambda function inside the S3 bucket. | `string` | n/a | yes |
 | assessment\_data\_import\_ssm\_db\_name | The name of the parameter in AWS SSM that holds the name of the database to store the assessment data in. | `string` | `""` | no |
@@ -655,6 +658,8 @@ terraform apply -var-file=<your_workspace>.tfvars
 | findings\_data\_field\_map | The key for the file storing field name mappings in JSON format. | `string` | n/a | yes |
 | findings\_data\_import\_db\_hostname | The hostname that has the database to store the findings data in. | `string` | `""` | no |
 | findings\_data\_import\_db\_port | The port that the database server is listening on. | `string` | `""` | no |
+| findings\_data\_import\_lambda\_description | The description to associate with the findings-data-import Lambda function. | `string` | `"Lambda function for importing findings data."` | no |
+| findings\_data\_import\_lambda\_handler | The entrypoint for the findings-data-import Lambda. | `string` | `"lambda_handler.handler"` | no |
 | findings\_data\_import\_lambda\_s3\_bucket | The name of the bucket where the findings data import Lambda function can be found.  This bucket should be created with the cisagov/findings-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | n/a | yes |
 | findings\_data\_import\_lambda\_s3\_key | The key (name) of the zip file for the findings data import Lambda function inside the S3 bucket. | `string` | n/a | yes |
 | findings\_data\_import\_ssm\_db\_name | The name of the parameter in AWS SSM that holds the name of the database to store the findings data in. | `string` | `""` | no |

--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -146,7 +146,7 @@ data "aws_s3_bucket" "adi_lambda" {
 resource "aws_lambda_function" "adi_lambda" {
   s3_bucket     = data.aws_s3_bucket.adi_lambda.id
   s3_key        = var.assessment_data_import_lambda_s3_key
-  function_name = format("assessment_data_import-%s", terraform.workspace)
+  function_name = format("assessment_data_import-%s", local.production_workspace ? "production" : terraform.workspace)
   role          = aws_iam_role.adi_lambda_role.arn
   handler       = "lambda_handler.handler"
   runtime       = "python3.8"

--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -161,23 +161,23 @@ resource "aws_lambda_function" "adi_lambda" {
 
   environment {
     variables = {
-      s3_bucket       = data.aws_s3_bucket.assessment_data.id
       data_filename   = var.assessment_data_filename
       db_hostname     = var.assessment_data_import_db_hostname
       db_port         = var.assessment_data_import_db_port
+      s3_bucket       = data.aws_s3_bucket.assessment_data.id
       ssm_db_name     = var.assessment_data_import_ssm_db_name
-      ssm_db_user     = var.assessment_data_import_ssm_db_user
       ssm_db_password = var.assessment_data_import_ssm_db_password
+      ssm_db_user     = var.assessment_data_import_ssm_db_user
     }
   }
 
   vpc_config {
-    subnet_ids = [
-      aws_subnet.cyhy_private_subnet.id,
-    ]
-
     security_group_ids = [
       aws_security_group.adi_lambda_sg.id,
+    ]
+
+    subnet_ids = [
+      aws_subnet.cyhy_private_subnet.id,
     ]
   }
 }

--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -148,11 +148,11 @@ resource "aws_lambda_function" "adi_lambda" {
   s3_key        = var.assessment_data_import_lambda_s3_key
   function_name = format("assessment_data_import-%s", local.production_workspace ? "production" : terraform.workspace)
   role          = aws_iam_role.adi_lambda_role.arn
-  handler       = "lambda_handler.handler"
+  handler       = var.assessment_data_import_lambda_handler
   runtime       = "python3.8"
   timeout       = 300
   memory_size   = 128
-  description   = "Lambda function for importing assessment data"
+  description   = var.assessment_data_import_lambda_description
 
   # This Lambda requires the database to function
   depends_on = [

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -162,26 +162,26 @@ resource "aws_lambda_function" "fdi_lambda" {
 
   environment {
     variables = {
-      s3_bucket       = data.aws_s3_bucket.findings_data.id
       db_hostname     = var.findings_data_import_db_hostname
       db_port         = var.findings_data_import_db_port
-      file_suffix     = var.findings_data_input_suffix
       field_map       = var.findings_data_field_map
+      file_suffix     = var.findings_data_input_suffix
+      s3_bucket       = data.aws_s3_bucket.findings_data.id
       save_failed     = var.findings_data_save_failed
       save_succeeded  = var.findings_data_save_succeeded
       ssm_db_name     = var.findings_data_import_ssm_db_name
-      ssm_db_user     = var.findings_data_import_ssm_db_user
       ssm_db_password = var.findings_data_import_ssm_db_password
+      ssm_db_user     = var.findings_data_import_ssm_db_user
     }
   }
 
   vpc_config {
-    subnet_ids = [
-      aws_subnet.cyhy_private_subnet.id,
-    ]
-
     security_group_ids = [
       aws_security_group.fdi_lambda_sg.id,
+    ]
+
+    subnet_ids = [
+      aws_subnet.cyhy_private_subnet.id,
     ]
   }
 }

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -149,11 +149,11 @@ resource "aws_lambda_function" "fdi_lambda" {
   s3_key        = var.findings_data_import_lambda_s3_key
   function_name = format("findings_data_import-%s", local.production_workspace ? "production" : terraform.workspace)
   role          = aws_iam_role.fdi_lambda_role.arn
-  handler       = "lambda_handler.handler"
+  handler       = var.findings_data_import_lambda_handler
   runtime       = "python3.9"
   timeout       = 300
   memory_size   = 128
-  description   = "Lambda function for importing findings data"
+  description   = var.findings_data_import_lambda_description
 
   # This Lambda requires the database to function
   depends_on = [

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -147,7 +147,7 @@ data "aws_s3_bucket" "fdi_lambda" {
 resource "aws_lambda_function" "fdi_lambda" {
   s3_bucket     = data.aws_s3_bucket.fdi_lambda.id
   s3_key        = var.findings_data_import_lambda_s3_key
-  function_name = format("findings_data_import-%s", terraform.workspace)
+  function_name = format("findings_data_import-%s", local.production_workspace ? "production" : terraform.workspace)
   role          = aws_iam_role.fdi_lambda_role.arn
   handler       = "lambda_handler.handler"
   runtime       = "python3.8"

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -150,7 +150,7 @@ resource "aws_lambda_function" "fdi_lambda" {
   function_name = format("findings_data_import-%s", local.production_workspace ? "production" : terraform.workspace)
   role          = aws_iam_role.fdi_lambda_role.arn
   handler       = "lambda_handler.handler"
-  runtime       = "python3.8"
+  runtime       = "python3.9"
   timeout       = 300
   memory_size   = 128
   description   = "Lambda function for importing findings data"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -126,6 +126,18 @@ variable "assessment_data_import_db_port" {
   type        = string
 }
 
+variable "assessment_data_import_lambda_description" {
+  default     = "Lambda function for importing assessment data."
+  description = "The description to associate with the assessment-data-import Lambda function."
+  type        = string
+}
+
+variable "assessment_data_import_lambda_handler" {
+  default     = "lambda_handler.handler"
+  description = "The entrypoint for the assessment-data-import Lambda."
+  type        = string
+}
+
 variable "assessment_data_import_ssm_db_name" {
   default     = ""
   description = "The name of the parameter in AWS SSM that holds the name of the database to store the assessment data in."
@@ -254,6 +266,18 @@ variable "findings_data_import_db_hostname" {
 variable "findings_data_import_db_port" {
   default     = ""
   description = "The port that the database server is listening on."
+  type        = string
+}
+
+variable "findings_data_import_lambda_description" {
+  default     = "Lambda function for importing findings data."
+  description = "The description to associate with the findings-data-import Lambda function."
+  type        = string
+}
+
+variable "findings_data_import_lambda_handler" {
+  default     = "lambda_handler.handler"
+  description = "The entrypoint for the findings-data-import Lambda."
   type        = string
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the configurations for the [adi](https://github.com/cisagov/assessment-data-import-lambda) and [fdi](https://github.com/cisagov/findings-data-import-lambda) AWS Lambda configurations:
1. Fix the function names to end in `-production` in a production workspace like the other resources.
2. Take the Lambda function description and handler as variables.
3. Sort the `aws_lambda_function` resources attributes alphabetically.
4. Bump the Python runtime for the [fdi] Lambda to `python3.9`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

1. The function names do not match how we usually identify resources in a production workspace.
2. These two attributes (per Lambda) make sense as variables in line with other resources.
3. The sorting brings these two resources more in line with our common best practices.
4. Now that we can build a Python 3.9 deployment package it makes sense to use the latest version we can support.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the `python3.9` runtime worked in my testing environment using the [latest deployment package for cisagov/findings-data-import-lambda](https://github.com/cisagov/findings-data-import-lambda/releases/tag/v1.1.0).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
