### PR TITLE
Update the Lambda bucket notification resource names

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -443,8 +443,8 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_route_table_association.mgmt_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_s3_bucket.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
-| [aws_s3_bucket_notification.fdi_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_notification.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_notification.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_security_group.adi_lambda_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.bod_bastion_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.bod_docker_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |

--- a/terraform/adi_lambda.tf
+++ b/terraform/adi_lambda.tf
@@ -194,7 +194,7 @@ resource "aws_lambda_permission" "adi_lambda_allow_bucket" {
 
 # Create the notification that triggers our Lambda function to run whenever
 # an object is created in our assessment data bucket
-resource "aws_s3_bucket_notification" "bucket_notification" {
+resource "aws_s3_bucket_notification" "adi_lambda" {
   bucket = data.aws_s3_bucket.assessment_data.id
 
   lambda_function {

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -198,7 +198,7 @@ resource "aws_lambda_permission" "fdi_lambda_allow_bucket" {
 
 # Create the notification that triggers our Lambda function to run whenever
 # an object is created in our findings data bucket
-resource "aws_s3_bucket_notification" "fdi_bucket_notification" {
+resource "aws_s3_bucket_notification" "fdi_lambda" {
   bucket = data.aws_s3_bucket.findings_data.id
 
   lambda_function {

--- a/terraform/scripts/deploy_new_adi_lambda.sh
+++ b/terraform/scripts/deploy_new_adi_lambda.sh
@@ -22,5 +22,5 @@ terraform taint "aws_lambda_function.adi_lambda"
 terraform apply -var-file="$workspace.tfvars" \
   -target=aws_lambda_function.adi_lambda \
   -target=aws_lambda_permission.adi_lambda_allow_bucket \
-  -target=aws_s3_bucket_notification.bucket_notification \
+  -target=aws_s3_bucket_notification.adi_lambda \
   -target=aws_cloudwatch_log_group.adi_lambda_logs

--- a/terraform/scripts/deploy_new_fdi_lambda.sh
+++ b/terraform/scripts/deploy_new_fdi_lambda.sh
@@ -22,5 +22,5 @@ terraform taint "aws_lambda_function.fdi_lambda"
 terraform apply -var-file="$workspace.tfvars" \
   -target=aws_lambda_function.fdi_lambda \
   -target=aws_lambda_permission.fdi_lambda_allow_bucket \
-  -target=aws_s3_bucket_notification.bucket_notification \
+  -target=aws_s3_bucket_notification.fdi_lambda \
   -target=aws_cloudwatch_log_group.fdi_lambda_logs


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the resource names for the [adi] and [fdi] S3 bucket notification resources and any references to those resources.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

One of the current bucket notification resource names is unhelpful to reference in a Terraform configuration this complex and does not mirror the other resource names for these Lambdas. It makes sense to update both resource names to be consistent with naming conventions. This also fixes the bug where the [adi] bucket notification is referenced in both the [adi] and [fdi] redeployment helper scripts.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

[adi]: https://github.com/cisagov/assessment-data-import-lambda
[fdi]: https://github.com/cisagov/findings-data-import-lambda