### PR TITLE
Update the Python runtime used by BOD 18-01 Lambdas

### DIFF
--- a/terraform/bod_lambdas.tf
+++ b/terraform/bod_lambdas.tf
@@ -95,7 +95,7 @@ resource "aws_lambda_function" "lambdas" {
   function_name = var.lambda_function_names[var.scan_types[count.index]]
   role          = aws_iam_role.lambda_roles[count.index].arn
   handler       = "lambda_handler.handler"
-  runtime       = "python3.6"
+  runtime       = "python3.7"
   timeout       = 900
   memory_size   = 128
   description   = "Lambda function for performing BOD 18-01 ${var.scan_types[count.index]} scans"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Python runtime used by the BOD 18-01 AWS Lambdas from `python3.6` to `python3.7`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In https://github.com/cisagov/lambda_functions/pull/48 and https://github.com/cisagov/domain-scan/commit/17dabc8e57ca1e66b4a22436c0a427d475b1b76e other parts of the BOD 18-01 infrastructure were updated to use the appropriate Python version and runtime. However we missed updating the Terraform configuration that would usually deploy these Lambdas in the CyHy environment.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I created Lambdas in my testing environment using this configuration and freshly built Lambda deployment packages and verified everything worked.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
