### PR TITLE
Add RAF IPs to egress list

### DIFF
--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -57,6 +57,13 @@ qualys_was_ips = (
     "64.39.108.104/29",
     "64.39.108.112/28",
 )
+# The following CIDR blocks are used by the RAF team for scanning:
+raf_ips = (
+    "3.90.198.239/32",
+    "3.211.199.252/32",
+    "52.201.65.180/32",
+    "54.87.25.47/32",
+)
 # The following CIDR blocks are where the STRIGA traffic originates
 # from:
 striga_ips = (
@@ -84,7 +91,7 @@ FILE_CONFIGS = [
     {
         "filename": "all.txt",
         "app_regex": re.compile(".*"),
-        "static_ips": cyhy_ips + qualys_was_ips,
+        "static_ips": cyhy_ips + qualys_was_ips + raf_ips,
         "description": "This file contains a consolidated list of all the IP addresses that VM is currently using for external scanning.",
     },
     {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds four (4) IPs used for scanning by the Rapid Action Force (RAF) to the list of IPs shown at https://rules.ncats.cyber.dhs.gov/.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Until a permanent solution to automate this process has been created, when new IPs are used for scanning, they must be added here.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran `egress_pub.py` and verified that the newly-added IPs appeared in the list at https://rules.ncats.cyber.dhs.gov/.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.