### PR TITLE
Move `cyhy` user creation to AMI build time

### DIFF
--- a/packer/ansible/create_cyhy_user.yml
+++ b/packer/ansible/create_cyhy_user.yml
@@ -21,5 +21,5 @@
 
     - name: Add the SSH public key as an authorized key
       ansible.posix.authorized_key:
-        user: cyhy
         key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy
+        user: cyhy

--- a/packer/ansible/create_cyhy_user.yml
+++ b/packer/ansible/create_cyhy_user.yml
@@ -1,0 +1,25 @@
+---
+# The bastion is the only instance that does not need a cyhy user for
+# operational functionality.
+- hosts: all:!bastion
+  name: Create the cyhy user and set up SSH access
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Create the cyhy user
+      ansible.builtin.user:
+        home: /var/cyhy
+        name: cyhy
+        shell: /bin/bash
+        uid: 2048
+      register: user_info
+
+    - name: Modify permissions on the home directory
+      ansible.builtin.file:
+        mode: 0750
+        path: "{{ user_info.home }}"
+
+    - name: Add the SSH public key as an authorized key
+      ansible.posix.authorized_key:
+        user: cyhy
+        key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -2,6 +2,9 @@
 - name: Import AWS playbook
   ansible.builtin.import_playbook: aws.yml
 
+- name: Import cyhy user creation playbook
+  ansible.builtin.import_playbook: create_cyhy_user.yml
+
 - hosts: all
   name: Add a banner, persist journald, install ClamAV, and setup dev team ssh
   become: yes

--- a/terraform/bod_docker_cloud_init.tf
+++ b/terraform/bod_docker_cloud_init.tf
@@ -6,13 +6,6 @@ data "cloudinit_config" "bod_docker_cloud_init_tasks" {
   gzip          = true
 
   part {
-    content      = file("${path.module}/cloud-init/cyhy_user_ssh_setup.yml")
-    content_type = "text/cloud-config"
-    filename     = "cyhy_user_ssh_setup.yml"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/set_hostname.tpl.yml", {
       # Note that the hostname here is identical to what is set in
       # the corresponding DNS A record.

--- a/terraform/cloud-init/cyhy_user_ssh_setup.yml
+++ b/terraform/cloud-init/cyhy_user_ssh_setup.yml
@@ -1,9 +1,0 @@
----
-
-users:
-  - homedir: /var/cyhy
-    name: cyhy
-    shell: /bin/bash
-    ssh-authorized-keys:
-      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy
-    uid: "2048"

--- a/terraform/cyhy_dashboard_cloud_init.tf
+++ b/terraform/cyhy_dashboard_cloud_init.tf
@@ -5,13 +5,6 @@ data "cloudinit_config" "cyhy_dashboard_cloud_init_tasks" {
   gzip          = true
 
   part {
-    content      = file("${path.module}/cloud-init/cyhy_user_ssh_setup.yml")
-    content_type = "text/cloud-config"
-    filename     = "cyhy_user_ssh_setup.yml"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/set_hostname.tpl.yml", {
       # Note that the hostname here is identical to what is set in
       # the corresponding DNS A record.

--- a/terraform/cyhy_mongo_cloud_init.tf
+++ b/terraform/cyhy_mongo_cloud_init.tf
@@ -8,13 +8,6 @@ data "cloudinit_config" "cyhy_mongo_cloud_init_tasks" {
   gzip          = true
 
   part {
-    content      = file("${path.module}/cloud-init/cyhy_user_ssh_setup.yml")
-    content_type = "text/cloud-config"
-    filename     = "cyhy_user_ssh_setup.yml"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/set_hostname.tpl.yml", {
       # Note that the hostname here is identical to what is set in
       # the corresponding DNS A record.

--- a/terraform/cyhy_nessus_cloud_init.tf
+++ b/terraform/cyhy_nessus_cloud_init.tf
@@ -8,13 +8,6 @@ data "cloudinit_config" "cyhy_nessus_cloud_init_tasks" {
   gzip          = true
 
   part {
-    content      = file("${path.module}/cloud-init/cyhy_user_ssh_setup.yml")
-    content_type = "text/cloud-config"
-    filename     = "cyhy_user_ssh_setup.yml"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/set_hostname.tpl.yml", {
       # Note that the hostname here is identical to what is set in
       # the corresponding DNS A record.

--- a/terraform/cyhy_nmap_cloud_init.tf
+++ b/terraform/cyhy_nmap_cloud_init.tf
@@ -8,13 +8,6 @@ data "cloudinit_config" "cyhy_nmap_cloud_init_tasks" {
   gzip          = true
 
   part {
-    content      = file("${path.module}/cloud-init/cyhy_user_ssh_setup.yml")
-    content_type = "text/cloud-config"
-    filename     = "cyhy_user_ssh_setup.yml"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/set_hostname.tpl.yml", {
       # Note that the hostname here is identical to what is set in
       # the corresponding DNS A record.

--- a/terraform/cyhy_reporter_cloud_init.tf
+++ b/terraform/cyhy_reporter_cloud_init.tf
@@ -6,13 +6,6 @@ data "cloudinit_config" "cyhy_reporter_cloud_init_tasks" {
   gzip          = true
 
   part {
-    content      = file("${path.module}/cloud-init/cyhy_user_ssh_setup.yml")
-    content_type = "text/cloud-config"
-    filename     = "cyhy_user_ssh_setup.yml"
-    merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  part {
     content = templatefile("${path.module}/cloud-init/set_hostname.tpl.yml", {
       # Note that the hostname here is identical to what is set in
       # the corresponding DNS A record.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request moves creation of the `cyhy` user to AMI build time from being part of individual instance cloud-init configurations.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change moves user creation to AMI build time to provide a better guarantee that the `cyhy` user exists before any Ansible provisioners are run against an instance during deployment. It will also allow the option for cyhy-specific Ansible roles to expect the existence of the `cyhy` user as part of their logic. As a bonus this reduces complexity by removing this element of the individual cloud-init configurations for instances that need this user.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this branch in my test environment and verified that the `cyhy` user existed and that SSH access worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
