### PR TITLE
Update Debian versions used for AMIs

### DIFF
--- a/packer/ansible/aws.yml
+++ b/packer/ansible/aws.yml
@@ -10,3 +10,17 @@
     # The instance types used for almost all the instances expose EBS
     # volumes as NVMe block devices, so that's why we need nvme here.
     - nvme
+  tasks:
+    # The version of python3-botocore in Debian Buster is too old to
+    # support IMDSv2.  I was able to get a more recent version
+    # published to buster-backports that does support IMDSv2, so we
+    # should use that.
+    - name: Install python3-botocore from buster-backports for Debian Buster
+      ansible.builtin.apt:
+        default_release: buster-backports
+        name:
+          - python3-botocore
+        state: latest
+      when:
+        - ansible_distribution == "Debian"
+        - ansible_distribution_release == "buster"

--- a/packer/ansible/aws.yml
+++ b/packer/ansible/aws.yml
@@ -11,14 +11,14 @@
     # volumes as NVMe block devices, so that's why we need nvme here.
     - nvme
   tasks:
-    # The version of python3-botocore in Debian Buster is too old to
-    # support IMDSv2.  I was able to get a more recent version
-    # published to buster-backports that does support IMDSv2, so we
-    # should use that.
-    - name: Install python3-botocore from buster-backports for Debian Buster
+    # The versions of awscli and python3-botocore in Debian Buster are too
+    # old to support IMDSv2. There are versions published to buster-backports
+    # that do support IMDSv2, so we should use them.
+    - name: Install AWS packages from buster-backports for Debian Buster
       ansible.builtin.apt:
         default_release: buster-backports
         name:
+          - awscli
           - python3-botocore
         state: latest
       when:

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -4,6 +4,8 @@
   name: apt_over_https
 - src: https://github.com/cisagov/ansible-role-automated-security-updates
   name: automated_security_updates
+- src: https://github.com/cisagov/ansible-role-backports
+  name: backports
 - src: https://github.com/cisagov/ansible-role-banner
   name: banner
 - src: https://github.com/cisagov/ansible-role-clamav

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -6,6 +6,7 @@
   become: yes
   become_method: sudo
   roles:
+    - backports
     - apt_over_https
     - upgrade
     - automated_security_updates

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -25,7 +25,7 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-10-amd64-*",
+          "name": "debian-11-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
@@ -38,7 +38,7 @@
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Buster",
+        "OS_Version": "Debian Bullseye",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/bastion.json
+++ b/packer/bastion.json
@@ -42,6 +42,7 @@
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
+      "temporary_key_pair_type": "ed25519",
       "type": "amazon-ebs"
     }
   ],

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -48,6 +48,10 @@
   ],
   "provisioners": [
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "dashboard"
       ],
@@ -57,6 +61,10 @@
       "use_sftp": true
     },
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "dashboard"
       ],
@@ -68,6 +76,10 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "cyhy_dashboard"

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -4,7 +4,7 @@
       "ami_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp3"
@@ -16,7 +16,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp3"
@@ -25,20 +25,20 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "name": "debian-10-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "379101102735"
+          "136693071363"
         ]
       },
       "ssh_username": "admin",
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Stretch",
+        "OS_Version": "Debian Buster",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -42,6 +42,7 @@
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
+      "temporary_key_pair_type": "ed25519",
       "type": "amazon-ebs"
     }
   ],

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -25,7 +25,7 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-10-amd64-*",
+          "name": "debian-11-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
@@ -38,7 +38,7 @@
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Buster",
+        "OS_Version": "Debian Bullseye",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
@@ -48,10 +48,6 @@
   ],
   "provisioners": [
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "docker"
       ],
@@ -61,10 +57,6 @@
       "use_sftp": true
     },
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "docker"
       ],
@@ -76,10 +68,6 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
-      ],
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "bod",

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -48,6 +48,10 @@
   ],
   "provisioners": [
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "docker"
       ],
@@ -57,6 +61,10 @@
       "use_sftp": true
     },
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "docker"
       ],
@@ -68,6 +76,10 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "bod",

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -4,7 +4,7 @@
       "ami_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 10,
           "volume_type": "gp3"
@@ -16,7 +16,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 10,
           "volume_type": "gp3"
@@ -25,20 +25,20 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "name": "debian-10-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "379101102735"
+          "136693071363"
         ]
       },
       "ssh_username": "admin",
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Stretch",
+        "OS_Version": "Debian Buster",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -42,6 +42,7 @@
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
+      "temporary_key_pair_type": "ed25519",
       "type": "amazon-ebs"
     }
   ],

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -4,7 +4,7 @@
       "ami_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp3"
@@ -16,7 +16,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
           "volume_type": "gp3"
@@ -25,20 +25,20 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "name": "debian-10-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "379101102735"
+          "136693071363"
         ]
       },
       "ssh_username": "admin",
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Stretch",
+        "OS_Version": "Debian Buster",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -48,6 +48,10 @@
   ],
   "provisioners": [
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "mongo"
       ],
@@ -57,6 +61,10 @@
       "use_sftp": true
     },
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "mongo"
       ],
@@ -68,6 +76,10 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "mongo",

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -42,6 +42,7 @@
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
+      "temporary_key_pair_type": "ed25519",
       "type": "amazon-ebs"
     }
   ],

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -25,7 +25,7 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-10-amd64-*",
+          "name": "debian-11-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
@@ -38,7 +38,7 @@
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Buster",
+        "OS_Version": "Debian Bullseye",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/nessus.json
+++ b/packer/nessus.json
@@ -42,6 +42,7 @@
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
+      "temporary_key_pair_type": "ed25519",
       "type": "amazon-ebs"
     }
   ],

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -25,7 +25,7 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-10-amd64-*",
+          "name": "debian-11-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
@@ -38,7 +38,7 @@
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Buster",
+        "OS_Version": "Debian Bullseye",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/nmap.json
+++ b/packer/nmap.json
@@ -42,6 +42,7 @@
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
+      "temporary_key_pair_type": "ed25519",
       "type": "amazon-ebs"
     }
   ],

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -48,6 +48,10 @@
   ],
   "provisioners": [
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "reporter"
       ],
@@ -57,6 +61,10 @@
       "use_sftp": true
     },
     {
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
+      ],
       "groups": [
         "reporter"
       ],
@@ -68,6 +76,10 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "cyhy_reporter"

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -4,7 +4,7 @@
       "ami_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 10,
           "volume_type": "gp3"
@@ -16,7 +16,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "xvda",
+          "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 10,
           "volume_type": "gp3"
@@ -25,20 +25,20 @@
       "region": "{{user `build_region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-stretch-hvm-x86_64-gp2-*",
+          "name": "debian-10-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "379101102735"
+          "136693071363"
         ]
       },
       "ssh_username": "admin",
       "tags": {
         "Application": "Cyber Hygiene",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
-        "OS_Version": "Debian Stretch",
+        "OS_Version": "Debian Buster",
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -42,6 +42,7 @@
         "Release": "Latest",
         "Team": "VM Fusion - Development"
       },
+      "temporary_key_pair_type": "ed25519",
       "type": "amazon-ebs"
     }
   ],


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the versions of Debian used as a base for our AMIs like so:

- `bastion` from [Buster] to [Bullseye]
- `dashboard` from [Stretch] to [Buster]
- `docker` from [Stretch] to [Bullseye]
- `mongo` from [Stretch] to [Buster]
- `nmap` from [Buster] to [Bullseye]
- `nessus` from [Buster] to [Bullseye]
- `reporter` from [Stretch] to [Buster]

The following packages on [Buster] instances are installed from `buster-backports` instead of the normal `buster` repository:

- [awscli]
- [python3-botocore]

Last any AMIs built off of [Buster] have an additional configuration option to the Ansible provisioners to use the `auto_legacy_silent` flag to force preferring Python 2 over Python 3.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Debian Stretch has been out of any kind of support since June 30, 2022 per the [LTS schedule page](https://wiki.debian.org/LTS). Unfortunately due to Python 2 requirements the newest version of Debian that most [Stretch] images could move to is [Buster] due to availability of dependent Python 2-based packages available from the respective version repositories. So that we can support [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) we install [awscli] and [python3-botocore] from [Backports] on [Buster]-based images.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I have verified that these image configurations can build and deploy successfully in my testing environment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[Stretch]: https://www.debian.org/releases/stretch/
[Buster]: https://www.debian.org/releases/buster/
[Bullseye]: https://www.debian.org/releases/bullseye/
[Backports]: https://backports.debian.org/
[awscli]: https://packages.debian.org/buster-backports/awscli
[python3-botocore]: https://packages.debian.org/buster-backports/python3-botocore