### PR TITLE
Fix issue with setting up MongoDB users

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,8 @@
 collections:
   - community.general
-  - community.mongodb
+  - name: community.mongodb
+    # The last version that officially supports MongoDB 3.6
+    version: 1.3.4
 
 roles:
   - src: https://github.com/cisagov/ansible-role-cyhy-logrotate

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -7,13 +7,17 @@
   ignore_errors: true
   register: checkifmongousers
 
-# HACK ALERT - Part 1:
-# Install pymongo 3.6 in order to use the Ansible mongodb_user module.
-- name: Install pymongo 3.6
+# Ensure PyMongo is available for the community.mongodb collection's modules.
+# The 3.12.3 version is the last of the PyMongo 3.x versions being tested. If
+# the version pin for the community.mongodb collection is updated to 1.4.0-1.5.1
+# we will need to pin to this version specifically due to how the collection
+# checks the version of PyMongo available. Note that this may negatively impact
+# other Python 3 packages that require newer versions of PyMongo.
+- name: Install PyMongo
   ansible.builtin.pip:
-    executable: /usr/bin/pip2
+    executable: /usr/bin/pip3
     name: pymongo
-    version: '3.6'
+    version: '>=3.12.3'
 
 - name: Create admin user in admin db (first user, no authentication)
   community.mongodb.mongodb_user:
@@ -54,14 +58,6 @@
   # miss an edge case like error output on task failure that would leak
   # password information by disabling the rule.
   no_log: true
-
-# HACK ALERT - Part 2:
-# Revert to older pymongo, needed for cyhy-core
-- name: Downgrade to pymongo 2.9.5
-  ansible.builtin.pip:
-    executable: /usr/bin/pip2
-    name: pymongo
-    version: '2.9.5'
 
 - name: Copy mongo configuration file
   ansible.builtin.template:

--- a/ansible/roles/mongo/templates/mongod.conf
+++ b/ansible/roles/mongo/templates/mongod.conf
@@ -21,7 +21,7 @@ net:
     port: 27017
     bindIp: 0.0.0.0   # Allow access from all IPv4 addresses
                       # This is safe in our current environment (no public IP)
-                      # Make sure it safe to do this in your environment!
+                      # Make sure it's safe to do this in your environment!
     ssl:
         mode: disabled
 

--- a/ansible/roles/mongo/templates/mongod.conf
+++ b/ansible/roles/mongo/templates/mongod.conf
@@ -19,23 +19,23 @@ processManagement:
 
 net:
     port: 27017
-    bindIp: 0.0.0.0   # Allow access from all IPv4 addresses
-                      # This is safe in our current environment (no public IP)
-                      # Make sure it's safe to do this in your environment!
+    bindIp: 0.0.0.0  # Allow access from all IPv4 addresses
+                     # This is safe in our current environment (no public IP)
+                     # Make sure it's safe to do this in your environment!
     ssl:
         mode: disabled
 
 security:
     keyFile: "{{ mongodb_data_root }}/keyFile"
-    #authorization      # keyFile implies security.authorization
-    #clusterAuthMode:
+    # authorization      # keyFile implies security.authorization
+    # clusterAuthMode:
 
-#replication:
-    #replSetName:
+# replication:
+#     replSetName:
 
 # Specifies one of the MongoDB parameters described here:
 #   http://docs.mongodb.org/manual/reference/parameters/
 #
 # You can specify multiple setParameter fields such as:
 #   setParameter: {enableTestCommands: 1}
-#setParameter:
+# setParameter:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a version constraint for the [community.mongodb] collection, updates the version constraint for the [PyMongo] package installed to use the aforementioned collection in the `mongo` role defined in this repository, changes the `mongo` role to install [PyMongo] into the Python 3 environment (and removes a hack in the process), and fixes some commenting in the MongoDB configuration file.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The latest version of the [community.mongodb] collection has issues running cleanly with our current deployment configuration and prevents the Ansible provisioner for the `database` instance from successfully completing. These changes are necessary to correctly set up the dependencies necessary to successfully run the Ansible provisioner for that instance.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that I was able to cleanly deploy a `database` instance in my development environment using this branch.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[community.mongodb]: https://galaxy.ansible.com/community/mongodb
[PyMongo]: https://pypi.org/project/pymongo/
