### PR TITLE
Update the Parameter Store path for the GitHub token used for running `cisagov/code-gov-update`

### DIFF
--- a/ansible/roles/code_gov_update/templates/scraper.json.j2
+++ b/ansible/roles/code_gov_update/templates/scraper.json.j2
@@ -9,7 +9,7 @@
       ],
       "public_only": true,
       "repos": [],
-      "token": "{{ github_oauth_token }}",
+      "token": "{{ github_pat }}",
       "url": "https://github.com"
     }
   ],

--- a/ansible/roles/code_gov_update/vars/main.yml
+++ b/ansible/roles/code_gov_update/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 # vars file for bod_docker
 
-# The GitHub OAUTH token
-github_oauth_token: "{{ lookup('aws_ssm', '/github/oauth_token') }}"
+# The GitHub Personal Access Token
+github_pat: "{{ lookup('aws_ssm', '/github/pat/code.gov') }}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the path in the SSM Parameter Store for the GitHub Personal Access Token (PAT) templated into the configuration that is used by the [cisagov/code-gov-update] Docker image. The name of the variable in the `code_gov_update` Ansible role defined in this repository is also changed to reflect that this is a new fine-grained PAT and not an older OAuth token-style PAT.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The old token used for this has expired and since I needed to update for a new token I thought this change made sense. The old token was a general PAT and not tailored specifically around this task. I created a new parameter to be used for this task specifically and generated a new fine-grained PAT also for this task specifically.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I created the new parameter in all four US regions of AWS and redeployed the `docker` instance in my development environment. After this I confirmed that the new PAT was in the configuration file generated and that I was able to successfully run the `code-gov-update` Docker composition.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/code-gov-update]: https://github.com/cisagov/code-gov-update
