### PR TITLE
Update the version of Nessus Professional used on `vulnscan` instances

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -51,7 +51,7 @@
     - role: nessus
       vars:
         package_bucket: ncats-3rd-party-packages
-        version: "10.3.0"
+        version: "10.4.1"
     - more_ephemeral_ports
 
 - hosts: bod

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -51,7 +51,7 @@
     - role: nessus
       vars:
         package_bucket: ncats-3rd-party-packages
-        version: "8.15.5"
+        version: "10.3.0"
     - more_ephemeral_ports
 
 - hosts: bod

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -51,7 +51,7 @@
     - role: nessus
       vars:
         package_bucket: ncats-3rd-party-packages
-        version: "10.4.1"
+        version: "10.4.2"
     - more_ephemeral_ports
 
 - hosts: bod

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -51,7 +51,7 @@
     - role: nessus
       vars:
         package_bucket: ncats-3rd-party-packages
-        version: "10.5.0"
+        version: "10.5.1"
     - more_ephemeral_ports
 
 - hosts: bod

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -51,7 +51,7 @@
     - role: nessus
       vars:
         package_bucket: ncats-3rd-party-packages
-        version: "10.4.2"
+        version: "10.5.0"
     - more_ephemeral_ports
 
 - hosts: bod


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `nessus` AMI configuration to use the latest release of Nessus Professional (`10.5.1` at this time).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This puts us on the latest major release with all of the updates, improvements, and fixes that go along with that upgrade.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I built a testing `nessus` AMI and deployed a `vulnscan` instance in my development environment using this configuration. I then verified that I could put work through the scanner using [cisagov/cyhy-commander] as it would occur under normal CyHy VS operation.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/cyhy-commander]: https://github.com/cisagov/cyhy-commander