### PR TITLE
Add notifications for findings-data-import Lambda processing failures

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -535,8 +535,11 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_security_group_rule.scanner_ingress_from_bastion_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.scanner_ingress_from_private_sg_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_sns_topic.cloudwatch_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.fdi_failure_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic.kevsync_failure_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.fdi_failure_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_sns_topic_subscription.account_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_sns_topic_subscription.fdi_failure_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_sns_topic_subscription.kevsync_failure_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_subnet.bod_docker_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.bod_lambda_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
@@ -593,6 +596,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_iam_policy_document.ec2_service_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.es_bod_docker_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.es_cyhy_mongo_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.fdi_failure_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fdi_lambda_cloudwatch_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fdi_lambda_ec2_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fdi_lambda_s3_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -659,6 +663,9 @@ terraform apply -var-file=<your_workspace>.tfvars
 | findings\_data\_import\_db\_hostname | The hostname that has the database to store the findings data in. | `string` | `""` | no |
 | findings\_data\_import\_db\_port | The port that the database server is listening on. | `string` | `""` | no |
 | findings\_data\_import\_lambda\_description | The description to associate with the findings-data-import Lambda function. | `string` | `"Lambda function for importing findings data."` | no |
+| findings\_data\_import\_lambda\_failure\_emails | A list of the emails to which alerts should be sent if findings data processing fails. | `list(string)` | `[]` | no |
+| findings\_data\_import\_lambda\_failure\_prefix | The object prefix that findings JSONs that have failed to process successfully will have in the findings data bucket. | `string` | `"failed/"` | no |
+| findings\_data\_import\_lambda\_failure\_suffix | The object suffix that findings JSONs that have failed to process successfully will have in the findings data bucket. | `string` | `".json"` | no |
 | findings\_data\_import\_lambda\_handler | The entrypoint for the findings-data-import Lambda. | `string` | `"lambda_handler.handler"` | no |
 | findings\_data\_import\_lambda\_s3\_bucket | The name of the bucket where the findings data import Lambda function can be found.  This bucket should be created with the cisagov/findings-data-import-terraform project.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | n/a | yes |
 | findings\_data\_import\_lambda\_s3\_key | The key (name) of the zip file for the findings data import Lambda function inside the S3 bucket. | `string` | n/a | yes |

--- a/terraform/fdi_failure_sns_topic.tf
+++ b/terraform/fdi_failure_sns_topic.tf
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent when the findings-data-import
+# Lambda has a failure when processing an uploaded JSON.
+# ------------------------------------------------------------------------------
+
+resource "aws_sns_topic" "fdi_failure_alarm" {
+  name         = format("fdi-failure-alarms_%s", local.production_workspace ? "production" : terraform.workspace)
+  display_name = "findings-data-import_failure_alarm"
+}
+
+# Allow the findings data bucket (and only the findings data bucket) to publish
+# notifications to the fdi failure alarm SNS topic.
+data "aws_iam_policy_document" "fdi_failure_alarm" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    resources = [aws_sns_topic.fdi_failure_alarm.arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [data.aws_s3_bucket.findings_data.arn]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "fdi_failure_alarm" {
+  arn    = aws_sns_topic.fdi_failure_alarm.arn
+  policy = data.aws_iam_policy_document.fdi_failure_alarm.json
+}
+
+resource "aws_sns_topic_subscription" "fdi_failure_alarm" {
+  for_each = toset(var.findings_data_import_lambda_failure_emails)
+
+  endpoint  = each.value
+  protocol  = "email"
+  topic_arn = aws_sns_topic.fdi_failure_alarm.arn
+}

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -200,7 +200,7 @@ resource "aws_lambda_permission" "fdi_lambda_allow_bucket" {
 resource "aws_s3_bucket_notification" "fdi_lambda" {
   bucket = data.aws_s3_bucket.findings_data.id
 
-  # Trigger the appropriate lambda function whenever an object with the configured
+  # Trigger the appropriate Lambda function whenever an object with the configured
   # suffix is created in the bucket.
   lambda_function {
     lambda_function_arn = aws_lambda_function.fdi_lambda.arn

--- a/terraform/fdi_lambda.tf
+++ b/terraform/fdi_lambda.tf
@@ -196,16 +196,27 @@ resource "aws_lambda_permission" "fdi_lambda_allow_bucket" {
   source_arn    = data.aws_s3_bucket.findings_data.arn
 }
 
-# Create the notification that triggers our Lambda function to run whenever
-# an object is created in our findings data bucket
+# Create the notification configuration for the findings data bucket
 resource "aws_s3_bucket_notification" "fdi_lambda" {
   bucket = data.aws_s3_bucket.findings_data.id
 
+  # Trigger the appropriate lambda function whenever an object with the configured
+  # suffix is created in the bucket.
   lambda_function {
     lambda_function_arn = aws_lambda_function.fdi_lambda.arn
     events              = ["s3:ObjectCreated:Put"]
     filter_suffix       = var.findings_data_input_suffix
   }
+
+  # Notify the appropriate SNS topic for fdi failures whenever an object is created
+  # with the configured prefix and suffix.
+  topic {
+    topic_arn     = aws_sns_topic.fdi_failure_alarm.arn
+    events        = ["s3:ObjectCreated:Copy"]
+    filter_prefix = var.findings_data_import_lambda_failure_prefix
+    filter_suffix = var.findings_data_import_lambda_failure_suffix
+  }
+
 }
 
 # The CloudWatch log group for the Lambda functions

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -269,6 +269,25 @@ variable "findings_data_import_db_port" {
   type        = string
 }
 
+variable "findings_data_import_lambda_failure_emails" {
+  default     = []
+  description = "A list of the emails to which alerts should be sent if findings data processing fails."
+  type        = list(string)
+}
+
+
+variable "findings_data_import_lambda_failure_prefix" {
+  default     = "failed/"
+  description = "The object prefix that findings JSONs that have failed to process successfully will have in the findings data bucket."
+  type        = string
+}
+
+variable "findings_data_import_lambda_failure_suffix" {
+  default     = ".json"
+  description = "The object suffix that findings JSONs that have failed to process successfully will have in the findings data bucket."
+  type        = string
+}
+
 variable "findings_data_import_lambda_description" {
   default     = "Lambda function for importing findings data."
   description = "The description to associate with the findings-data-import Lambda function."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds all of the Terraform necessary to send notifications if processing a findings JSON with [cisagov/findings-data-import-lambda] fails.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This addition will add the ability to notify operations staff if there is a failure when processing a findings JSON. This will help alert the appropriate team if there is an issue with the data or the Lambda.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I applied these changes in my development environment and was able to confirm I received an email notification if I uploaded an invalid JSON to the bucket in my environment and the Lambda failed when processing.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

[cisagov/findings-data-import-lambda]: https://github.com/cisagov/findings-data-import-lambda
