### PR TITLE
Refactor the Ansible playbooks used by the Packer configurations

### DIFF
--- a/packer/ansible/base.yml
+++ b/packer/ansible/base.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  name: Setup base image
+  become: yes
+  become_method: sudo
+  roles:
+    - automated_security_updates
+    - banner
+    - clamav
+    - htop
+    - persist_journald
+    - dev_ssh_access

--- a/packer/ansible/bod.yml
+++ b/packer/ansible/bod.yml
@@ -6,5 +6,4 @@
   roles:
     - xfs
     - orchestrator
-    - vdp_scanner
     - cyhy_mailer

--- a/packer/ansible/bod.yml
+++ b/packer/ansible/bod.yml
@@ -1,0 +1,10 @@
+---
+- hosts: bod
+  name: Configure host for BOD 18-01 scanning and reporting
+  become: yes
+  become_method: sudo
+  roles:
+    - xfs
+    - orchestrator
+    - vdp_scanner
+    - cyhy_mailer

--- a/packer/ansible/client_cert.yml
+++ b/packer/ansible/client_cert.yml
@@ -1,0 +1,7 @@
+---
+- hosts: client_cert
+  name: Configure host for client cert auth updating
+  become: yes
+  become_method: sudo
+  roles:
+    - client_cert_update

--- a/packer/ansible/code_gov.yml
+++ b/packer/ansible/code_gov.yml
@@ -1,0 +1,7 @@
+---
+- hosts: code_gov
+  name: Configure host for code.gov updating
+  become: yes
+  become_method: sudo
+  roles:
+    - code_gov_update

--- a/packer/ansible/cyhy_archive.yml
+++ b/packer/ansible/cyhy_archive.yml
@@ -1,0 +1,9 @@
+---
+- hosts: cyhy_archive
+  name: Install cyhy-archive helper script
+  become: yes
+  become_method: sudo
+  roles:
+    - cyhy_archive
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/ansible/cyhy_archive.yml
+++ b/packer/ansible/cyhy_archive.yml
@@ -5,5 +5,5 @@
   become_method: sudo
   roles:
     - cyhy_archive
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+  vars_files:
+    - vars/maxmind_license_key.yml

--- a/packer/ansible/cyhy_commander.yml
+++ b/packer/ansible/cyhy_commander.yml
@@ -5,5 +5,5 @@
   become_method: sudo
   roles:
     - cyhy_commander
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+  vars_files:
+    - vars/maxmind_license_key.yml

--- a/packer/ansible/cyhy_commander.yml
+++ b/packer/ansible/cyhy_commander.yml
@@ -1,0 +1,9 @@
+---
+- hosts: cyhy_commander
+  name: Install and configure cyhy-commander
+  become: yes
+  become_method: sudo
+  roles:
+    - cyhy_commander
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: cyhy_dashboard
-  name: Install and configure cyhy-dashboard
+  name: Install and configure the CyHy dashboard
   become: yes
   become_method: sudo
   roles:

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -1,0 +1,11 @@
+---
+- hosts: cyhy_dashboard
+  name: Install and configure cyhy-dashboard
+  become: yes
+  become_method: sudo
+  roles:
+    - ncats_webd
+    - ncats_webui
+    - docker
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -6,6 +6,5 @@
   roles:
     - ncats_webd
     - ncats_webui
-    - docker
   vars:
     maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -6,5 +6,5 @@
   roles:
     - ncats_webd
     - ncats_webui
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+  vars_files:
+    - vars/maxmind_license_key.yml

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -1,0 +1,11 @@
+---
+- hosts: cyhy_reporter
+  name: Install and configure cyhy-reports
+  become: yes
+  become_method: sudo
+  roles:
+    - xfs
+    - cyhy_reports
+    - cyhy_mailer
+  vars:
+    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -7,5 +7,5 @@
     - xfs
     - cyhy_reports
     - cyhy_mailer
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+  vars_files:
+    - vars/maxmind_license_key.yml

--- a/packer/ansible/mongo.yml
+++ b/packer/ansible/mongo.yml
@@ -1,0 +1,9 @@
+---
+- hosts: mongo
+  name: Install and configure MongoDB and xfsprogs
+  become: yes
+  become_method: sudo
+  roles:
+    - xfs
+    - mongo
+    - cyhy_feeds

--- a/packer/ansible/nessus.yml
+++ b/packer/ansible/nessus.yml
@@ -1,0 +1,12 @@
+---
+- hosts: nessus
+  name: Install and configure Nessus
+  become: yes
+  become_method: sudo
+  roles:
+    - cyhy_runner
+    - role: nessus
+      vars:
+        package_bucket: ncats-3rd-party-packages
+        version: "10.5.1"
+    - more_ephemeral_ports

--- a/packer/ansible/nmap.yml
+++ b/packer/ansible/nmap.yml
@@ -1,0 +1,9 @@
+---
+- hosts: nmap
+  name: Install nmap
+  become: yes
+  become_method: sudo
+  roles:
+    - cyhy_runner
+    - nmap
+    - more_ephemeral_ports

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -8,96 +8,32 @@
 - name: Import cyhy user creation playbook
   ansible.builtin.import_playbook: create_cyhy_user.yml
 
-- hosts: nmap
-  name: Install nmap
-  become: yes
-  become_method: sudo
-  roles:
-    - cyhy_runner
-    - nmap
-    - more_ephemeral_ports
+- name: Import the nmap host playbook
+  ansible.builtin.import_playbook: nmap.yml
 
-- hosts: mongo
-  name: Install and configure MongoDB and xfsprogs
-  become: yes
-  become_method: sudo
-  roles:
-    - xfs
-    - mongo
-    - cyhy_feeds
+- name: Import the mongo host playbook
+  ansible.builtin.import_playbook: mongo.yml
 
-- hosts: nessus
-  name: Install and configure Nessus
-  become: yes
-  become_method: sudo
-  roles:
-    - cyhy_runner
-    - role: nessus
-      vars:
-        package_bucket: ncats-3rd-party-packages
-        version: "10.5.1"
-    - more_ephemeral_ports
+- name: Import the nessus host playbook
+  ansible.builtin.import_playbook: nessus.yml
 
-- hosts: bod
-  name: Configure host for BOD 18-01 scanning and reporting
-  become: yes
-  become_method: sudo
-  roles:
-    - xfs
-    - orchestrator
-    - vdp_scanner
-    - cyhy_mailer
+- name: Import the bod host playbook
+  ansible.builtin.import_playbook: bod.yml
 
-- hosts: code_gov
-  name: Configure host for code.gov updating
-  become: yes
-  become_method: sudo
-  roles:
-    - code_gov_update
+- name: Import the code_gov host playbook
+  ansible.builtin.import_playbook: code_gov.yml
 
-- hosts: client_cert
-  name: Configure host for client cert auth updating
-  become: yes
-  become_method: sudo
-  roles:
-    - client_cert_update
+- name: Import the client_cert host playbook
+  ansible.builtin.import_playbook: client_cert.yml
 
-- hosts: cyhy_commander
-  name: Install and configure cyhy-commander
-  become: yes
-  become_method: sudo
-  roles:
-    - cyhy_commander
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+- name: Import the cyhy_commander host playbook
+  ansible.builtin.import_playbook: cyhy_commander.yml
 
-- hosts: cyhy_reporter
-  name: Install and configure cyhy-reports
-  become: yes
-  become_method: sudo
-  roles:
-    - xfs
-    - cyhy_reports
-    - cyhy_mailer
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+- name: Import the cyhy_reporter host playbook
+  ansible.builtin.import_playbook: cyhy_reporter.yml
 
-- hosts: cyhy_dashboard
-  name: Install and configure cyhy-dashboard
-  become: yes
-  become_method: sudo
-  roles:
-    - ncats_webd
-    - ncats_webui
-    - docker
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+- name: Import the cyhy_dashboard host playbook
+  ansible.builtin.import_playbook: cyhy_dashboard.yml
 
-- hosts: cyhy_archive
-  name: Install cyhy-archive helper script
-  become: yes
-  become_method: sudo
-  roles:
-    - cyhy_archive
-  vars:
-    maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+- name: Import the cyhy_archive host playbook
+  ansible.builtin.import_playbook: cyhy_archive.yml

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -26,6 +26,9 @@
 - name: Import the client_cert host playbook
   ansible.builtin.import_playbook: client_cert.yml
 
+- name: Import the vdp_scan host playbook
+  ansible.builtin.import_playbook: vdp_scan.yml
+
 - name: Import the cyhy_commander host playbook
   ansible.builtin.import_playbook: cyhy_commander.yml
 

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -1,28 +1,12 @@
 ---
+- name: Import base image playbook
+  ansible.builtin.import_playbook: base.yml
+
 - name: Import AWS playbook
   ansible.builtin.import_playbook: aws.yml
 
 - name: Import cyhy user creation playbook
   ansible.builtin.import_playbook: create_cyhy_user.yml
-
-- hosts: all
-  name: Add a banner, persist journald, install ClamAV, and setup dev team ssh
-  become: yes
-  become_method: sudo
-  roles:
-    - banner
-    - persist_journald
-    - clamav
-    - dev_ssh_access
-
-# The bastion should have as little installed as possible, since it's
-# exposed to the cruel world
-- hosts: all:!bastion
-  name: Install htop
-  become: yes
-  become_method: sudo
-  roles:
-    - htop
 
 - hosts: nmap
   name: Install nmap

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -38,8 +38,6 @@
   name: disable_numa
 - src: https://github.com/GekoCloud/ansible-role-disable-thp
   name: disable_thp
-- src: https://github.com/cisagov/ansible-role-docker
-  name: docker
 - src: https://github.com/cisagov/ansible-role-geoip2
   name: geoip2
 - src: https://github.com/cisagov/ansible-role-htop

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -1,12 +1,9 @@
 ---
 - hosts: all
-  name: >
-    Set up apt over HTTPS, upgrade base image, and enable automated security
-    updates
+  name: Set up backports, apt over HTTPS, and upgrade base image
   become: yes
   become_method: sudo
   roles:
     - backports
     - apt_over_https
     - upgrade
-    - automated_security_updates

--- a/packer/ansible/vars/maxmind_license_key.yml
+++ b/packer/ansible/vars/maxmind_license_key.yml
@@ -1,0 +1,3 @@
+---
+# Retrieve the MaxMind GeoIP2 license from the AWS SSM Paramter Store
+maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/ansible/vars/maxmind_license_key.yml
+++ b/packer/ansible/vars/maxmind_license_key.yml
@@ -1,3 +1,3 @@
 ---
-# Retrieve the MaxMind GeoIP2 license from the AWS SSM Paramter Store
+# Retrieve the MaxMind GeoIP2 license from the AWS SSM Parameter Store
 maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/ansible/vdp_scan.yml
+++ b/packer/ansible/vdp_scan.yml
@@ -1,0 +1,7 @@
+---
+- hosts: vdp_scan
+  name: Configure host for BOD 20-01 VDP scanning
+  become: yes
+  become_method: sudo
+  roles:
+    - vdp_scanner

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -72,7 +72,8 @@
       "groups": [
         "bod",
         "code_gov",
-        "client_cert"
+        "client_cert",
+        "vdp_scan"
       ],
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request refactors the Ansible playbooks used by the Packer AMI configurations in this repository.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This effort tries to organize these playbooks to be more similar to the standalone Packer projects by following similar practices as used in [cisagov/skeleton-packer]. This mainly involves breaking each host type out into its own playbook and importing those playbooks in the main `playbook.yml` configuration. The setup for VDP scanning is also broken out into its own `vdp_scan` host type to mimic how `bod`, `client_cert`, and `code_gov` are their own host types even though they all run on the same instance (and are built into the one AMI).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I built testing AMIs and deployed them in my development environment and there were no issues observed.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/skeleton-packer]: https://github.com/cisagov/skeleton-packer
