### PR TITLE
Update the `cisagov/ansible-role-cyhy-reports` configuration

### DIFF
--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -8,6 +8,7 @@
     - cyhy_reports
     - cyhy_mailer
   vars:
-    texmf_buffer_size: 1000000
+    texmf_buffer_size: 100000000
+    texmf_main_memory: 10000000
   vars_files:
     - vars/maxmind_license_key.yml


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the configuration that we use for [cisagov/ansible-role-cyhy-reports](https://github.com/cisagov/ansible-role-cyhy-reports) in our Packer configuration.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The current value used for `buf_size` does not match what is configured in production. Additionally with the merge of https://github.com/cisagov/ansible-role-cyhy-reports/pull/70 we can configure the `main_memory` setting so that it matches what is configured in production.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this branch in my development environment and confirmed that the correct values were deployed.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
