### PR TITLE
Break out S3 bucket settings using backported resources

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -146,15 +146,15 @@ terraform apply -var-file=<your_workspace>.tfvars
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 3.62 |
+| aws | ~> 3.75 |
 | cloudinit | ~> 2.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.62 |
-| aws.public\_dns | ~> 3.62 |
+| aws | ~> 3.75 |
+| aws.public\_dns | ~> 3.75 |
 | cloudinit | ~> 2.0 |
 | null | n/a |
 | terraform | n/a |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -451,6 +451,10 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_s3_bucket.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_notification.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_notification.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_public_access_block.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_security_group.adi_lambda_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.bod_bastion_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.bod_docker_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -1,14 +1,28 @@
 # The S3 bucket where the cyhy-archive compressed archives are stored
 resource "aws_s3_bucket" "cyhy_archive" {
   bucket = "${var.cyhy_archive_bucket_name}-${terraform.workspace}"
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+# Ensure the S3 bucket is encrypted
+resource "aws_s3_bucket_server_side_encryption_configuration" "cyhy_archive" {
+  bucket = aws_s3_bucket.cyhy_archive.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
+}
+
+# This blocks ANY public access to the bucket or the objects it
+# contains, even if misconfigured to allow public access.
+resource "aws_s3_bucket_public_access_block" "cyhy_archive" {
+  bucket = aws_s3_bucket.cyhy_archive.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 # IAM policy document that that allows S3 PutObject (write) on our

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,14 +7,12 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.62.0 of the Terraform AWS provider adds the
-    # `stop_instance_before_detaching` argument to the `aws_volume_attachment`
-    # resource.
-    # https://github.com/hashicorp/terraform-provider-aws/pull/21144
-    # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3620-october-08-2021
+    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
+    # AWS S3 resources are structured from the 4.0 release.
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.62"
+      version = "~> 3.75"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -13,15 +13,16 @@ data "aws_acm_certificate" "rules_cert" {
 # An S3 bucket where artifacts for the Lambda@Edge can be stored
 resource "aws_s3_bucket" "lambda_artifact_bucket" {
   bucket_prefix = "cyhy-egress-lambda-at-edge"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+}
+
+# Ensure the S3 bucket is encrypted
+resource "aws_s3_bucket_server_side_encryption_configuration" "lambda_artifact_bucket" {
+  bucket = aws_s3_bucket.lambda_artifact_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
-  }
-  versioning {
-    enabled = true
   }
 }
 
@@ -34,6 +35,14 @@ resource "aws_s3_bucket_public_access_block" "lambda_artifact_bucket" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "lambda_artifact_bucket" {
+  bucket = aws_s3_bucket.lambda_artifact_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 # A Lambda@Edge for injecting security headers

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -1,19 +1,47 @@
 resource "aws_s3_bucket" "rules_bucket" {
   bucket = var.rules_bucket_name
-  acl    = "private"
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  website {
-    index_document = "all.txt"
-    error_document = "error.html"
+  # This is the recommendation of the documentation here:
+  # https://registry.terraform.io/providers/hashicorp/aws/3.75.0/docs/resources/s3_bucket_website_configuration#usage-notes
+  lifecycle {
+    ignore_changes = [
+      website
+    ]
   }
 
   tags = { "Application" = "Egress Publish" }
+}
+
+# Ensure the S3 bucket is encrypted
+resource "aws_s3_bucket_server_side_encryption_configuration" "rules_bucket" {
+  bucket = aws_s3_bucket.rules_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+
+# This blocks ANY public access to the bucket or the objects it
+# contains, even if misconfigured to allow public access.
+resource "aws_s3_bucket_public_access_block" "rules_bucket" {
+  bucket = aws_s3_bucket.rules_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_website_configuration" "rules_bucket" {
+  bucket = aws_s3_bucket.rules_bucket.id
+
+  index_document {
+    suffix = "all.txt"
+  }
+  error_document {
+    key = "error.html"
+  }
 }

--- a/terraform_egress_pub/versions.tf
+++ b/terraform_egress_pub/versions.tf
@@ -6,12 +6,12 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
+    # AWS S3 resources are structured from the 4.0 release.
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.75"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/terraform_nessus_only/versions.tf
+++ b/terraform_nessus_only/versions.tf
@@ -6,12 +6,12 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
+    # AWS S3 resources are structured from the 4.0 release.
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.75"
     }
     template = {
       source  = "hashicorp/template"

--- a/terraform_route_53/versions.tf
+++ b/terraform_route_53/versions.tf
@@ -6,12 +6,12 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
+    # AWS S3 resources are structured from the 4.0 release.
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.75"
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request breaks out settings for AWS S3 buckets into their own resources. In some cases additional resources were added around encryption and/or public access blocking.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In the 4.0 release of the Terraform AWS provider they performed a refactor of the overloaded S3 resource per [this post](https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource). In the 3.75.0 release they [backported these S3 changes](https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3750-march-18-2022). This allows us to make these changes before migrating to the 4.x release of this provider (and is the only known breaking change).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I deployed this in my development environment without issue.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
