### PR TITLE
Start daily CyHy notifications cron earlier (0600 UTC)

### DIFF
--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -46,11 +46,11 @@
 
     #
     # The cron job below generates and emails CyHy notifications;
-    # it runs at 0800 UTC every day.
+    # it runs at 0600 UTC every day.
     #
     - name: Create cron job for daily CyHy notifications
       ansible.builtin.cron:
-        hour: '8'
+        hour: '6'
         job: cd /var/cyhy/reports && ./create_send_notifications.py --log-level=info cyhy 2>&1 | /usr/bin/logger -t cyhy-notifications
         minute: '0'
         name: "Generate and send daily CyHy notifications"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR sets the daily CyHy notifications cron job to start at 0600 UTC instead of 0800 UTC.

## 💭 Motivation and context ##

As the number of CyHy stakeholders has grown, the daily notification job has taken longer and longer to run.  Starting it a couple of hours earlier ensures that the notification emails don't arrive too late in the morning.

This is the same as the change that was done in #341, but we are now moving the start time even earlier since the number of stakeholders has risen significantly since then.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.


## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Manually apply this crontab change to the currently-deployed CyHy reporter instance.
