### PR TITLE
Update `boto3` and `botocore` installation on Debian Buster

### DIFF
--- a/packer/ansible/aws.yml
+++ b/packer/ansible/aws.yml
@@ -11,16 +11,31 @@
     # volumes as NVMe block devices, so that's why we need nvme here.
     - nvme
   tasks:
-    # The versions of awscli and python3-botocore in Debian Buster are too
-    # old to support IMDSv2. There are versions published to buster-backports
-    # that do support IMDSv2, so we should use them.
-    - name: Install AWS packages from buster-backports for Debian Buster
-      ansible.builtin.apt:
-        default_release: buster-backports
-        name:
-          - awscli
-          - python3-botocore
-        state: latest
+    - name: Support IMDSv2 on Debian Buster
+      block:
+        # We need a more recent version of botocore to support IMDSv2. The
+        # version of python3-botocore in buster-backports is new enough, but
+        # the only version of python3-boto3 available is much older. Since
+        # these packages are updated in lock-step any major difference in
+        # package versions can cause incompatibilities. Therefore, we install
+        # both boto3 and botocore as regular Python packages to ensure we get
+        # both a new enough version of botocore and a compatible version of
+        # boto3.
+        - name: Install boto-related Python packages
+          ansible.builtin.pip:
+            executable: pip3
+            name:
+              - boto3
+              - botocore
+        # The version of awscli in Debian Buster is too old to support IMDSv2.
+        # There is a compatible version published to buster-backports so we
+        # should use that package instead.
+        - name: Install awscli from buster-backports
+          ansible.builtin.apt:
+            default_release: buster-backports
+            name:
+              - awscli
+            state: latest
       when:
         - ansible_distribution == "Debian"
         - ansible_distribution_release == "buster"

--- a/packer/ansible/aws.yml
+++ b/packer/ansible/aws.yml
@@ -17,10 +17,17 @@
         # version of python3-botocore in buster-backports is new enough, but
         # the only version of python3-boto3 available is much older. Since
         # these packages are updated in lock-step any major difference in
-        # package versions can cause incompatibilities. Therefore, we install
-        # both boto3 and botocore as regular Python packages to ensure we get
-        # both a new enough version of botocore and a compatible version of
-        # boto3.
+        # package versions can cause incompatibilities. Therefore, we ensure
+        # existing system packages for boto3/botocore are uninstalled and then
+        # install both boto3 and botocore as regular Python packages. This will
+        # ensure we get both a new enough version of botocore and a compatible
+        # version of boto3.
+        - name: Remove boto-related system packages
+          ansible.builtin.apt:
+            name:
+              - python3-boto3
+              - python3-botocore
+            state: absent
         - name: Install boto-related Python packages
           ansible.builtin.pip:
             executable: pip3


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the logic for Debian Buster-based AMIs to install [boto3] and [botocore] directly into the Python 3 environment instead of as Debian system packages.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We need a newer version of [botocore] to support [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html). We were installing the version of `python3-botocore` from Debian Buster Backports, but the version of `python3-boto3` available for Debian Buster is too old in comparison as there is no version available from Backports. This causes a failure for the [cisagov/cyhy-feeds] project as it is Python 3 and requires both packages. We resolve this by ensuring the system packages are not installed, installing the Python versions directly, and then continuing with the installation of the `awscli` from Debian Buster Backports.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this in my development environment and verified that both `awscli` and the [cisagov/cyhy-feeds] project worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[boto3]: https://pypi.org/project/boto3/
[botocore]: https://pypi.org/project/botocore/
[cisagov/cyhy-feeds]: https://github.com/cisagov/cyhy-feeds
