### PR TITLE
Enforce S3 object ownership and add missing lifecycle rule for S3 buckets

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -451,6 +451,8 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_s3_bucket.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_notification.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_notification.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_ownership_controls.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_public_access_block.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -25,6 +25,17 @@ resource "aws_s3_bucket_public_access_block" "cyhy_archive" {
   restrict_public_buckets = true
 }
 
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
+resource "aws_s3_bucket_ownership_controls" "cyhy_archive" {
+  bucket = aws_s3_bucket.cyhy_archive.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 # IAM policy document that that allows S3 PutObject (write) on our
 # cyhy-archive bucket.  This will be applied to the cyhy-archive role.
 data "aws_iam_policy_document" "s3_cyhy_archive_write_doc" {

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "cyhy_archive" {
   lifecycle {
     ignore_changes = [
       # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # v4. It is necessary to use with the backported resources in v3.75 to
       # avoid conflicts/unexpected apply results.
       server_side_encryption_configuration,
     ]

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -1,6 +1,15 @@
 # The S3 bucket where the cyhy-archive compressed archives are stored
 resource "aws_s3_bucket" "cyhy_archive" {
   bucket = "${var.cyhy_archive_bucket_name}-${terraform.workspace}"
+
+  lifecycle {
+    ignore_changes = [
+      # This should be removed when we upgrade the Terraform AWS provider to
+      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # avoid conflicts/unexpected apply results.
+      server_side_encryption_configuration,
+    ]
+  }
 }
 
 # Ensure the S3 bucket is encrypted

--- a/terraform/moe_bucket.tf
+++ b/terraform/moe_bucket.tf
@@ -30,6 +30,17 @@ resource "aws_s3_bucket_public_access_block" "moe_bucket" {
   restrict_public_buckets = true
 }
 
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
+resource "aws_s3_bucket_ownership_controls" "moe_bucket" {
+  bucket = aws_s3_bucket.moe_bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 # IAM policy document that that allows read permissions on the MOE bucket.
 data "aws_iam_policy_document" "moe_bucket_read_doc" {
   statement {

--- a/terraform/moe_bucket.tf
+++ b/terraform/moe_bucket.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "moe_bucket" {
   lifecycle {
     ignore_changes = [
       # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # v4. It is necessary to use with the backported resources in v3.75 to
       # avoid conflicts/unexpected apply results.
       server_side_encryption_configuration,
     ]

--- a/terraform/moe_bucket.tf
+++ b/terraform/moe_bucket.tf
@@ -4,6 +4,12 @@ resource "aws_s3_bucket" "moe_bucket" {
   tags = { "Name" = "MOE bucket" }
 
   lifecycle {
+    ignore_changes = [
+      # This should be removed when we upgrade the Terraform AWS provider to
+      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # avoid conflicts/unexpected apply results.
+      server_side_encryption_configuration,
+    ]
     prevent_destroy = true
   }
 }

--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -13,6 +13,15 @@ data "aws_acm_certificate" "rules_cert" {
 # An S3 bucket where artifacts for the Lambda@Edge can be stored
 resource "aws_s3_bucket" "lambda_artifact_bucket" {
   bucket_prefix = "cyhy-egress-lambda-at-edge"
+
+  lifecycle {
+    ignore_changes = [
+      # This should be removed when we upgrade the Terraform AWS provider to
+      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # avoid conflicts/unexpected apply results.
+      server_side_encryption_configuration,
+    ]
+  }
 }
 
 # Ensure the S3 bucket is encrypted

--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -37,6 +37,17 @@ resource "aws_s3_bucket_public_access_block" "lambda_artifact_bucket" {
   restrict_public_buckets = true
 }
 
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
+resource "aws_s3_bucket_ownership_controls" "lambda_artifact_bucket" {
+  bucket = aws_s3_bucket.lambda_artifact_bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 resource "aws_s3_bucket_versioning" "lambda_artifact_bucket" {
   bucket = aws_s3_bucket.lambda_artifact_bucket.id
 

--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -17,7 +17,7 @@ resource "aws_s3_bucket" "lambda_artifact_bucket" {
   lifecycle {
     ignore_changes = [
       # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # v4. It is necessary to use with the backported resources in v3.75 to
       # avoid conflicts/unexpected apply results.
       server_side_encryption_configuration,
     ]

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -35,6 +35,17 @@ resource "aws_s3_bucket_public_access_block" "rules_bucket" {
   restrict_public_buckets = true
 }
 
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
+resource "aws_s3_bucket_ownership_controls" "rules_bucket" {
+  bucket = aws_s3_bucket.rules_bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 resource "aws_s3_bucket_website_configuration" "rules_bucket" {
   bucket = aws_s3_bucket.rules_bucket.id
 

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "rules_bucket" {
   lifecycle {
     ignore_changes = [
       # These should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # v4. It is necessary to use with the backported resources in v3.75 to
       # avoid conflicts/unexpected apply results.
       server_side_encryption_configuration,
       website,

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -5,7 +5,11 @@ resource "aws_s3_bucket" "rules_bucket" {
   # https://registry.terraform.io/providers/hashicorp/aws/3.75.0/docs/resources/s3_bucket_website_configuration#usage-notes
   lifecycle {
     ignore_changes = [
-      website
+      # These should be removed when we upgrade the Terraform AWS provider to
+      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # avoid conflicts/unexpected apply results.
+      server_side_encryption_configuration,
+      website,
     ]
   }
 
@@ -22,7 +26,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "rules_bucket" {
     }
   }
 }
-
 
 # This blocks ANY public access to the bucket or the objects it
 # contains, even if misconfigured to allow public access.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the S3 bucket configurations in this repository in two ways:
- An `ignore_changes` rule is added for the `server_side_encryption_configuration` argument
- Add a resource to enforce bucket object ownership
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

While using `aws` provider S3 resources from v4 in a v3 configuration you need to configure some bucket arguments to be ignored so that there is no conflict between the optional arguments in the `aws_s3_bucket` resource and the backported standalone resource. This was missed when the standalone resource was added. Additionally we add a rule to enforce that the bucket owner will own all objects put into the bucket. None of our buckets require another account to own objects in the bucket so this will ensure expected behavior in this configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. Performing a `terraform apply` in my development environment had the expected additions and no unexpected deletions.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
