### PR TITLE
Add the ability to configure the `cyhy-commander`'s `next-scan-limit` value

### DIFF
--- a/ansible/roles/cyhy_commander/defaults/main.yml
+++ b/ansible/roles/cyhy_commander/defaults/main.yml
@@ -1,2 +1,10 @@
 ---
 # defaults file for cyhy_commander
+
+# The maximum number of hosts that are scheduled to have scanning restarted
+# whose next scan stage should be updated per cyhy-commander cycle. The checks
+# for hosts that were "up" or "down" are processed separately so the total
+# number of hosts that are transitioned is double the provided value. Hosts
+# that are "up" are transitioned to PORTSCAN and hosts that are "down" are
+# transitioned to NETSCAN1.
+next_scan_limit: 8192

--- a/ansible/roles/cyhy_commander/templates/commander.conf.j2
+++ b/ansible/roles/cyhy_commander/templates/commander.conf.j2
@@ -17,6 +17,7 @@ nessus-hosts = vulnscan1
 database-name = cyhy
 jobs-per-nmap-host = 12
 jobs-per-nessus-host = 128
+next-scan-limit = {{ next_scan_limit }}
 nmap-hosts = {{ nmap_hosts }}
 nessus-hosts = {{ nessus_hosts }}
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -658,6 +658,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | bod\_lambda\_functions | A map of information for each BOD 18-01 Lambda. The keys are the scan types and the values are objects that contain the Lambda's name and the key (name) for the corresponding deployment package in the BOD Lambda S3 bucket. Example: `{ pshtt = { lambda_file = "pshtt.zip", lambda_name = "task_pshtt" }}` | `map(object({ lambda_file = string, lambda_name = string }))` | `{}` | no |
 | bod\_nat\_gateway\_eip | The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created. | `string` | `""` | no |
 | cloudwatch\_alarm\_emails | A list of the emails to which alerts should be sent if any CloudWatch Alarm is triggered. | `list(string)` | ```[ "cisa-cool-group+cyhy@trio.dhs.gov" ]``` | no |
+| commander\_config | Configuration options for the CyHy commander's configuration file. | `object({ next_scan_limit = number })` | ```{ "next_scan_limit": 8192 }``` | no |
 | create\_bod\_flow\_logs | Whether or not to create flow logs for the BOD 18-01 VPC. | `bool` | `false` | no |
 | create\_cyhy\_flow\_logs | Whether or not to create flow logs for the CyHy VPC. | `bool` | `false` | no |
 | create\_mgmt\_flow\_logs | Whether or not to create flow logs for the Management VPC. | `bool` | `false` | no |

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -193,6 +193,7 @@ module "cyhy_mongo_ansible_provisioner" {
     "dmarc_import_es_role=${var.dmarc_import_es_role_arn}",
     "nmap_hosts=${join(",", formatlist("portscan%d", range(1, var.nmap_instance_count + 1)))}",
     "nessus_hosts=${join(",", formatlist("vulnscan%d", range(1, var.nessus_instance_count + 1)))}",
+    "next_scan_limit=${var.commander_config.next_scan_limit}",
   ]
   playbook = "../ansible/playbook.yml"
   dry_run  = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -179,6 +179,14 @@ variable "cloudwatch_alarm_emails" {
   type        = list(string)
 }
 
+variable "commander_config" {
+  default = {
+    next_scan_limit = 8192
+  }
+  description = "Configuration options for the CyHy commander's configuration file."
+  type        = object({ next_scan_limit = number })
+}
+
 variable "create_bod_flow_logs" {
   default     = false
   description = "Whether or not to create flow logs for the BOD 18-01 VPC."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds the ability to configure the `next-scan-limit` value in the [cyhy-commander] configuration file.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We want to update the value being deployed in production but rather than continuously modifying a hard-coded value it made sense to integrate this as a configurable value between the Ansible role and the Terraform configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass locally. Tests on GitHub will require final resolution of #661 and integration in this branch to pass. I deployed this in my development environment with a non-default value and confirmed it deployed successfully.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] All new and existing tests pass.

[cyhy-commander]: https://github.com/cisagov/cyhy-commander
