### PR TITLE
Remove Old Nexpose Source IP and Add Nessus IP

### DIFF
--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -44,8 +44,7 @@ HEADER = """###
 # The following CIDR blocks are where our Cyber Hygiene scans
 # originate from:
 cyhy_ips = (
-    "52.86.228.163/32",  # CyHy "manual scan" Nessus instance (env2)
-    "54.145.197.20/32",  # CyHy "manual scan" Nexpose instance (env2)
+    "54.157.136.44/32",  # CyHy "manual scan" Nessus instance (env2)
     "64.69.57.0/24",
     "100.27.42.128/25",
 )


### PR DESCRIPTION
This scanner/IP is no longer in use and can be removed.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes the old Nexpose Source  and adds the new IP address used by VS in the list of IPs shown at https://rules.ncats.cyber.dhs.gov/.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Until a permanent solution to automate this process has been created, when IPs are or are not used for scanning, they must be updated here.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran egress_pub.py and verified that the IPs no longer appears in the list at https://rules.ncats.cyber.dhs.gov/.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

