### PR TITLE
Tear down Docker composition before bringing it up again

### DIFF
--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -65,6 +65,8 @@
     - name: Create a cron job for BOD 18-01 scanning
       ansible.builtin.cron:
         hour: '0'
+        # TODO: Remove the docker compose down when possible.  See
+        # #668 for more details.
         job: cd /var/cyhy/orchestrator && docker compose down && docker compose up --detach 2>&1 | /usr/bin/logger --tag orchestrator
         minute: '0'
         name: "BOD 18-01 scanning"

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -65,7 +65,7 @@
     - name: Create a cron job for BOD 18-01 scanning
       ansible.builtin.cron:
         hour: '0'
-        job: cd /var/cyhy/orchestrator && docker compose up -d 2>&1 | /usr/bin/logger -t orchestrator
+        job: cd /var/cyhy/orchestrator && docker compose down && docker compose up -d 2>&1 | /usr/bin/logger -t orchestrator
         minute: '0'
         name: "BOD 18-01 scanning"
         user: cyhy

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -65,7 +65,7 @@
     - name: Create a cron job for BOD 18-01 scanning
       ansible.builtin.cron:
         hour: '0'
-        job: cd /var/cyhy/orchestrator && docker compose down && docker compose up --detach 2>&1 | /usr/bin/logger -t orchestrator
+        job: cd /var/cyhy/orchestrator && docker compose down && docker compose up --detach 2>&1 | /usr/bin/logger --tag orchestrator
         minute: '0'
         name: "BOD 18-01 scanning"
         user: cyhy

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -65,7 +65,7 @@
     - name: Create a cron job for BOD 18-01 scanning
       ansible.builtin.cron:
         hour: '0'
-        job: cd /var/cyhy/orchestrator && docker compose down && docker compose up -d 2>&1 | /usr/bin/logger -t orchestrator
+        job: cd /var/cyhy/orchestrator && docker compose down && docker compose up --detach 2>&1 | /usr/bin/logger -t orchestrator
         minute: '0'
         name: "BOD 18-01 scanning"
         user: cyhy


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes a change to tear down the [cisagov/orchestrator](https://github.com/cisagov/orchestrator) Docker composition before bringing it up again.

## 💭 Motivation and context ##

We have had an issue lately where the Docker composition does not start up correctly otherwise; this change will obviate said issue.

## 🧪 Testing ##

All automated tests pass.  I made this same change manually on the production system.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.