### PR TITLE
Bump production `portscan` instances from `t3.small` to `t3.medium`

### DIFF
--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -22,7 +22,7 @@ data "aws_ami" "nmap" {
 
 resource "aws_instance" "cyhy_nmap" {
   ami           = data.aws_ami.nmap.id
-  instance_type = local.production_workspace ? "t3.small" : "t3.small"
+  instance_type = local.production_workspace ? "t3.medium" : "t3.small"
   count         = var.nmap_instance_count
 
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This changes the AWS EC2 instance type used for `portscan` instances in production workspaces to use `t3.medium` instead of `t3.small`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We are moving these instances to a larger instance type to support putting more jobs on a given instance. Since we have a limited number of `portscan` instances we can spin up (due to networking configurations and IP address availability) we need the ability to put more work on each instance.

This aligns the Terraform configuration in this repository with what is currently deployed to production for these instances.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
