### PR TITLE
Add the ability to configure the `cyhy-commander`'s `jobs-per-*-host` values

### DIFF
--- a/ansible/roles/cyhy_commander/defaults/main.yml
+++ b/ansible/roles/cyhy_commander/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 # defaults file for cyhy_commander
 
+# The maximum number of jobs to assign to each nessus host (vulnscanner)
+jobs_per_nessus_host: 16
+
+# The maximum number of jobs to assign to each nmap host (portscanner)
+jobs_per_nmap_host: 8
+
 # The maximum number of hosts that are scheduled to have scanning restarted
 # whose next scan stage should be updated per cyhy-commander cycle. The checks
 # for hosts that were "up" or "down" are processed separately so the total

--- a/ansible/roles/cyhy_commander/defaults/main.yml
+++ b/ansible/roles/cyhy_commander/defaults/main.yml
@@ -1,10 +1,14 @@
 ---
 # defaults file for cyhy_commander
 
-# The maximum number of jobs to assign to each nessus host (vulnscanner)
+# The maximum number of jobs to assign to each nessus host (vulnscanner).
+# This value is used in the "production" section of the cyhy-commander
+# configuration file this role generates.
 jobs_per_nessus_host: 16
 
-# The maximum number of jobs to assign to each nmap host (portscanner)
+# The maximum number of jobs to assign to each nmap host (portscanner).
+# This value is used in the "production" section of the cyhy-commander
+# configuration file this role generates.
 jobs_per_nmap_host: 8
 
 # The maximum number of hosts that are scheduled to have scanning restarted
@@ -13,4 +17,6 @@ jobs_per_nmap_host: 8
 # number of hosts that are transitioned is double the provided value. Hosts
 # that are "up" are transitioned to PORTSCAN and hosts that are "down" are
 # transitioned to NETSCAN1.
+# This value is used in the "production" section of the cyhy-commander
+# configuration file this role generates.
 next_scan_limit: 8192

--- a/ansible/roles/cyhy_commander/templates/commander.conf.j2
+++ b/ansible/roles/cyhy_commander/templates/commander.conf.j2
@@ -15,8 +15,8 @@ nessus-hosts = vulnscan1
 
 [production]
 database-name = cyhy
-jobs-per-nmap-host = 12
-jobs-per-nessus-host = 128
+jobs-per-nmap-host = {{ jobs_per_nmap_host }}
+jobs-per-nessus-host = {{ jobs_per_nessus_host }}
 next-scan-limit = {{ next_scan_limit }}
 nmap-hosts = {{ nmap_hosts }}
 nessus-hosts = {{ nessus_hosts }}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -658,7 +658,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | bod\_lambda\_functions | A map of information for each BOD 18-01 Lambda. The keys are the scan types and the values are objects that contain the Lambda's name and the key (name) for the corresponding deployment package in the BOD Lambda S3 bucket. Example: `{ pshtt = { lambda_file = "pshtt.zip", lambda_name = "task_pshtt" }}` | `map(object({ lambda_file = string, lambda_name = string }))` | `{}` | no |
 | bod\_nat\_gateway\_eip | The IP corresponding to the EIP to be used for the BOD 18-01 NAT gateway in production.  In a non-production workspace an EIP will be created. | `string` | `""` | no |
 | cloudwatch\_alarm\_emails | A list of the emails to which alerts should be sent if any CloudWatch Alarm is triggered. | `list(string)` | ```[ "cisa-cool-group+cyhy@trio.dhs.gov" ]``` | no |
-| commander\_config | Configuration options for the CyHy commander's configuration file. | `object({ next_scan_limit = number })` | ```{ "next_scan_limit": 8192 }``` | no |
+| commander\_config | Configuration options for the CyHy commander's configuration file. | `object({ jobs_per_nessus_host = number, jobs_per_nmap_host = number, next_scan_limit = number })` | ```{ "jobs_per_nessus_host": 16, "jobs_per_nmap_host": 8, "next_scan_limit": 8192 }``` | no |
 | create\_bod\_flow\_logs | Whether or not to create flow logs for the BOD 18-01 VPC. | `bool` | `false` | no |
 | create\_cyhy\_flow\_logs | Whether or not to create flow logs for the CyHy VPC. | `bool` | `false` | no |
 | create\_mgmt\_flow\_logs | Whether or not to create flow logs for the Management VPC. | `bool` | `false` | no |

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -191,6 +191,8 @@ module "cyhy_mongo_ansible_provisioner" {
     "aws_region=${var.aws_region}",
     "dmarc_import_aws_region=${var.dmarc_import_aws_region}",
     "dmarc_import_es_role=${var.dmarc_import_es_role_arn}",
+    "jobs_per_nessus_host=${var.commander_config.jobs_per_nessus_host}",
+    "jobs_per_nmap_host=${var.commander_config.jobs_per_nmap_host}",
     "nmap_hosts=${join(",", formatlist("portscan%d", range(1, var.nmap_instance_count + 1)))}",
     "nessus_hosts=${join(",", formatlist("vulnscan%d", range(1, var.nessus_instance_count + 1)))}",
     "next_scan_limit=${var.commander_config.next_scan_limit}",

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -182,20 +182,20 @@ module "cyhy_mongo_ansible_provisioner" {
   ]
   envs = [
     "ANSIBLE_SSH_RETRIES=5",
-    "host=${aws_instance.cyhy_mongo[count.index].private_ip}",
+    "aws_region=${var.aws_region}",
     "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "cyhy_archive_s3_bucket_name=${aws_s3_bucket.cyhy_archive.bucket}",
     "cyhy_archive_s3_bucket_region=${var.aws_region}",
-    "host_groups=mongo,cyhy_commander,cyhy_archive",
-    "production_workspace=${local.production_workspace}",
-    "aws_region=${var.aws_region}",
     "dmarc_import_aws_region=${var.dmarc_import_aws_region}",
     "dmarc_import_es_role=${var.dmarc_import_es_role_arn}",
+    "host_groups=mongo,cyhy_commander,cyhy_archive",
+    "host=${aws_instance.cyhy_mongo[count.index].private_ip}",
     "jobs_per_nessus_host=${var.commander_config.jobs_per_nessus_host}",
     "jobs_per_nmap_host=${var.commander_config.jobs_per_nmap_host}",
-    "nmap_hosts=${join(",", formatlist("portscan%d", range(1, var.nmap_instance_count + 1)))}",
     "nessus_hosts=${join(",", formatlist("vulnscan%d", range(1, var.nessus_instance_count + 1)))}",
     "next_scan_limit=${var.commander_config.next_scan_limit}",
+    "nmap_hosts=${join(",", formatlist("portscan%d", range(1, var.nmap_instance_count + 1)))}",
+    "production_workspace=${local.production_workspace}",
   ]
   playbook = "../ansible/playbook.yml"
   dry_run  = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -181,10 +181,12 @@ variable "cloudwatch_alarm_emails" {
 
 variable "commander_config" {
   default = {
-    next_scan_limit = 8192
+    jobs_per_nessus_host = 16
+    jobs_per_nmap_host   = 8
+    next_scan_limit      = 8192
   }
   description = "Configuration options for the CyHy commander's configuration file."
-  type        = object({ next_scan_limit = number })
+  type        = object({ jobs_per_nessus_host = number, jobs_per_nmap_host = number, next_scan_limit = number })
 }
 
 variable "create_bod_flow_logs" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds the ability to configure the `jobs-per-nessus-host` and `jobs-per-nmap-host` values in the [cyhy-commander] configuration file.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We want to update the value being deployed in production but rather than continuously modifying a hard-coded value it made sense to integrate this as a configurable value between the Ansible role and the Terraform configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I deployed this in my development environment with a non-default value and confirmed it deployed successfully.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

[cyhy-commander]: https://github.com/cisagov/cyhy-commander
