### PR TITLE
Allow HTTPS egress for `bastion` instances

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -483,6 +483,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_security_group_rule.bod_bastion_egress_all_icmp_to_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.bod_bastion_egress_all_tcp_to_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.bod_bastion_egress_all_udp_to_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.bod_bastion_https_egress_to_anywhere](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.bod_bastion_ingress_all_icmp_from_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.bod_bastion_ingress_all_tcp_from_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.bod_bastion_ingress_all_udp_from_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -495,6 +496,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_security_group_rule.cyhy_bastion_egress_all_icmp_to_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cyhy_bastion_egress_all_tcp_to_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cyhy_bastion_egress_all_udp_to_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.cyhy_bastion_https_egress_to_anywhere](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cyhy_bastion_ingress_all_icmp_from_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cyhy_bastion_ingress_all_tcp_from_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cyhy_bastion_ingress_all_udp_from_mgmt_vulnscan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/terraform/bod_bastion_security_group_rules.tf
+++ b/terraform/bod_bastion_security_group_rules.tf
@@ -26,6 +26,16 @@ resource "aws_security_group_rule" "bastion_self_ssh" {
   to_port   = 22
 }
 
+# Allow HTTPS egress anywhere
+resource "aws_security_group_rule" "bod_bastion_https_egress_to_anywhere" {
+  security_group_id = aws_security_group.bod_bastion_sg.id
+  type              = "egress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+}
+
 # Allow ssh egress to the docker security group
 resource "aws_security_group_rule" "bastion_ssh_to_docker" {
   security_group_id        = aws_security_group.bod_bastion_sg.id

--- a/terraform/cyhy_bastion_security_group_rules.tf
+++ b/terraform/cyhy_bastion_security_group_rules.tf
@@ -40,6 +40,16 @@ resource "aws_security_group_rule" "bastion_self_egress" {
   to_port   = 22
 }
 
+# Allow HTTPS egress anywhere
+resource "aws_security_group_rule" "cyhy_bastion_https_egress_to_anywhere" {
+  security_group_id = aws_security_group.cyhy_bastion_sg.id
+  type              = "egress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+}
+
 # Allow egress via ssh to the private security group
 resource "aws_security_group_rule" "bastion_egress_to_private_sg_via_ssh" {
   security_group_id        = aws_security_group.cyhy_bastion_sg.id


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request allows HTTPS (port `443`) egress from both the `bod` and `cyhy` `bastion` instances.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Allowing HTTPS egress will allow these instances to retrieve security updates and push logs to CloudWatch. There is little risk of allowing this since it is only egress traffic and other instances (including the `portscan` and `vulnscan` instances) are already permitted egress for this kind of traffic.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I deployed this in my test environment and confirmed both that logs were being pushed to CloudWatch and that I could successfully perform a `curl https://example.com`. This contrasts with production where neither of these things are successful.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
