### PR TITLE
Cleanup the Ansible roles defined in this project

### DIFF
--- a/ansible/roles/client_cert_update/defaults/main.yml
+++ b/ansible/roles/client_cert_update/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for bod_docker

--- a/ansible/roles/client_cert_update/handlers/main.yml
+++ b/ansible/roles/client_cert_update/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for bod_docker

--- a/ansible/roles/client_cert_update/meta/main.yml
+++ b/ansible/roles/client_cert_update/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: client_cert_update
-
-dependencies: []

--- a/ansible/roles/client_cert_update/tasks/main.yml
+++ b/ansible/roles/client_cert_update/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for client_cert_update
-
 #
 # client_cert_update secrets
 #

--- a/ansible/roles/client_cert_update/vars/main.yml
+++ b/ansible/roles/client_cert_update/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for client_cert_update
-
 # scan-reader mongo username
 scan_reader_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/user') }}"
 # scan-reader mongo password

--- a/ansible/roles/code_gov_update/defaults/main.yml
+++ b/ansible/roles/code_gov_update/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for bod_docker

--- a/ansible/roles/code_gov_update/handlers/main.yml
+++ b/ansible/roles/code_gov_update/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for bod_docker

--- a/ansible/roles/code_gov_update/meta/main.yml
+++ b/ansible/roles/code_gov_update/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: code_gov_update
-
-dependencies: []

--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for code_gov_update
-
 #
 # code_gov_update secrets
 #

--- a/ansible/roles/code_gov_update/vars/main.yml
+++ b/ansible/roles/code_gov_update/vars/main.yml
@@ -1,5 +1,3 @@
 ---
-# vars file for bod_docker
-
 # The GitHub Personal Access Token
 github_pat: "{{ lookup('aws_ssm', '/github/pat/code.gov') }}"

--- a/ansible/roles/cyhy_archive/defaults/main.yml
+++ b/ansible/roles/cyhy_archive/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for cyhy_archive

--- a/ansible/roles/cyhy_archive/handlers/main.yml
+++ b/ansible/roles/cyhy_archive/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for cyhy_archive

--- a/ansible/roles/cyhy_archive/meta/main.yml
+++ b/ansible/roles/cyhy_archive/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,8 +12,5 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
   role_name: cyhy_archive
-
-dependencies: []

--- a/ansible/roles/cyhy_archive/tasks/main.yml
+++ b/ansible/roles/cyhy_archive/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for cyhy_archive
-
 # Create directory to temporarily store cyhy-archives until
 # they are copied to S3
 - name: Create the /var/lib/mongodb/cyhy_archives directory

--- a/ansible/roles/cyhy_archive/vars/main.yml
+++ b/ansible/roles/cyhy_archive/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for cyhy_archive

--- a/ansible/roles/cyhy_commander/defaults/main.yml
+++ b/ansible/roles/cyhy_commander/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# defaults file for cyhy_commander
-
 # The maximum number of jobs to assign to each nessus host (vulnscanner).
 # This value is used in the "production" section of the cyhy-commander
 # configuration file this role generates.

--- a/ansible/roles/cyhy_commander/handlers/main.yml
+++ b/ansible/roles/cyhy_commander/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for cyhy_commander

--- a/ansible/roles/cyhy_commander/meta/main.yml
+++ b/ansible/roles/cyhy_commander/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,8 +12,5 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
   role_name: cyhy_commander
-
-dependencies: []

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for cyhy_commander
-
 #
 # Copy private key to new instance
 #

--- a/ansible/roles/cyhy_commander/vars/main.yml
+++ b/ansible/roles/cyhy_commander/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for cyhy_commander
-
 # The CyHy SSH private key
 ssh_private_key: "{{ lookup('aws_ssm', '/cyhy/ssh/private_key') }}"
 

--- a/ansible/roles/cyhy_dashboard/defaults/main.yml
+++ b/ansible/roles/cyhy_dashboard/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for cyhy_dashboard

--- a/ansible/roles/cyhy_dashboard/handlers/main.yml
+++ b/ansible/roles/cyhy_dashboard/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for cyhy_dashboard

--- a/ansible/roles/cyhy_dashboard/meta/main.yml
+++ b/ansible/roles/cyhy_dashboard/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,8 +12,5 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
   role_name: cyhy_dashboard
-
-dependencies: []

--- a/ansible/roles/cyhy_dashboard/tasks/main.yml
+++ b/ansible/roles/cyhy_dashboard/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for cyhy_dashboard
-
 - name: Create needed directories
   ansible.builtin.file:
     group: cyhy

--- a/ansible/roles/cyhy_dashboard/vars/main.yml
+++ b/ansible/roles/cyhy_dashboard/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for cyhy_dashboard
-
 # commander mongo username
 commander_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/user') }}"
 # commander mongo password

--- a/ansible/roles/cyhy_feeds/defaults/main.yml
+++ b/ansible/roles/cyhy_feeds/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for cyhy_feeds

--- a/ansible/roles/cyhy_feeds/handlers/main.yml
+++ b/ansible/roles/cyhy_feeds/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for cyhy_feeds

--- a/ansible/roles/cyhy_feeds/meta/main.yml
+++ b/ansible/roles/cyhy_feeds/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,8 +12,5 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
   role_name: cyhy_feeds
-
-dependencies: []

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for cyhy_feeds
-
 - name: Create cyhy-feeds config
   ansible.builtin.copy:
     content: "{{ config }}"

--- a/ansible/roles/cyhy_feeds/vars/main.yml
+++ b/ansible/roles/cyhy_feeds/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for cyhy_feeds
-
 # cyhy-feeds config
 config: "{{ lookup('aws_ssm', '/cyhy/feeds/config') }}"
 

--- a/ansible/roles/cyhy_mailer/defaults/main.yml
+++ b/ansible/roles/cyhy_mailer/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for bod_docker

--- a/ansible/roles/cyhy_mailer/handlers/main.yml
+++ b/ansible/roles/cyhy_mailer/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for bod_docker

--- a/ansible/roles/cyhy_mailer/meta/main.yml
+++ b/ansible/roles/cyhy_mailer/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: cyhy_mailer
-
-dependencies: []

--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for cyhy_mailer
-
 #
 # cyhy-mailer secrets
 #

--- a/ansible/roles/cyhy_mailer/vars/main.yml
+++ b/ansible/roles/cyhy_mailer/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for cyhy_mailer
-
 # reporter mongo username
 reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
 # reporter mongo password

--- a/ansible/roles/cyhy_ops/defaults/main.yml
+++ b/ansible/roles/cyhy_ops/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for cyhy_ops

--- a/ansible/roles/cyhy_ops/handlers/main.yml
+++ b/ansible/roles/cyhy_ops/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for cyhy_ops

--- a/ansible/roles/cyhy_ops/meta/main.yml
+++ b/ansible/roles/cyhy_ops/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: cyhy_ops
-
-dependencies: []

--- a/ansible/roles/cyhy_ops/tasks/main.yml
+++ b/ansible/roles/cyhy_ops/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for cyhy_ops
-
 #
 # Create the cyhy_ops user
 #

--- a/ansible/roles/cyhy_ops/vars/main.yml
+++ b/ansible/roles/cyhy_ops/vars/main.yml
@@ -1,5 +1,3 @@
 ---
-# vars file for cyhy_ops
-
 # A list of the CyHy OPS users
 ops_users: "{{ lookup('aws_ssm', '/cyhy/ops/users').split(',') }}"

--- a/ansible/roles/cyhy_reporter/defaults/main.yml
+++ b/ansible/roles/cyhy_reporter/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for cyhy_reporter

--- a/ansible/roles/cyhy_reporter/handlers/main.yml
+++ b/ansible/roles/cyhy_reporter/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for cyhy_reporter

--- a/ansible/roles/cyhy_reporter/meta/main.yml
+++ b/ansible/roles/cyhy_reporter/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,8 +12,5 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
   role_name: cyhy_reporter
-
-dependencies: []

--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for cyhy_reporter
-
 #
 # Set up /etc/cyhy/cyhy.conf
 #

--- a/ansible/roles/cyhy_reporter/vars/main.yml
+++ b/ansible/roles/cyhy_reporter/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for cyhy_reporter
-
 # The master key for all reports
 master_report_key: "{{ lookup('aws_ssm', '/cyhy/master_report_key') }}"
 

--- a/ansible/roles/groups/defaults/main.yml
+++ b/ansible/roles/groups/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for groups

--- a/ansible/roles/groups/handlers/main.yml
+++ b/ansible/roles/groups/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for groups

--- a/ansible/roles/groups/meta/main.yml
+++ b/ansible/roles/groups/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: groups
-
-dependencies: []

--- a/ansible/roles/groups/tasks/main.yml
+++ b/ansible/roles/groups/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for groups
-
 # Grab the existing users and groups
 - name: Grab the existing users
   ansible.builtin.getent:

--- a/ansible/roles/groups/vars/main.yml
+++ b/ansible/roles/groups/vars/main.yml
@@ -1,5 +1,3 @@
 ---
-# vars file for groups
-
 # The development users
 dev_users: "{{ lookup('aws_ssm', '/cyhy/dev/users').split(',') }}"

--- a/ansible/roles/mgmt_ops/defaults/main.yml
+++ b/ansible/roles/mgmt_ops/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for mgmt_ops

--- a/ansible/roles/mgmt_ops/handlers/main.yml
+++ b/ansible/roles/mgmt_ops/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for mgmt_ops

--- a/ansible/roles/mgmt_ops/meta/main.yml
+++ b/ansible/roles/mgmt_ops/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: mgmt_ops
-
-dependencies: []

--- a/ansible/roles/mgmt_ops/tasks/main.yml
+++ b/ansible/roles/mgmt_ops/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for mgmt_ops
-
 #
 # Create the mgmt_ops user
 #

--- a/ansible/roles/mgmt_ops/vars/main.yml
+++ b/ansible/roles/mgmt_ops/vars/main.yml
@@ -1,5 +1,3 @@
 ---
-# vars file for mgmt_ops
-
 # A list of the management OPS users
 ops_users: "{{ lookup('aws_ssm', '/mgmt/ops/users').split(',') }}"

--- a/ansible/roles/mongo/defaults/main.yml
+++ b/ansible/roles/mongo/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-# defaults file for mongo
 mongodb_data_root: /var/lib/mongodb

--- a/ansible/roles/mongo/handlers/main.yml
+++ b/ansible/roles/mongo/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-# handlers file for mongo
 - name: Enable mongo
   ansible.builtin.service:
     enabled: yes

--- a/ansible/roles/mongo/meta/main.yml
+++ b/ansible/roles/mongo/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,8 +12,5 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
   role_name: mongo
-
-dependencies: []

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# tasks file for mongo
 - name: Check if any mongo users already exist
   ansible.builtin.command: mongo --eval 'db.getUsers()' admin
   # This is a read-only operation

--- a/ansible/roles/mongo/vars/main.yml
+++ b/ansible/roles/mongo/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for mongo
-
 # admin mongo username
 admin_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/admin/user') }}"
 # Old admin mongo password

--- a/ansible/roles/nessus/defaults/main.yml
+++ b/ansible/roles/nessus/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for nessus

--- a/ansible/roles/nessus/handlers/main.yml
+++ b/ansible/roles/nessus/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for nessus

--- a/ansible/roles/nessus/meta/main.yml
+++ b/ansible/roles/nessus/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: nessus
-
-dependencies: []

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for nessus
-
 #
 # Check if a license key is registered and if not register one
 #

--- a/ansible/roles/nessus/vars/main.yml
+++ b/ansible/roles/nessus/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for nessus
-
 # The Nessus username
 username: "{{ lookup('aws_ssm', '/cyhy/nessus/username') }}"
 # The Nessus password

--- a/ansible/roles/orchestrator/defaults/main.yml
+++ b/ansible/roles/orchestrator/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for bod_docker

--- a/ansible/roles/orchestrator/handlers/main.yml
+++ b/ansible/roles/orchestrator/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for bod_docker

--- a/ansible/roles/orchestrator/meta/main.yml
+++ b/ansible/roles/orchestrator/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: orchestrator
-
-dependencies: []

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for orchestrator
-
 #
 # orchestrator secrets
 #

--- a/ansible/roles/orchestrator/vars/main.yml
+++ b/ansible/roles/orchestrator/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for orchestrator
-
 # reporter mongo username
 reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
 # reporter mongo password

--- a/ansible/roles/swap/defaults/main.yml
+++ b/ansible/roles/swap/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
-# defaults file for swap
 swapfile_location: /swapfile
 swapfile_size: 2GiB

--- a/ansible/roles/swap/handlers/main.yml
+++ b/ansible/roles/swap/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for swap

--- a/ansible/roles/swap/meta/main.yml
+++ b/ansible/roles/swap/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: swap
-
-dependencies: []

--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for swap
-
 #
 # Since these tasks rely on each other in a sequential fashion we disable the
 # no-handler test for ansible-lint for tasks that are dependent on a previous

--- a/ansible/roles/swap/vars/main.yml
+++ b/ansible/roles/swap/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for swap

--- a/ansible/roles/vdp_scanner/defaults/main.yml
+++ b/ansible/roles/vdp_scanner/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for vdp_scanner

--- a/ansible/roles/vdp_scanner/handlers/main.yml
+++ b/ansible/roles/vdp_scanner/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for vdp_scanner

--- a/ansible/roles/vdp_scanner/meta/main.yml
+++ b/ansible/roles/vdp_scanner/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+dependencies: []
 galaxy_info:
   author: VM Fusion Dev
   company: CISA Cyber Assessments
@@ -11,9 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   role_name: vdp_scanner
-
-dependencies: []

--- a/ansible/roles/vdp_scanner/tasks/main.yml
+++ b/ansible/roles/vdp_scanner/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for vdp_scanner
-
 # Create a cron job for scanning
 # This cron job runs at midnight UTC on Monday mornings, so it
 # should be done in time to be sent Monday morning.

--- a/ansible/roles/vdp_scanner/vars/main.yml
+++ b/ansible/roles/vdp_scanner/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for vdp_scanner


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does some simple cleanup on the Ansible roles in this project including:
- Remove unused sub-directories as applicable (`defaults/`, `handlers/`, and/or `vars/` for example)
- Remove the unneeded `x file for role_name` comment headers if they are present
- Remove Debian Stretch as a supported platform
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These changes continue the effort to bring the Ansible roles in this project more in line with how we develop our standalone Ansible roles. We only include sub-directories if the functionality is used, we removed the comment headers in files, and since we no longer deploy Debian Stretch instances we should remove them from the list of supported platforms.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. Since there are no code changes this should be "good enough".
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
