### PR TITLE
Increase report data volume size on reporter instance

### DIFF
--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -92,7 +92,7 @@ resource "aws_instance" "cyhy_reporter" {
 resource "aws_ebs_volume" "cyhy_reporter_data" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   type              = "io2"
-  size              = local.production_workspace ? 1000 : 5
+  size              = local.production_workspace ? 2000 : 5
   iops              = 100
   encrypted         = true
 


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR increases the size of the report data volume on the reporter instance. 

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This was done because I noticed that we were getting low on disk space.  We currently retain all reports and the number of reports generated each week continues to increase.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
After this change was made, it was applied in production with:
```
terraform apply -var-file=prod-a.tfvars -target=aws_ebs_volume.cyhy_reporter_data
```

After the Terraform apply completed successfully, I opened a session on the reporter instance and ran through the [steps to grow the file system](https://github.com/cisagov/cyhy-system/wiki/Adjust-reporter-partition-and-filesystem-size) so that it took advantage of the larger volume size.
  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.