### PR TITLE
Fix variable usage for Ansible roles in the Packer configuration

### DIFF
--- a/packer/ansible/cyhy_archive.yml
+++ b/packer/ansible/cyhy_archive.yml
@@ -4,6 +4,8 @@
   become: yes
   become_method: ansible.builtin.sudo
   roles:
-    - cyhy_archive
+    - role: cyhy_archive
+      vars:
+        cyhy_archive_maxmind_license_key: "{{ maxmind_license_key }}"
   vars_files:
     - vars/maxmind_license_key.yml

--- a/packer/ansible/cyhy_commander.yml
+++ b/packer/ansible/cyhy_commander.yml
@@ -4,6 +4,8 @@
   become: yes
   become_method: ansible.builtin.sudo
   roles:
-    - cyhy_commander
+    - role: cyhy_commander
+      vars:
+        cyhy_commander_maxmind_license_key: "{{ maxmind_license_key }}"
   vars_files:
     - vars/maxmind_license_key.yml

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -4,7 +4,9 @@
   become: yes
   become_method: ansible.builtin.sudo
   roles:
-    - ncats_webd
+    - role: ncats_webd
+      vars:
+        ncats_webd_maxmind_license_key: "{{ maxmind_license_key }}"
     - ncats_webui
   vars_files:
     - vars/maxmind_license_key.yml

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -5,7 +5,9 @@
   become_method: ansible.builtin.sudo
   roles:
     - xfs
-    - cyhy_reports
+    - role: cyhy_reports
+      vars:
+        cyhy_reports_maxmind_license_key: "{{ maxmind_license_key }}"
     - cyhy_mailer
   vars:
     texmf_buffer_size: 100000000

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -8,9 +8,8 @@
     - role: cyhy_reports
       vars:
         cyhy_reports_maxmind_license_key: "{{ maxmind_license_key }}"
+        cyhy_reports_texmf_buffer_size: 100000000
+        cyhy_reports_texmf_main_memory: 10000000
     - cyhy_mailer
-  vars:
-    texmf_buffer_size: 100000000
-    texmf_main_memory: 10000000
   vars_files:
     - vars/maxmind_license_key.yml

--- a/packer/ansible/nessus.yml
+++ b/packer/ansible/nessus.yml
@@ -7,6 +7,6 @@
     - cyhy_runner
     - role: nessus
       vars:
-        package_bucket: ncats-3rd-party-packages
-        version: "10.5.1"
+        nessus_package_bucket: ncats-3rd-party-packages
+        nessus_version: "10.5.1"
     - more_ephemeral_ports

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -8,12 +8,12 @@
       vars:
         # Install pip2 for all images that will run Python 2 CyHy code.
         # Right now these are the dashboard, mongo, and reporter AMIs.
-        install_pip2: "{{ inventory_hostname_short is in ['dashboard', 'mongo', 'reporter'] }}"
+        pip_install_pip2: "{{ inventory_hostname_short is in ['dashboard', 'mongo', 'reporter'] }}"
     - role: python
       vars:
         # Install Python 2 for images that will run Python 2 CyHy code.
         # Right now these are the dashboard, mongo, and reporter AMIs.
-        install_python2: "{{ inventory_hostname_short is in ['dashboard', 'mongo', 'reporter'] }}"
+        python_install_python2: "{{ inventory_hostname_short is in ['dashboard', 'mongo', 'reporter'] }}"
 
 # Any instances that are not built on Amazon Linux 2 and don't require
 # Python 2 should have it removed.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request fixes the usage of variables with Ansible roles used in our Packer configuration.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When we merged https://github.com/cisagov/skeleton-ansible-role/pull/147 it included a bump to [Ansible-lint] v6. This added the requirement that role variables be prefixed with the role name. Once these changes were rolled out into our Ansible roles this configuration needed to be updated correspondingly.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I was able to successfully build all of the AMIs.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[Ansible-lint]: https://github.com/ansible/ansible-lint