### PR TITLE
Add a post-deployment Ansible provisioner for the BOD bastion

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -163,6 +163,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 
 | Name | Source | Version |
 |------|--------|---------|
+| bod\_bastion\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
 | bod\_docker\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
 | cyhy\_bastion\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
 | cyhy\_dashboard\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |

--- a/terraform/bod_bastion_ec2.tf
+++ b/terraform/bod_bastion_ec2.tf
@@ -44,3 +44,19 @@ resource "aws_instance" "bod_bastion" {
     },
   )
 }
+
+# Provision the bastion EC2 instance via Ansible
+module "bod_bastion_ansible_provisioner" {
+  source = "github.com/cloudposse/terraform-null-ansible"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no'",
+  ]
+  envs = [
+    "host=${aws_instance.bod_bastion.public_ip}",
+    "host_groups=bod_bastion",
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run  = false
+}

--- a/terraform/scripts/deploy_new_bod_bastion_ami.sh
+++ b/terraform/scripts/deploy_new_bod_bastion_ami.sh
@@ -44,4 +44,5 @@ terraform apply -var-file="$workspace.tfvars" \
   -target=aws_route53_record.bod_rev_bastion_PTR \
   -target=aws_security_group_rule.bastion_self_ssh \
   -target=aws_security_group_rule.bastion_ssh_from_trusted \
-  -target=aws_security_group_rule.bastion_ssh_to_docker
+  -target=aws_security_group_rule.bastion_ssh_to_docker \
+  -target=module.bod_bastion_ansible_provisioner


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a post-deployment Ansible provisioner for the BOD bastion.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This ensures that all of our EC2 instances are configured with an Ansible provisioner for post-deployment configuration needs. Although there is nothing specifically needed for the BOD bastion (the `groups` Ansible role will be run against it now) it ensures that the scaffolding exists for any future needs.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I was able to successfully deploy a new BOD bastion in my test environment and had no issues with functionality.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
