### PR TITLE
Alphabetize the Ansible provisioner modules in the Terraform configurations

### DIFF
--- a/terraform/bod_bastion_ec2.tf
+++ b/terraform/bod_bastion_ec2.tf
@@ -50,13 +50,13 @@ module "bod_bastion_ansible_provisioner" {
   source = "github.com/cloudposse/terraform-null-ansible"
 
   arguments = [
-    "--user=${var.remote_ssh_user}",
     "--ssh-common-args='-o StrictHostKeyChecking=no'",
+    "--user=${var.remote_ssh_user}",
   ]
+  dry_run = false
   envs = [
     "host=${aws_instance.bod_bastion.public_ip}",
     "host_groups=bod_bastion",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -158,23 +158,23 @@ module "bod_docker_ansible_provisioner" {
   ]
 
   arguments = [
-    "--user=${var.remote_ssh_user}",
     "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.bod_bastion.public_ip}\"'",
+    "--user=${var.remote_ssh_user}",
   ]
+  dry_run = false
   envs = [
-    "host=${aws_instance.bod_docker.private_ip}",
-    "bastion_host=${aws_instance.bod_bastion.public_ip}",
-    "host_groups=docker,bod_docker",
-    "production_workspace=${local.production_workspace}",
     "aws_region=${var.aws_region}",
+    "bastion_host=${aws_instance.bod_bastion.public_ip}",
     "dmarc_import_aws_region=${var.dmarc_import_aws_region}",
     "dmarc_import_es_role=${var.dmarc_import_es_role_arn}",
-    "ses_aws_region=${var.ses_aws_region}",
-    "ses_send_email_role=${var.ses_role_arn}",
     # This file will be used to add/override any settings in
     # docker-compose.yml (for cyhy-mailer).
     "docker_compose_override_file_for_mailer=${var.docker_mailer_override_filename}",
+    "host=${aws_instance.bod_docker.private_ip}",
+    "host_groups=docker,bod_docker",
+    "production_workspace=${local.production_workspace}",
+    "ses_aws_region=${var.ses_aws_region}",
+    "ses_send_email_role=${var.ses_role_arn}",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -50,13 +50,13 @@ module "cyhy_bastion_ansible_provisioner" {
   source = "github.com/cloudposse/terraform-null-ansible"
 
   arguments = [
-    "--user=${var.remote_ssh_user}",
     "--ssh-common-args='-o StrictHostKeyChecking=no'",
+    "--user=${var.remote_ssh_user}",
   ]
+  dry_run = false
   envs = [
     "host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_bastion",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/cyhy_dashboard_ec2.tf
+++ b/terraform/cyhy_dashboard_ec2.tf
@@ -77,14 +77,14 @@ module "cyhy_dashboard_ansible_provisioner" {
   source = "github.com/cloudposse/terraform-null-ansible"
 
   arguments = [
-    "--user=${var.remote_ssh_user}",
     "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'",
+    "--user=${var.remote_ssh_user}",
   ]
+  dry_run = false
   envs = [
-    "host=${aws_instance.cyhy_dashboard.private_ip}",
     "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "host=${aws_instance.cyhy_dashboard.private_ip}",
     "host_groups=cyhy_dashboard",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -177,9 +177,10 @@ module "cyhy_mongo_ansible_provisioner" {
   ]
 
   arguments = [
-    "--user=${var.remote_ssh_user}",
     "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'",
+    "--user=${var.remote_ssh_user}",
   ]
+  dry_run = false
   envs = [
     "ANSIBLE_SSH_RETRIES=5",
     "aws_region=${var.aws_region}",
@@ -188,8 +189,8 @@ module "cyhy_mongo_ansible_provisioner" {
     "cyhy_archive_s3_bucket_region=${var.aws_region}",
     "dmarc_import_aws_region=${var.dmarc_import_aws_region}",
     "dmarc_import_es_role=${var.dmarc_import_es_role_arn}",
-    "host_groups=mongo,cyhy_commander,cyhy_archive",
     "host=${aws_instance.cyhy_mongo[count.index].private_ip}",
+    "host_groups=mongo,cyhy_commander,cyhy_archive",
     "jobs_per_nessus_host=${var.commander_config.jobs_per_nessus_host}",
     "jobs_per_nmap_host=${var.commander_config.jobs_per_nmap_host}",
     "nessus_hosts=${join(",", formatlist("vulnscan%d", range(1, var.nessus_instance_count + 1)))}",
@@ -198,5 +199,4 @@ module "cyhy_mongo_ansible_provisioner" {
     "production_workspace=${local.production_workspace}",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/cyhy_nessus_ec2.tf
+++ b/terraform/cyhy_nessus_ec2.tf
@@ -154,10 +154,12 @@ module "cyhy_nessus_ansible_provisioner" {
   ]
 
   arguments = [
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'",
     "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
   ]
+  dry_run = false
   envs = [
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     # If you terminate all the existing Nessus instances and then run apply,
     # the list aws_instance.cyhy_nessus[*].private_ip is empty at that time.
     # Then there is an error condition when Terraform evaluates what must be
@@ -169,11 +171,9 @@ module "cyhy_nessus_ansible_provisioner" {
     # If you find a better way, please use it and get rid of this
     # affront to basic decency.
     "host=${length(aws_instance.cyhy_nessus[*].private_ip) > 0 ? element(aws_instance.cyhy_nessus[*].private_ip, count.index) : ""}",
-    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     "host_groups=cyhy_runner,nessus",
     "nessus_activation_code=${var.nessus_activation_codes[count.index]}",
-    "smtp_hostname=${aws_route53_record.cyhy_nessus_pub_A[count.index].name}"
+    "smtp_hostname=${aws_route53_record.cyhy_nessus_pub_A[count.index].name}",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -176,10 +176,12 @@ module "cyhy_nmap_ansible_provisioner" {
   ]
 
   arguments = [
+    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'",
     "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'"
   ]
+  dry_run = false
   envs = [
+    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
     # If you terminate all the existing nmap instances and then run apply, the
     # list aws_instance.cyhy_nmap[*].private_ip is empty at that time.  Then
     # there is an error condition when Terraform evaluates what must be done
@@ -191,9 +193,7 @@ module "cyhy_nmap_ansible_provisioner" {
     # If you find a better way, please use it and get rid of this
     # affront to basic decency.
     "host=${length(aws_instance.cyhy_nmap[*].private_ip) > 0 ? element(aws_instance.cyhy_nmap[*].private_ip, count.index) : ""}",
-    "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
-    "host_groups=cyhy_runner,nmap"
+    "host_groups=cyhy_runner,nmap",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/cyhy_reporter_ec2.tf
+++ b/terraform/cyhy_reporter_ec2.tf
@@ -119,18 +119,18 @@ module "cyhy_reporter_ansible_provisioner" {
   ]
 
   arguments = [
-    "--user=${var.remote_ssh_user}",
     "--ssh-common-args='-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -W %h:%p -o StrictHostKeyChecking=no -q ${var.remote_ssh_user}@${aws_instance.cyhy_bastion.public_ip}\"'",
+    "--user=${var.remote_ssh_user}",
   ]
+  dry_run = false
   envs = [
-    "host=${aws_instance.cyhy_reporter.private_ip}",
     "bastion_host=${aws_instance.cyhy_bastion.public_ip}",
+    "docker_compose_override_file_for_mailer=${var.reporter_mailer_override_filename}",
+    "host=${aws_instance.cyhy_reporter.private_ip}",
     "host_groups=docker,cyhy_reporter",
     "production_workspace=${local.production_workspace}",
     "ses_aws_region=${var.ses_aws_region}",
-    "docker_compose_override_file_for_mailer=${var.reporter_mailer_override_filename}",
     "ses_send_email_role=${var.ses_role_arn}",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform/mgmt_bastion_ec2.tf
+++ b/terraform/mgmt_bastion_ec2.tf
@@ -52,13 +52,13 @@ module "mgmt_bastion_ansible_provisioner" {
   count  = var.enable_mgmt_vpc ? length(aws_instance.mgmt_bastion) : 0
 
   arguments = [
+    "--ssh-common-args='-o StrictHostKeyChecking=no'",
     "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no'"
   ]
+  dry_run = false
   envs = [
     "host=${aws_instance.mgmt_bastion[*].public_ip[count.index]}",
-    "host_groups=mgmt_bastion"
+    "host_groups=mgmt_bastion",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }

--- a/terraform_nessus_only/nessus_ec2.tf
+++ b/terraform_nessus_only/nessus_ec2.tf
@@ -115,12 +115,11 @@ module "nessus_ansible_provisioner" {
   source = "github.com/cloudposse/terraform-null-ansible"
   count  = length(aws_instance.nessus)
 
-
   arguments = [
+    "--ssh-common-args='-o StrictHostKeyChecking=no'",
     "--user=${var.remote_ssh_user}",
-    "--ssh-common-args='-o StrictHostKeyChecking=no'"
   ]
-
+  dry_run = false
   envs = [
     # If you terminate all the existing Nessus instances and then run apply,
     # the list aws_eip_association.nessus_eip_assocs[*].public_ip is empty at
@@ -134,8 +133,7 @@ module "nessus_ansible_provisioner" {
     # affront to basic decency.
     "host=${length(aws_eip_association.nessus_eip_assocs[*].public_ip) > 0 ? element(aws_eip_association.nessus_eip_assocs[*].public_ip, count.index) : ""}",
     "host_groups=nessus",
-    "nessus_activation_code=${var.nessus_activation_codes[count.index]}"
+    "nessus_activation_code=${var.nessus_activation_codes[count.index]}",
   ]
   playbook = "../ansible/playbook.yml"
-  dry_run  = false
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request alphabetizes the arguments in all of the Ansible provisioners in this repository. This includes the keys and the elements of any values that are lists (where order does not matter).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is consistent with our general development practices and finishes work that has been done toward this in a piecemeal fashion. It also serves to resolve the request in https://github.com/cisagov/cyhy_amis/pull/699#discussion_r1364081479.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
