### PR TITLE
Update the Terraform AWS provider version constraint from ~> 3.75 to ~> 4.9

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -146,15 +146,15 @@ terraform apply -var-file=<your_workspace>.tfvars
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 3.75 |
+| aws | ~> 4.9 |
 | cloudinit | ~> 2.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.75 |
-| aws.public\_dns | ~> 3.75 |
+| aws | ~> 4.9 |
+| aws.public\_dns | ~> 4.9 |
 | cloudinit | ~> 2.0 |
 | null | n/a |
 | terraform | n/a |

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -1,15 +1,6 @@
 # The S3 bucket where the cyhy-archive compressed archives are stored
 resource "aws_s3_bucket" "cyhy_archive" {
   bucket = "${var.cyhy_archive_bucket_name}-${terraform.workspace}"
-
-  lifecycle {
-    ignore_changes = [
-      # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the backported resources in v3.75 to
-      # avoid conflicts/unexpected apply results.
-      server_side_encryption_configuration,
-    ]
-  }
 }
 
 # Ensure the S3 bucket is encrypted

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -31,6 +31,7 @@ resource "aws_s3_bucket_public_access_block" "cyhy_archive" {
 # objects stored in this bucket.
 resource "aws_s3_bucket_ownership_controls" "cyhy_archive" {
   bucket = aws_s3_bucket.cyhy_archive.id
+
   rule {
     object_ownership = "BucketOwnerEnforced"
   }

--- a/terraform/moe_bucket.tf
+++ b/terraform/moe_bucket.tf
@@ -36,6 +36,7 @@ resource "aws_s3_bucket_public_access_block" "moe_bucket" {
 # objects stored in this bucket.
 resource "aws_s3_bucket_ownership_controls" "moe_bucket" {
   bucket = aws_s3_bucket.moe_bucket.id
+
   rule {
     object_ownership = "BucketOwnerEnforced"
   }

--- a/terraform/moe_bucket.tf
+++ b/terraform/moe_bucket.tf
@@ -4,12 +4,6 @@ resource "aws_s3_bucket" "moe_bucket" {
   tags = { "Name" = "MOE bucket" }
 
   lifecycle {
-    ignore_changes = [
-      # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the backported resources in v3.75 to
-      # avoid conflicts/unexpected apply results.
-      server_side_encryption_configuration,
-    ]
     prevent_destroy = true
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -20,6 +20,7 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.9"
     }
+
     cloudinit = {
       source  = "hashicorp/cloudinit"
       version = "~> 2.0"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,12 +7,18 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
-    # AWS S3 resources are structured from the 4.0 release.
+    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
+    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
+    # only non-breaking changes and deprecation notices are introduced. Using
+    # this version will simplify migration to the new, broken out AWS S3 bucket
+    # configuration resources. Please see
+    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
+    # for more information about the changes in v4.9 and
     # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
+    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.75"
+      version = "~> 4.9"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -1,18 +1,6 @@
 resource "aws_s3_bucket" "rules_bucket" {
   bucket = var.rules_bucket_name
 
-  # This is the recommendation of the documentation here:
-  # https://registry.terraform.io/providers/hashicorp/aws/3.75.0/docs/resources/s3_bucket_website_configuration#usage-notes
-  lifecycle {
-    ignore_changes = [
-      # These should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the backported resources in v3.75 to
-      # avoid conflicts/unexpected apply results.
-      server_side_encryption_configuration,
-      website,
-    ]
-  }
-
   tags = { "Application" = "Egress Publish" }
 }
 

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -32,6 +32,7 @@ resource "aws_s3_bucket_public_access_block" "rules_bucket" {
 # objects stored in this bucket.
 resource "aws_s3_bucket_ownership_controls" "rules_bucket" {
   bucket = aws_s3_bucket.rules_bucket.id
+
   rule {
     object_ownership = "BucketOwnerEnforced"
   }
@@ -40,10 +41,11 @@ resource "aws_s3_bucket_ownership_controls" "rules_bucket" {
 resource "aws_s3_bucket_website_configuration" "rules_bucket" {
   bucket = aws_s3_bucket.rules_bucket.id
 
-  index_document {
-    suffix = "all.txt"
-  }
   error_document {
     key = "error.html"
+  }
+
+  index_document {
+    suffix = "all.txt"
   }
 }

--- a/terraform_egress_pub/versions.tf
+++ b/terraform_egress_pub/versions.tf
@@ -6,12 +6,18 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
-    # AWS S3 resources are structured from the 4.0 release.
+    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
+    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
+    # only non-breaking changes and deprecation notices are introduced. Using
+    # this version will simplify migration to the new, broken out AWS S3 bucket
+    # configuration resources. Please see
+    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
+    # for more information about the changes in v4.9 and
     # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
+    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.75"
+      version = "~> 4.9"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/terraform_egress_pub/versions.tf
+++ b/terraform_egress_pub/versions.tf
@@ -6,6 +6,11 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.1"
+    }
+
     # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
     # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
     # only non-breaking changes and deprecation notices are introduced. Using
@@ -18,10 +23,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.9"
-    }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "~> 2.1"
     }
   }
 }

--- a/terraform_nessus_only/versions.tf
+++ b/terraform_nessus_only/versions.tf
@@ -19,6 +19,7 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.9"
     }
+
     template = {
       source  = "hashicorp/template"
       version = "~> 2.1"

--- a/terraform_nessus_only/versions.tf
+++ b/terraform_nessus_only/versions.tf
@@ -6,12 +6,18 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
-    # AWS S3 resources are structured from the 4.0 release.
+    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
+    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
+    # only non-breaking changes and deprecation notices are introduced. Using
+    # this version will simplify migration to the new, broken out AWS S3 bucket
+    # configuration resources. Please see
+    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
+    # for more information about the changes in v4.9 and
     # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
+    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.75"
+      version = "~> 4.9"
     }
     template = {
       source  = "hashicorp/template"

--- a/terraform_route_53/versions.tf
+++ b/terraform_route_53/versions.tf
@@ -6,12 +6,18 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
-    # AWS S3 resources are structured from the 4.0 release.
+    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
+    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
+    # only non-breaking changes and deprecation notices are introduced. Using
+    # this version will simplify migration to the new, broken out AWS S3 bucket
+    # configuration resources. Please see
+    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
+    # for more information about the changes in v4.9 and
     # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
+    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.75"
+      version = "~> 4.9"
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the version constraint for the [Terraform AWS provider](https://github.com/hashicorp/terraform-provider-aws). This also involves making changes to align with the [Terraform AWS provider v4 upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade). Lastly there are some small formatting adjustments made.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We are _quite_ behind on provider versions at this point and it behooves us to start updating so we are not left woefully behind. Some changes to v4.9 of the provider that I missed (eased some of the headaches around the refactor of S3 resources) will make it easier to manage updating to this major version.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. After upgrading my Terraform configuration with `terraform init -upgrade` an apply to my testing configuration resulted in no changes (the expected outcome).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
