### PR TITLE
Move the use of `cisagov/ansible-role-cyhy-feeds` into its own playbook

### DIFF
--- a/packer/ansible/cyhy_feeds.yml
+++ b/packer/ansible/cyhy_feeds.yml
@@ -1,0 +1,7 @@
+---
+- hosts: cyhy_feeds
+  name: Install cyhy-feeds
+  become: yes
+  become_method: ansible.builtin.sudo
+  roles:
+    - cyhy_feeds

--- a/packer/ansible/mongo.yml
+++ b/packer/ansible/mongo.yml
@@ -6,4 +6,3 @@
   roles:
     - xfs
     - mongo
-    - cyhy_feeds

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -40,3 +40,6 @@
 
 - name: Import the cyhy_archive host playbook
   ansible.builtin.import_playbook: cyhy_archive.yml
+
+- name: Import the cyhy_feeds host playbook
+  ansible.builtin.import_playbook: cyhy_feeds.yml

--- a/packer/docker.json
+++ b/packer/docker.json
@@ -71,8 +71,8 @@
       ],
       "groups": [
         "bod",
-        "code_gov",
         "client_cert",
+        "code_gov",
         "vdp_scan"
       ],
       "playbook_file": "ansible/playbook.yml",

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -82,9 +82,9 @@
         "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
-        "mongo",
+        "cyhy_archive",
         "cyhy_commander",
-        "cyhy_archive"
+        "mongo"
       ],
       "playbook_file": "ansible/playbook.yml",
       "type": "ansible",

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -84,6 +84,7 @@
       "groups": [
         "cyhy_archive",
         "cyhy_commander",
+        "cyhy_feeds",
         "mongo"
       ],
       "playbook_file": "ansible/playbook.yml",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request moves the use of [cisagov/ansible-role-cyhy-feeds] into its own playbook in the Packer configuration. It also ensures the groups in each Packer image configuration's Ansible provisioners are sorted alphabetically.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It's best to separate the usage of this role into its own playbook instead of bundling it with the MongoDB playbook. Since the groups are a list with no importance on order it makes sense to sort them alphabetically as the team prefers.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I built and deployed a fresh `database` AMI in my testing environment and ensured that everything was installed as expected and that the post-deployment Ansible provisioning worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/ansible-role-cyhy-feeds]: https://github.com/cisagov/ansible-role-cyhy-feeds
