### PR TITLE
Create the `/etc/cyhy` directory at AMI build time

### DIFF
--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -11,17 +11,6 @@
     owner: cyhy
 
 #
-# Create the cyhy directory in etc for commander conf
-#
-- name: Create the /etc/cyhy directory
-  ansible.builtin.file:
-    group: cyhy
-    mode: 0755
-    owner: cyhy
-    path: /etc/cyhy
-    state: directory
-
-#
 # Copy the cyhy-commander conf file
 #
 - name: Create the configuration file for cyhy-commander

--- a/ansible/roles/cyhy_dashboard/tasks/main.yml
+++ b/ansible/roles/cyhy_dashboard/tasks/main.yml
@@ -1,14 +1,11 @@
 ---
-- name: Create needed directories
+- name: Create the /var/cyhy/web directory
   ansible.builtin.file:
     group: cyhy
     mode: 0750
     owner: cyhy
-    path: "{{ item }}"
+    path: /var/cyhy/web
     state: directory
-  loop:
-    - /etc/cyhy
-    - /var/cyhy/web
 
 - name: Create secret key file for webd
   ansible.builtin.file:

--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -2,12 +2,6 @@
 #
 # Set up /etc/cyhy/cyhy.conf
 #
-- name: Create the /etc/cyhy directory
-  ansible.builtin.file:
-    mode: 0755
-    path: /etc/cyhy
-    state: directory
-
 - name: Create /etc/cyhy/cyhy.conf
   ansible.builtin.template:
     dest: /etc/cyhy/cyhy.conf

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -94,14 +94,6 @@
         name: nessusd
         state: started
 
-- name: Create /etc/cyhy directory
-  ansible.builtin.file:
-    group: cyhy
-    mode: 0750
-    owner: cyhy
-    path: /etc/cyhy
-    state: directory
-
 - name: Create the configuration file for Nessus API access
   ansible.builtin.template:
     dest: /etc/cyhy/nessus_api.yml

--- a/packer/ansible/create_credentials_directory.yml
+++ b/packer/ansible/create_credentials_directory.yml
@@ -1,0 +1,15 @@
+---
+- hosts: cyhy_commander,cyhy_dashboard,cyhy_reporter,nessus
+  name: Create the directory used for cyhy-commander, cyhy-core, and Nessus credentials
+  become: yes
+  become_method: ansible.builtin.sudo
+  tasks:
+    - name: Create the /etc/cyhy directory
+      ansible.builtin.file:
+        group: "{{ cyhy_user_username }}"
+        mode: 0750
+        owner: "{{ cyhy_user_username }}"
+        path: /etc/cyhy
+        state: directory
+  vars_files:
+    - vars/cyhy_user.yml

--- a/packer/ansible/create_cyhy_user.yml
+++ b/packer/ansible/create_cyhy_user.yml
@@ -9,9 +9,9 @@
     - name: Create the cyhy user
       ansible.builtin.user:
         home: /var/cyhy
-        name: cyhy
+        name: "{{ cyhy_user_username }}"
         shell: /bin/bash
-        uid: 2048
+        uid: "{{ cyhy_user_uid }}"
       register: user_info
 
     - name: Modify permissions on the home directory
@@ -22,4 +22,6 @@
     - name: Add the SSH public key as an authorized key
       ansible.posix.authorized_key:
         key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy
-        user: cyhy
+        user: "{{ cyhy_user_username }}"
+  vars_files:
+    - vars/cyhy_user.yml

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -8,6 +8,9 @@
 - name: Import cyhy user creation playbook
   ansible.builtin.import_playbook: create_cyhy_user.yml
 
+- name: Import credentials directory creation playbook
+  ansible.builtin.import_playbook: create_credentials_directory.yml
+
 - name: Import the nmap host playbook
   ansible.builtin.import_playbook: nmap.yml
 

--- a/packer/ansible/vars/cyhy_user.yml
+++ b/packer/ansible/vars/cyhy_user.yml
@@ -1,0 +1,4 @@
+---
+# CyHy user information
+cyhy_user_uid: 2048
+cyhy_user_username: cyhy


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request consolidates creation of the `/etc/cyhy` directory and moves it from a post-deployment action to part of AMI build time. It also breaks out information about the `cyhy` user into a variables file.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It makes sense to consolidate creation of common directory paths and to move their creation to AMI build time instead of as part of post-deployment Ansible provisioners. Since the `cyhy` user name is needed in two different locations it makes sense to store information about the user in a variables file instead of hard coding across the Packer configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this to build and deploy fresh AMIs in my test environment and everything appears to be running successfully.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
