### PR TITLE
Update the security header Lambda's runtime to Node 18

### DIFF
--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -13,15 +13,6 @@ data "aws_acm_certificate" "rules_cert" {
 # An S3 bucket where artifacts for the Lambda@Edge can be stored
 resource "aws_s3_bucket" "lambda_artifact_bucket" {
   bucket_prefix = "cyhy-egress-lambda-at-edge"
-
-  lifecycle {
-    ignore_changes = [
-      # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the backported resources in v3.75 to
-      # avoid conflicts/unexpected apply results.
-      server_side_encryption_configuration,
-    ]
-  }
 }
 
 # Ensure the S3 bucket is encrypted

--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -73,7 +73,7 @@ module "security_header_lambda" {
   description            = "Adds HSTS and other security headers to the response"
   lambda_code_source_dir = "${path.root}/add_security_headers"
   name                   = "add_security_headers"
-  runtime                = "nodejs16.x"
+  runtime                = "nodejs18.x"
   s3_artifact_bucket     = aws_s3_bucket.lambda_artifact_bucket.id
   tags                   = { "Application" = "Egress Publish" }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the security header Lambda's runtime from Node 16 to Node 18.

## 💭 Motivation and context ##

We recently received an email from AWS Lambda stating that they are dropping support for Node 16 in mid-2024.  Now that we are using version 4.9 of the Terraform AWS provider, we can upgrade our Lambda runtime to Node 18.  When we move to the latest version of the Terraform AWS provider, we will be able to upgrade the runtime to at least Node 20.

## 🧪 Testing ##

I tested this in the most brütal fashion - by deploying it to production.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.