### PR TITLE
Fix the rules publication Terraform configuration

### DIFF
--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -69,18 +69,20 @@ module "security_header_lambda" {
   tags                   = { "Application" = "Egress Publish" }
 }
 
-resource "aws_cloudfront_origin_access_identity" "rules_s3_distribution" {
-  comment = var.distribution_oai_comment
+resource "aws_cloudfront_origin_access_control" "rules_s3_distribution" {
+  description = var.distribution_oac_description
+  name        = var.distribution_oac_name
+
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
 }
 
 resource "aws_cloudfront_distribution" "rules_s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.rules_bucket.bucket_regional_domain_name
-    origin_id   = local.s3_origin_id
-
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.rules_s3_distribution.cloudfront_access_identity_path
-    }
+    domain_name              = aws_s3_bucket.rules_bucket.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.rules_s3_distribution.id
+    origin_id                = local.s3_origin_id
   }
 
   enabled             = true

--- a/terraform_egress_pub/cloudfront.tf
+++ b/terraform_egress_pub/cloudfront.tf
@@ -69,10 +69,18 @@ module "security_header_lambda" {
   tags                   = { "Application" = "Egress Publish" }
 }
 
+resource "aws_cloudfront_origin_access_identity" "rules_s3_distribution" {
+  comment = var.distribution_oai_comment
+}
+
 resource "aws_cloudfront_distribution" "rules_s3_distribution" {
   origin {
     domain_name = aws_s3_bucket.rules_bucket.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.rules_s3_distribution.cloudfront_access_identity_path
+    }
   }
 
   enabled             = true

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -37,15 +37,3 @@ resource "aws_s3_bucket_ownership_controls" "rules_bucket" {
     object_ownership = "BucketOwnerEnforced"
   }
 }
-
-resource "aws_s3_bucket_website_configuration" "rules_bucket" {
-  bucket = aws_s3_bucket.rules_bucket.id
-
-  error_document {
-    key = "error.html"
-  }
-
-  index_document {
-    suffix = "all.txt"
-  }
-}

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -43,9 +43,17 @@ data "aws_iam_policy_document" "cloudfront_read_rules_bucket" {
     actions   = ["s3:GetObject"]
     resources = ["${aws_s3_bucket.rules_bucket.arn}/*"]
 
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+
+      values = [
+        aws_cloudfront_distribution.rules_s3_distribution.arn
+      ]
+    }
     principals {
-      identifiers = [aws_cloudfront_origin_access_identity.rules_s3_distribution.iam_arn]
-      type        = "AWS"
+      identifiers = ["cloudfront.amazonaws.com"]
+      type        = "Service"
     }
   }
 
@@ -53,9 +61,18 @@ data "aws_iam_policy_document" "cloudfront_read_rules_bucket" {
     actions   = ["s3:ListBucket"]
     resources = [aws_s3_bucket.rules_bucket.arn]
 
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+
+      values = [
+        aws_cloudfront_distribution.rules_s3_distribution.arn
+      ]
+    }
+
     principals {
-      identifiers = [aws_cloudfront_origin_access_identity.rules_s3_distribution.iam_arn]
-      type        = "AWS"
+      identifiers = ["cloudfront.amazonaws.com"]
+      type        = "Service"
     }
   }
 }

--- a/terraform_egress_pub/s3.tf
+++ b/terraform_egress_pub/s3.tf
@@ -37,3 +37,30 @@ resource "aws_s3_bucket_ownership_controls" "rules_bucket" {
     object_ownership = "BucketOwnerEnforced"
   }
 }
+
+data "aws_iam_policy_document" "cloudfront_read_rules_bucket" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.rules_bucket.arn}/*"]
+
+    principals {
+      identifiers = [aws_cloudfront_origin_access_identity.rules_s3_distribution.iam_arn]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.rules_bucket.arn]
+
+    principals {
+      identifiers = [aws_cloudfront_origin_access_identity.rules_s3_distribution.iam_arn]
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudfront_read_rules_bucket" {
+  bucket = aws_s3_bucket.rules_bucket.id
+  policy = data.aws_iam_policy_document.cloudfront_read_rules_bucket.json
+}

--- a/terraform_egress_pub/scripts/egress_pub.py
+++ b/terraform_egress_pub/scripts/egress_pub.py
@@ -193,10 +193,6 @@ def update_bucket(bucket_name, filename, bucket_contents):
         ContentType="text/plain",
     )
 
-    # by default new objects cannot be read by public
-    # allow public reads of this object
-    b_object.Acl().put(ACL="public-read")
-
 
 def main():
     """Get the list of IPs to publish and upload them to the S3 bucket."""

--- a/terraform_egress_pub/variables.tf
+++ b/terraform_egress_pub/variables.tf
@@ -28,6 +28,12 @@ variable "distribution_domain" {
   type        = string
 }
 
+variable "distribution_oai_comment" {
+  default     = "Allow CloudFront to reach the rules bucket."
+  description = "The comment to apply to the CloudFront Origin Access Identity."
+  type        = string
+}
+
 variable "root_object" {
   default     = "all.txt"
   description = "The root object to serve when no path is provided, or an error occurs."

--- a/terraform_egress_pub/variables.tf
+++ b/terraform_egress_pub/variables.tf
@@ -28,9 +28,15 @@ variable "distribution_domain" {
   type        = string
 }
 
-variable "distribution_oai_comment" {
-  default     = "Allow CloudFront to reach the rules bucket."
-  description = "The comment to apply to the CloudFront Origin Access Identity."
+variable "distribution_oac_description" {
+  default     = "Allow CloudFront to read from the rules bucket."
+  description = "The description to apply to the CloudFront Origin Access Control."
+  type        = string
+}
+
+variable "distribution_oac_name" {
+  default     = "rules-s3-distribution"
+  description = "The name for the CloudFront Origin Access Control."
   type        = string
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the configuration in `terraform_egress_pub/` that publishes the [rules site] listing the IP ranges we publish that are in use for assessments. This includes:
- Removing the S3 static website configuration.
- Adding an OAC ([Origin Access Control]) for the CloudFront distribution.
- Adding a policy to the rules S3 bucket to allow read access from the OAC now associated with the CloudFront distribution.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When #654 was merged I apparently neglected to apply the changes in the `terraform_egress_pub/` configuration. As a result a bug went unnoticed until @jsf9k applied his changes for #738 and suddenly the [rules site] was no longer working. I took a look and realized that the problem was due to the fact that although the bucket was set to use the `private` canned ACL, the script that uploads objects to the bucket would set each uploaded object to use the `public-read` canned ACL. With the addition of a `aws_s3_bucket_public_access_block` for the rules S3 bucket that disallowed _any_ public access it broke access to the objects in the bucket. Adding an OAC and appropriate policy to the bucket allows the CloudFront distribution to access the S3 bucket even if it is completely private.

The static website configuration was removed because
1) The bucket is now completely private.
2) The CloudFront distribution handles the same functionality making it superfluous. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I applied this in production and verified that the [rules site] works once more.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[Origin Access Control]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
[rules site]: https://rules.ncats.cyber.dhs.gov