### PR TITLE
Start orchestrator 12 hours earlier (noon UTC on Friday)

### DIFF
--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -58,15 +58,15 @@
         user: cyhy
         value: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 
-    # This cron job runs at midnight UTC on Saturday mornings, so it
-    # should be done by 2PM on Saturday.
+    # This cron job runs at noon UTC on Friday, so it
+    # should be done by noon UTC on Sunday.
     - name: Create a cron job for BOD 18-01 scanning
       ansible.builtin.cron:
-        hour: '0'
+        hour: '12'
         # TODO: Remove the docker compose down when possible.  See
         # #668 for more details.
         job: cd /var/cyhy/orchestrator && docker compose down && docker compose up --detach 2>&1 | /usr/bin/logger --tag orchestrator
         minute: '0'
         name: "BOD 18-01 scanning"
         user: cyhy
-        weekday: '6'
+        weekday: '5'


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the cron scheduler to start the BOD 18-01 orchestrator 12 hours earlier (noon UTC on Friday, rather than midnight UTC on Saturday).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The overall run time of the BOD 18-01 scanning and report generation has increased a bit over the years.  This change ensures that everything wraps up by Sunday morning when we typically begin CyHy reporting.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

👀 Visual inspection looks good to me!  👀 

> [!NOTE]  
> I already made the equivalent change to the crontab in Production, so there is no need to redeploy after this PR is merged.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
