### PR TITLE
Create CSA region-to-email mapping YAML file for `cisagov/cyhy-mailer`

### DIFF
--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -31,6 +31,14 @@
     owner: cyhy
     src: aws_config.j2
 
+- name: Create the CSA region-to-email mapping YAML file
+  ansible.builtin.file:
+    content: "{{ csa_email_yaml }}"
+    dest: /var/cyhy/cyhy-mailer/secrets/csa_emails.yml
+    group: cyhy
+    mode: 0444
+    owner: cyhy
+
 # The compose command will automatically use docker-compose.yml and
 # docker-compose.override.yml, so this is a way for us to tune
 # compose's behavior to the particular machine.

--- a/ansible/roles/cyhy_mailer/vars/main.yml
+++ b/ansible/roles/cyhy_mailer/vars/main.yml
@@ -5,3 +5,5 @@ reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
 reporter_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
 # reporter mongo database
 reporter_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
+# CSA region-to-email YAML mapping
+csa_email_yaml: "{{ lookup('aws_ssm', '/cyhy/csa_email_yaml') }}"

--- a/ansible/roles/cyhy_mailer/vars/main.yml
+++ b/ansible/roles/cyhy_mailer/vars/main.yml
@@ -1,9 +1,9 @@
 ---
-# reporter mongo username
-reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
-# reporter mongo password
-reporter_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
-# reporter mongo database
-reporter_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
 # CSA region-to-email YAML mapping
 csa_email_yaml: "{{ lookup('aws_ssm', '/cyhy/csa_email_yaml') }}"
+# reporter mongo database
+reporter_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
+# reporter mongo password
+reporter_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
+# reporter mongo username
+reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes the necessary changes to create the CSA region-to-email mapping YAML file now required by [cisagov/cyhy-mailer](https://github.com/cisagov/cyhy-mailer) as of cisagov/cyhy-mailer#101.

Note that I added the appropriate YAML to the SSM Parameter Store variable `/cyhy/csa_email_yaml` to the CyHy AWS account in all four US regions.

## 💭 Motivation and context ##

Partly resolves cisagov/cyhy-system#114.  See also cisagov/cyhy-mailer#101.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
