### PR TITLE
Update Ansible version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,16 @@
 # OS family.  This simplifies a lot of things for roles that support
 # Kali Linux, so it makes sense to force the installation of Ansible
 # 2.10 or newer.
-ansible>=2.10,<6
+#
+# We need at least version 6 to correctly identify Amazon Linux 2023
+# as using the dnf package manager, and version 8 is currently the
+# oldest supported version.
+#
+# We have tested against version 9.  We want to avoid automatically
+# jumping to another major version without testing, since there are
+# often breaking changes across major versions.  This is the reason
+# for the upper bound.
+ansible>=8,<10
 boto3
 setuptools
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,15 @@
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
 ansible>=8,<10
+# TODO: Remove this pin when possible.  See
+# cisagov/skeleton-ansible-role#178 for more details.
+#
+# ansible-core 2.16.3 and later suffer from the bug discussed in
+# ansible/ansible#82702, which breaks any symlinked files in vars,
+# tasks, etc. for any Ansible role installed via ansible-galaxy.
+#
+# See also cisagov/skeleton-packer#312.
+ansible-core<2.16.3
 boto3
 setuptools
 wheel


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the version of [ansible](https://pypi.org/project/ansible) we pin against and adds a version for [ansible-core](https://pypi.org/project/ansible-core).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These changes mirror the changes in https://github.com/cisagov/skeleton-ansible-role/pull/173 and https://github.com/cisagov/skeleton-ansible-role/pull/179 so that any Ansible use in this project is consistent with the roles it uses.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used these versions to redeploy my testing environment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
