### PR TITLE
Remove suffix from the argument to the `sleep` command

### DIFF
--- a/terraform/cyhy_nessus_route53.tf
+++ b/terraform/cyhy_nessus_route53.tf
@@ -24,7 +24,7 @@ resource "null_resource" "cyhy_nessus_pub_PTR" {
   # Set up a corresponding PTR record for the EIP once the A record has been
   # created, then loop until the PTR record creation has been verified.
   provisioner "local-exec" {
-    command = "aws --region ${self.triggers.region} ec2 modify-address-attribute --allocation-id ${self.triggers.eip_allocation_id} --domain-name ${self.triggers.eip_a_record} && until aws --region ${self.triggers.region} ec2 describe-addresses-attribute --allocation-id ${self.triggers.eip_allocation_id} --attribute domain-name | grep PtrRecord | grep --quiet ${self.triggers.eip_a_record}; do sleep 5s; done"
+    command = "aws --region ${self.triggers.region} ec2 modify-address-attribute --allocation-id ${self.triggers.eip_allocation_id} --domain-name ${self.triggers.eip_a_record} && until aws --region ${self.triggers.region} ec2 describe-addresses-attribute --allocation-id ${self.triggers.eip_allocation_id} --attribute domain-name | grep PtrRecord | grep --quiet ${self.triggers.eip_a_record}; do sleep 5; done"
   }
 
   # The PTR records we create for the EIP need to be destroyed at some point,
@@ -32,7 +32,7 @@ resource "null_resource" "cyhy_nessus_pub_PTR" {
   # like a suitable time to do so.
   provisioner "local-exec" {
     when    = destroy
-    command = "aws --region ${self.triggers.region} ec2 reset-address-attribute --allocation-id ${self.triggers.eip_allocation_id} --attribute domain-name && until aws --region ${self.triggers.region} ec2 describe-addresses-attribute --allocation-id ${self.triggers.eip_allocation_id} --attribute domain-name | grep --quiet '\"Addresses\": \\[\\]'; do sleep 5s; done"
+    command = "aws --region ${self.triggers.region} ec2 reset-address-attribute --allocation-id ${self.triggers.eip_allocation_id} --attribute domain-name && until aws --region ${self.triggers.region} ec2 describe-addresses-attribute --allocation-id ${self.triggers.eip_allocation_id} --attribute domain-name | grep --quiet '\"Addresses\": \\[\\]'; do sleep 5; done"
   }
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request removes the suffix indicating the unit of time for the `sleep` command in the two `local-exec` commands used to set up PTR records for vulnscan instances.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The version of `sleep` available on macOS does not support suffixes and only accepts a number of seconds to sleep. This appears to have changed in a recent macOS release as these `local-exec`s ran without issue before. The other possibility is that the Homebrew `coreutils` package was not prefixing the GNU `sleep` command previously and since they currently are it no longer overrides the macOS default. Either way it does not work and so we must rectify that.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I needed this change to successfully deploy my testing environment with no issues.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
