### PR TITLE
Fix incorrect module usage in the `cyhy_mailer` Ansible role

### DIFF
--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -32,7 +32,7 @@
     src: aws_config.j2
 
 - name: Create the CSA region-to-email mapping YAML file
-  ansible.builtin.file:
+  ansible.builtin.copy:
     content: "{{ cyhy_mailer_csa_email_yaml }}"
     dest: /var/cyhy/cyhy-mailer/secrets/csa_emails.yml
     group: cyhy


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request replaces the usage of the [ansible.builtin.file] module with the [ansible.builtin.copy] module in the `cyhy_mailer` Ansible role.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [ansible.builtin.file] module does not support creating a file with contents and Ansible complains about `content` as an invalid argument for the module. Therefore we switch to the [ansible.builtin.copy] module as the appropriate one to create a file with the specified contents. When attempting to redeploy Ansible provisioners in the production CyHy environment I needed this change to successfully run on the `reporter` instance.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I was able to successfully complete a `terraform apply` of the production CyHy environment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[ansible.builtin.copy]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html
[ansible.builtin.file]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html