### PR TITLE
Update Ansible related pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 # jumping to another major version without testing, since there are
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
-ansible>=8,<10
+ansible>=9,<10
 # ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,19 @@
 # jumping to another major version without testing, since there are
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
+#
+# Note that this dependency should be kept in sync with the version
+# pin found in the requirements-test.txt file in
+# cisagov/skeleton-ansible-role.
 ansible>=9,<10
 # ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
 # Hence we never want to install those versions.
+#
+# Note that this dependency should be kept in sync with the version
+# pin found in the requirements-test.txt file in
+# cisagov/skeleton-ansible-role.
 ansible-core>=2.16.7
 boto3
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,15 +13,11 @@
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
 ansible>=8,<10
-# TODO: Remove this pin when possible.  See
-# cisagov/skeleton-ansible-role#178 for more details.
-#
-# ansible-core 2.16.3 and later suffer from the bug discussed in
+# ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
-#
-# See also cisagov/skeleton-packer#312.
-ansible-core<2.16.3
+# Hence we never want to install those versions.
+ansible-core>=2.16.7
 boto3
 setuptools
 wheel


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull requests updates the Ansible related version pins in the `requirements.txt` file. They are updated to reflect the latest pins in the [cisagov/skeleton-ansible-role] project.

> [!NOTE]
> ~~We are not able to fully match the version pin for `ansible-core` as version 2.17 removes support for both Python 2 and Python 3.6 on remote hosts. Since some of the AMIs we are building use Python 2 on the remote host, and the  we must pin under this version. Please see #808 to track resolving this problem.~~
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since we consume our own Ansible roles in this project it makes sense to match Ansible versions that they are developed under.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.

> [!NOTE]
> Once the [cisagov/skeleton-ansible-role] mini-kraken in progress is completed I will test building images and redeploy my testing environment to ensure that things work as expected with these new pins.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/skeleton-ansible-role]: https://github.com/cisagov/skeleton-ansible-role
