### PR TITLE
Change the EC2 instance type for the production CyHy bastion

### DIFF
--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -1,7 +1,7 @@
 # The bastion EC2 instance
 resource "aws_instance" "cyhy_bastion" {
   ami               = data.aws_ami.bastion.id
-  instance_type     = "t3.small"
+  instance_type     = local.production_workspace ? "c5n.large" : "t3.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the public subnet


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the configuration for the CyHy bastion instance to use a `c5n.large` instead of a `t3.small` in production workspaces.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is being done to increase the baseline bandwidth of this instance from 0.128 Gbps to 3 Gbps. We are increasing the baseline bandwidth to hopefully alleviate overloading traffic through the bastion by users connecting to the database and accessing the dashboard. Please see https://github.com/cisagov/cyhy-system/issues/124 for more information.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
