### PR TITLE
Update dependency to the new `cisagov/ansible-role-manage-thp` role

### DIFF
--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -38,12 +38,12 @@ roles:
     src: https://github.com/cisagov/ansible-role-dev-ssh-access
   - name: disable_numa
     src: https://github.com/cisagov/ansible-role-disable-numa
-  - name: disable_thp
-    src: https://github.com/GekoCloud/ansible-role-disable-thp
   - name: geoip2
     src: https://github.com/cisagov/ansible-role-geoip2
   - name: htop
     src: https://github.com/cisagov/ansible-role-htop
+  - name: manage_thp
+    src: https://github.com/cisagov/ansible-role-manage-thp
   - name: mongo
     src: https://github.com/cisagov/ansible-role-mongo
   - name: more_ephemeral_ports


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the Ansible role used to manage transparent hugepage settings from the unmaintained [GekoCloud/ansible-role-disable-thp] to the new [cisagov/ansible-role-manage-thp].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [GekoCloud/ansible-role-disable-thp] role has not seen regular maintenance and has broken with changes to Ansible previously. Now it has conflicts with Ansible-lint and so it made sense to create and use our own equivalent to ensure functionality.

> [!NOTE]
> This is a dependency of [cisagov/ansible-role-mongo] that was changed in https://github.com/cisagov/ansible-role-mongo/pull/25 and is not used directly in this configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this to build and redeploy a database instance in my testing environment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/ansible-role-manage-thp]: https://github.com/cisagov/ansible-role-manage-thp
[cisagov/ansible-role-mongo]: https://github.com/cisagov/ansible-role-mongo
[GekoCloud/ansible-role-disable-thp]: https://github.com/GekoCloud/ansible-role-disable-thp
