### PR TITLE
Stop forcing the use of Python 2 when building AMIs

### DIFF
--- a/packer/ansible/aws.yml
+++ b/packer/ansible/aws.yml
@@ -33,7 +33,7 @@
             state: absent
         - name: Install boto-related Python packages
           ansible.builtin.pip:
-            executable: pip3
+            executable: /usr/bin/pip3
             name:
               - boto3
               - botocore

--- a/packer/dashboard.json
+++ b/packer/dashboard.json
@@ -48,10 +48,6 @@
   ],
   "provisioners": [
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "dashboard"
       ],
@@ -61,10 +57,6 @@
       "use_sftp": true
     },
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "dashboard"
       ],
@@ -76,10 +68,6 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
-      ],
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "cyhy_dashboard"

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -48,10 +48,6 @@
   ],
   "provisioners": [
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "mongo"
       ],
@@ -61,10 +57,6 @@
       "use_sftp": true
     },
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "mongo"
       ],
@@ -76,10 +68,6 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
-      ],
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "cyhy_archive",

--- a/packer/reporter.json
+++ b/packer/reporter.json
@@ -48,10 +48,6 @@
   ],
   "provisioners": [
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "reporter"
       ],
@@ -61,10 +57,6 @@
       "use_sftp": true
     },
     {
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
-      ],
       "groups": [
         "reporter"
       ],
@@ -76,10 +68,6 @@
     {
       "ansible_env_vars": [
         "AWS_DEFAULT_REGION={{user `build_region`}}"
-      ],
-      "extra_arguments": [
-        "--extra-vars",
-        "ansible_python_interpreter=auto_legacy_silent"
       ],
       "groups": [
         "cyhy_reporter"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request removes the use of  `ansible_python_interpreter=auto_legacy_silent` in the provisioners for AMIs that use Python 2. It also updates an Ansible playbook to use the full path for `pip3`. This resolves #808.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The `auto_legacy_silent` for the `ansible_python_interpreter` variable instructs Ansible to use legacy behavior when discovering the Python interpreter on the remote. We used this in the configurations for the `dashboard`, `mongo`, and `reporter` AMI configurations to ensure that Python 2 was used when installing Python packages. Now that Python 2 is unsupported on remotes in `ansible-core` 2.17, and there is [currently broken behavior for remotes in 2.16](https://github.com/ansible/ansible/issues/83812), it makes sense to remove this configuration. Since all of our Ansible roles that install Python 2 packages with `pip` now specify `pip2` in their configuration we can safely make this change in this configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I successfully built all of the AMIs and redeployed them in my testing environment with no observed issues.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
