### PR TITLE
Adjust the `upgrade.yml` Ansible playbook in the Packer configuration

### DIFF
--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -15,3 +15,11 @@
     - name: Set up apt to use HTTPS
       ansible.builtin.include_role:
         name: apt_over_https
+      vars:
+        apt_over_https_apt_source_files:
+          # Legacy SourceList files (pre Debian Bookworm)
+          - /etc/apt/sources.list
+          - /etc/apt/sources.list.d/backports.list
+          # DEB822 SourceList files (Debian Bookworm and later)
+          - /etc/apt/sources.list.d/debian.sources
+          - /etc/apt/sources.list.d/backports.sources

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -1,9 +1,17 @@
 ---
-- name: Set up backports, apt over HTTPS, and upgrade base image
+- name: Upgrade the base image, set up Debian Backports, and configure apt over HTTPS
   hosts: all
   become: yes
   become_method: ansible.builtin.sudo
-  roles:
-    - backports
-    - apt_over_https
-    - upgrade
+  tasks:
+    - name: Upgrade system packages
+      ansible.builtin.include_role:
+        name: upgrade
+
+    - name: Set up Debian Backports repository
+      ansible.builtin.include_role:
+        name: backports
+
+    - name: Set up apt to use HTTPS
+      ansible.builtin.include_role:
+        name: apt_over_https


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request modifies the `upgrade.yml` Ansible playbook used in the Packer configurations in this project. It converts the use of `roles` to a list of `tasks` so that we can more directly reflect what is being done with each role and flexibility in the playbook.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Rather than having to document why the list of `roles` is not in alphabetical order I think it is cleaner to just convert them to `tasks` in the desired order. This also allows us to give a `name` to describe what each role is being used to do and opens up more flexibility to intermingle other tasks.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I built and deployed new AMIs using this change with no issues. I also verified that the backports SourceList is being updated on systems that do not use DEB822 formatted SourceList files (please see https://github.com/cisagov/ansible-role-apt-over-https/issues/25 for why I only checked these files).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
