### PR TITLE
Revert "Create CSA region-to-email mapping YAML file for cyhy-mailer"

### DIFF
--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -31,14 +31,6 @@
     owner: cyhy
     src: aws_config.j2
 
-- name: Create the CSA region-to-email mapping YAML file
-  ansible.builtin.copy:
-    content: "{{ cyhy_mailer_csa_email_yaml }}"
-    dest: /var/cyhy/cyhy-mailer/secrets/csa_emails.yml
-    group: cyhy
-    mode: 0444
-    owner: cyhy
-
 # The compose command will automatically use docker-compose.yml and
 # docker-compose.override.yml, so this is a way for us to tune
 # compose's behavior to the particular machine.

--- a/ansible/roles/cyhy_mailer/vars/main.yml
+++ b/ansible/roles/cyhy_mailer/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-# CSA region-to-email YAML mapping
-cyhy_mailer_csa_email_yaml: "{{ lookup('aws_ssm', '/cyhy/csa_email_yaml') }}"
 # reporter mongo database
 cyhy_mailer_reporter_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
 # reporter mongo password


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR reverts commit 1ca6c51902bdde9ac0e85bf9aacb4024e906116a, which was the primary commit in this PR:
* #749

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This was requested in https://github.com/cisagov/cyhy-system/issues/129, please refer to that issue for more information.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] After https://github.com/cisagov/cyhy-mailer/pull/117 has been deployed, manually delete `/var/cyhy/cyhy-mailer/secrets/csa_emails.yml` from the Production `reporter` instance (or redeploy the entire `reporter` instance, but that seems like overkill here).
