### PR TITLE
Create a databricks user and key with read-only access to the MOE bucket

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -210,6 +210,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_flow_log.bod_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_flow_log.cyhy_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_flow_log.mgmt_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
+| [aws_iam_access_key.databricks_user_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_access_key.moe_user_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_instance_profile.bod_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.bod_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
@@ -270,7 +271,9 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_cyhy_nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_cyhy_nmap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_cyhy_reporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_user.databricks_user_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.moe_user_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy_attachment.moe_bucket_read_policy_attachment_databricks_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.moe_bucket_read_policy_attachment_moe_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_instance.bod_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.bod_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |

--- a/terraform/databricks_user_read.tf
+++ b/terraform/databricks_user_read.tf
@@ -18,6 +18,6 @@ resource "aws_iam_access_key" "databricks_user_read" {
 
 # Attach the MOE S3 bucket read policy
 resource "aws_iam_user_policy_attachment" "moe_bucket_read_policy_attachment_databricks_user" {
-  user       = aws_iam_user.databricks_user_read.name
   policy_arn = aws_iam_policy.moe_bucket_read.arn
+  user       = aws_iam_user.databricks_user_read.name
 }

--- a/terraform/databricks_user_read.tf
+++ b/terraform/databricks_user_read.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_user" "databricks_user_read" {
+  # We name the user databricks-user-read for production workspaces and
+  # databricks-user-read-<workspace_name> for non-production workspaces.
+  #
+  # The reason is that we want to avoid name conflicts when deploying
+  # to test environments but share (via terraform import) the users
+  # when working in production environments.
+  name = local.production_workspace ? "databricks-user-read" : format("databricks-user-read-%s", terraform.workspace)
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_iam_access_key" "databricks_user_read" {
+  user = aws_iam_user.databricks_user_read.name
+}
+
+# Attach the databricks S3 bucket read policy
+resource "aws_iam_user_policy_attachment" "moe_bucket_read_policy_attachment_databricks_user" {
+  user       = aws_iam_user.databricks_user_read.name
+  policy_arn = aws_iam_policy.moe_bucket_read.arn
+}

--- a/terraform/databricks_user_read.tf
+++ b/terraform/databricks_user_read.tf
@@ -16,7 +16,7 @@ resource "aws_iam_access_key" "databricks_user_read" {
   user = aws_iam_user.databricks_user_read.name
 }
 
-# Attach the databricks S3 bucket read policy
+# Attach the MOE S3 bucket read policy
 resource "aws_iam_user_policy_attachment" "moe_bucket_read_policy_attachment_databricks_user" {
   user       = aws_iam_user.databricks_user_read.name
   policy_arn = aws_iam_policy.moe_bucket_read.arn


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR creates a new IAM user and access key with read-only access to the bucket containing the daily CyHy feed data.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This user will be used to ingest CyHy data into Databricks for the current proof-of-concept project.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran `terraform plan` targeted for the resources added in this PR and everything looks correct.

* [x] Run `terraform apply` and confirm that the user and key are created properly

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
