### PR TITLE
Use symbolic permissions in Ansible code

### DIFF
--- a/ansible/roles/code_gov_update/tasks/main.yml
+++ b/ansible/roles/code_gov_update/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Create the secrets directory
   ansible.builtin.file:
     group: cyhy
-    mode: 0755
+    mode: u=rwx,g=rx,o=rx
     owner: cyhy
     path: /var/cyhy/code-gov-update/secrets
     state: directory
@@ -14,7 +14,7 @@
   ansible.builtin.template:
     dest: /var/cyhy/code-gov-update/secrets/scraper.json
     group: cyhy
-    mode: 0440
+    mode: u=r,g=r,o=
     owner: cyhy
     src: scraper.json.j2
 
@@ -22,7 +22,7 @@
   ansible.builtin.template:
     dest: /var/cyhy/code-gov-update/secrets/aws_config
     group: cyhy
-    mode: 0440
+    mode: u=r,g=r,o=
     owner: cyhy
     src: aws_config.j2
 

--- a/ansible/roles/cyhy_archive/tasks/main.yml
+++ b/ansible/roles/cyhy_archive/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Create the /var/lib/mongodb/cyhy_archives directory
   ansible.builtin.file:
     group: cyhy
-    mode: 0755
+    mode: u=rwx,g=rx,o=rx
     owner: cyhy
     path: /var/lib/mongodb/cyhy_archives
     state: directory

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -7,7 +7,7 @@
     content: "{{ cyhy_commander_ssh_private_key }}"
     dest: /var/cyhy/.ssh/id_ed25519
     group: cyhy
-    mode: 0600
+    mode: u=rw,g=,o=
     owner: cyhy
 
 #
@@ -16,7 +16,7 @@
 - name: Create the configuration file for cyhy-commander
   ansible.builtin.template:
     dest: /etc/cyhy/commander.conf
-    mode: 0644
+    mode: u=rw,g=r,o=r
     src: commander.conf.j2
 
 #
@@ -25,7 +25,7 @@
 - name: Create empty ssh config file
   ansible.builtin.file:
     group: cyhy
-    mode: 0644
+    mode: u=rw,g=r,o=r
     owner: cyhy
     path: /var/cyhy/.ssh/config
     state: touch
@@ -41,7 +41,7 @@
 #
 - name: Create the directories needed to import places data
   ansible.builtin.file:
-    mode: 0755
+    mode: u=rwx,g=rx,o=rx
     path: "{{ item }}"
     state: directory
   loop:
@@ -51,19 +51,19 @@
 - name: Download load_places.sh from GitHub
   ansible.builtin.get_url:
     dest: /tmp/cyhy-places/scripts/load_places.sh
-    mode: 0755
+    mode: u=rwx,g=rx,o=rx
     url: "https://raw.githubusercontent.com/cisagov/cyhy-core/develop/var/load_places.sh"
 
 - name: Download GNIS_data_import.py from GitHub
   ansible.builtin.get_url:
     dest: /tmp/cyhy-places/scripts/GNIS_data_import.py
-    mode: 0755
+    mode: u=rwx,g=rx,o=rx
     url: "https://raw.githubusercontent.com/cisagov/cyhy-core/develop/var/GNIS_data_import.py"
 
 - name: Download ADDL_CYHY_PLACES.txt from GitHub
   ansible.builtin.get_url:
     dest: /tmp/cyhy-places/extras/ADDL_CYHY_PLACES.txt
-    mode: 0644
+    mode: u=rw,g=r,o=r
     url: "https://raw.githubusercontent.com/cisagov/cyhy-core/develop/extras/ADDL_CYHY_PLACES.txt"
 
 - name: Check if cyhy.conf already exists
@@ -84,7 +84,7 @@
   ansible.builtin.template:
     dest: /etc/cyhy/cyhy.conf
     group: cyhy
-    mode: 0660
+    mode: u=rw,g=rw,o=
     owner: cyhy
     src: cyhy.conf.j2
   when: not cyhy_commander_cyhy_conf_result.stat.exists

--- a/ansible/roles/cyhy_dashboard/tasks/main.yml
+++ b/ansible/roles/cyhy_dashboard/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Create the /var/cyhy/web directory
   ansible.builtin.file:
     group: cyhy
-    mode: 0750
+    mode: u=rwx,g=rx,o=
     owner: cyhy
     path: /var/cyhy/web
     state: directory
@@ -10,7 +10,7 @@
 - name: Create secret key file for webd
   ansible.builtin.file:
     group: cyhy
-    mode: 0664
+    mode: u=rw,g=rw,o=r
     owner: cyhy
     path: /var/cyhy/web/secret_key
     state: touch
@@ -30,7 +30,7 @@
   ansible.builtin.template:
     dest: /etc/cyhy/cyhy.conf
     group: cyhy
-    mode: 0660
+    mode: u=rw,g=rw,o=
     owner: cyhy
     src: cyhy.conf.j2
 
@@ -43,7 +43,7 @@
 - name: Copy webd service file
   ansible.builtin.copy:
     dest: /etc/systemd/system/ncats-webd.service
-    mode: 0644
+    mode: u=rw,g=r,o=r
     src: ncats-webd.service
 
 - name: Start webd service
@@ -54,7 +54,7 @@
 - name: Copy webui service file
   ansible.builtin.copy:
     dest: /etc/systemd/system/ncats-webui.service
-    mode: 0644
+    mode: u=rw,g=r,o=r
     src: ncats-webui.service
 
 - name: Start webui service

--- a/ansible/roles/cyhy_feeds/tasks/main.yml
+++ b/ansible/roles/cyhy_feeds/tasks/main.yml
@@ -4,7 +4,7 @@
     content: "{{ cyhy_feeds_config }}"
     dest: "/var/cyhy/scripts/cyhy-feeds/cyhy-data-extract.cfg"
     group: cyhy
-    mode: 0444
+    mode: u=r,g=r,o=r
     owner: cyhy
 
 #
@@ -14,7 +14,7 @@
   ansible.builtin.template:
     dest: /var/cyhy/scripts/cyhy-feeds/aws_config
     group: cyhy
-    mode: 0440
+    mode: u=r,g=r,o=
     owner: cyhy
     src: aws_config.j2
 
@@ -26,7 +26,7 @@
   ansible.builtin.template:
     dest: "/var/cyhy/scripts/cyhy-feeds/{{ item.filename }}"
     group: cyhy
-    mode: 0660
+    mode: u=rw,g=rw,o=
     owner: cyhy
     src: mongodb_credentials.yml.j2
   loop:

--- a/ansible/roles/cyhy_mailer/tasks/main.yml
+++ b/ansible/roles/cyhy_mailer/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Create the secrets directory for cyhy-mailer
   ansible.builtin.file:
     group: cyhy
-    mode: 0755
+    mode: u=rwx,g=rx,o=rx
     owner: cyhy
     path: /var/cyhy/cyhy-mailer/secrets
     state: directory
@@ -19,7 +19,7 @@
   ansible.builtin.template:
     dest: /var/cyhy/cyhy-mailer/secrets/database_creds.yml
     group: cyhy
-    mode: 0444
+    mode: u=r,g=r,o=r
     owner: cyhy
     src: database_creds.yml.j2
 
@@ -27,7 +27,7 @@
   ansible.builtin.template:
     dest: /var/cyhy/cyhy-mailer/secrets/aws_config
     group: cyhy
-    mode: 0444
+    mode: u=r,g=r,o=r
     owner: cyhy
     src: aws_config.j2
 
@@ -40,7 +40,7 @@
 - name: Create a symlink for the docker compose override file
   ansible.builtin.file:
     group: cyhy
-    mode: 0664
+    mode: u=rw,g=rw,o=r
     owner: cyhy
     path: /var/cyhy/cyhy-mailer/docker-compose.override.yml
     src: /var/cyhy/cyhy-mailer/{{ cyhy_mailer_docker_compose_override_file_for_mailer }}

--- a/ansible/roles/cyhy_ops/tasks/main.yml
+++ b/ansible/roles/cyhy_ops/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Create the /home/cyhy_ops/.ssh directory
   ansible.builtin.file:
     group: cyhy_ops
-    mode: 0700
+    mode: u=rwx,g=,o=
     owner: cyhy_ops
     path: /home/cyhy_ops/.ssh
     state: directory
@@ -23,7 +23,7 @@
     create: true
     group: cyhy_ops
     line: "{{ lookup('aws_ssm', '/ssh/public_keys/' + item) }}"
-    mode: 0600
+    mode: u=rw,g=,o=
     owner: cyhy_ops
     path: /home/cyhy_ops/.ssh/authorized_keys
   loop: "{{ cyhy_ops_users }}"

--- a/ansible/roles/cyhy_reporter/tasks/main.yml
+++ b/ansible/roles/cyhy_reporter/tasks/main.yml
@@ -6,7 +6,7 @@
   ansible.builtin.template:
     dest: /etc/cyhy/cyhy.conf
     group: cyhy
-    mode: 0660
+    mode: u=rw,g=rw,o=
     owner: cyhy
     src: cyhy.conf.j2
 

--- a/ansible/roles/mgmt_ops/tasks/main.yml
+++ b/ansible/roles/mgmt_ops/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Create the /home/mgmt_ops/.ssh directory
   ansible.builtin.file:
     group: mgmt_ops
-    mode: 0700
+    mode: u=rwx,g=,o=
     owner: mgmt_ops
     path: /home/mgmt_ops/.ssh
     state: directory
@@ -23,7 +23,7 @@
     create: true
     group: mgmt_ops
     line: "{{ lookup('aws_ssm', '/ssh/public_keys/' + item) }}"
-    mode: 0600
+    mode: u=rw,g=,o=
     owner: mgmt_ops
     path: /home/mgmt_ops/.ssh/authorized_keys
   loop: "{{ mgmt_ops_users }}"

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: Copy mongo configuration file
   ansible.builtin.template:
     dest: /etc/mongod.conf
-    mode: 0644
+    mode: u=rw,g=r,o=r
     src: mongod.conf
 
 - name: Restart mongod service to use new configuration

--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -98,20 +98,20 @@
   ansible.builtin.template:
     dest: /etc/cyhy/nessus_api.yml
     group: cyhy
-    mode: 0640
+    mode: u=rw,g=r,o=
     owner: cyhy
     src: nessus_api.yml.j2
 
 - name: Copy the nessus_base.py Python file for configuring Nessus
   ansible.builtin.copy:
     dest: /tmp/nessus_base.py
-    mode: 0644
+    mode: u=rw,g=r,o=r
     src: nessus_base.py
 
 - name: Copy base Nessus scan policy to instance tmp
   ansible.builtin.template:
     dest: /tmp/cyhy-base-nessus8-policy.xml
-    mode: 0644
+    mode: u=rw,g=r,o=r
     src: cyhy-base-nessus8-policy.xml.j2
 
 - name: Wait for Nessus port to be open

--- a/ansible/roles/orchestrator/tasks/main.yml
+++ b/ansible/roles/orchestrator/tasks/main.yml
@@ -6,7 +6,7 @@
   ansible.builtin.file:
     path: /var/cyhy/orchestrator/secrets
     group: cyhy
-    mode: 0755
+    mode: u=rwx,g=rx,o=rx
     owner: cyhy
     state: directory
 
@@ -14,7 +14,7 @@
   ansible.builtin.template:
     dest: "/var/cyhy/orchestrator/secrets/{{ item.filename }}"
     group: cyhy
-    mode: 0440
+    mode: u=r,g=r,o=
     owner: cyhy
     src: mongodb_credentials.yml.j2
   loop:
@@ -41,7 +41,7 @@
   ansible.builtin.template:
     dest: /var/cyhy/orchestrator/secrets/aws_config
     group: cyhy
-    mode: 0440
+    mode: u=r,g=r,o=
     owner: cyhy
     src: aws_config.j2
 

--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Set swapfile permissions
   ansible.builtin.file:
-    mode: 0600
+    mode: u=rw,g=,o=
     path: "{{ swap_swapfile_location }}"
 
 - name: Create swapfile

--- a/packer/ansible/create_credentials_directory.yml
+++ b/packer/ansible/create_credentials_directory.yml
@@ -7,7 +7,7 @@
     - name: Create the /etc/cyhy directory
       ansible.builtin.file:
         group: "{{ cyhy_user_username }}"
-        mode: 0750
+        mode: u=rwx,g=rx,o=
         owner: "{{ cyhy_user_username }}"
         path: /etc/cyhy
         state: directory

--- a/packer/ansible/create_cyhy_user.yml
+++ b/packer/ansible/create_cyhy_user.yml
@@ -16,7 +16,7 @@
 
     - name: Modify permissions on the home directory
       ansible.builtin.file:
-        mode: 0750
+        mode: u=rwx,g=rx,o=
         path: "{{ user_info.home }}"
 
     - name: Add the SSH public key as an authorized key


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request replaces all uses of implicit permission (octal permissions representation) with symbolic permissions.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In addition to being easier to read this will also be required by the linter changes in #856. Since there is nothing stopping us from doing it "in advance" and due to the amount of Ansible code that lives in this repository I thought it would be helpful to break the change out into its own pull request.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that no implicit permissions remain with

```console
$ grep -rnE ': 0[0-7]{3}'
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
