### PR TITLE
Update the `aws_ssm` lookup module reference to a fully qualified collection name

### DIFF
--- a/ansible/roles/code_gov_update/vars/main.yml
+++ b/ansible/roles/code_gov_update/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # The GitHub Personal Access Token
-code_gov_update_github_pat: "{{ lookup('aws_ssm', '/github/pat/code.gov') }}"
+code_gov_update_github_pat: "{{ lookup('amazon.aws.aws_ssm', '/github/pat/code.gov') }}"

--- a/ansible/roles/cyhy_commander/vars/main.yml
+++ b/ansible/roles/cyhy_commander/vars/main.yml
@@ -1,10 +1,10 @@
 ---
 # The CyHy SSH private key
-cyhy_commander_ssh_private_key: "{{ lookup('aws_ssm', '/cyhy/ssh/private_key') }}"
+cyhy_commander_ssh_private_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/ssh/private_key') }}"
 
 # commander mongo username
-cyhy_commander_commander_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/user') }}"
+cyhy_commander_commander_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/user') }}"
 # commander mongo password
-cyhy_commander_commander_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/password') }}"
+cyhy_commander_commander_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/password') }}"
 # commander mongo database
-cyhy_commander_commander_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/database') }}"
+cyhy_commander_commander_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/database') }}"

--- a/ansible/roles/cyhy_dashboard/vars/main.yml
+++ b/ansible/roles/cyhy_dashboard/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # commander mongo username
-cyhy_dashboard_commander_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/user') }}"
+cyhy_dashboard_commander_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/user') }}"
 # commander mongo password
-cyhy_dashboard_commander_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/password') }}"
+cyhy_dashboard_commander_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/password') }}"
 # commander mongo database
-cyhy_dashboard_commander_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/database') }}"
+cyhy_dashboard_commander_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/database') }}"

--- a/ansible/roles/cyhy_feeds/vars/main.yml
+++ b/ansible/roles/cyhy_feeds/vars/main.yml
@@ -1,36 +1,36 @@
 ---
 # cyhy-feeds config
-cyhy_feeds_config: "{{ lookup('aws_ssm', '/cyhy/feeds/config') }}"
+cyhy_feeds_config: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/feeds/config') }}"
 
 # cyhy-feeds public GPG key
-cyhy_feeds_public_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/public') }}"
+cyhy_feeds_public_gpg_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/feeds/gpg/public') }}"
 # cyhy-feeds private GPG key
-cyhy_feeds_private_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/private') }}"
+cyhy_feeds_private_gpg_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/feeds/gpg/private') }}"
 # NSD public GPG key
-cyhy_feeds_nsd_public_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/nsd_public') }}"
+cyhy_feeds_nsd_public_gpg_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/feeds/gpg/nsd_public') }}"
 # NCPS Analytics Environment public GPG key
-cyhy_feeds_ncps_ae_public_gpg_key: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/ncps_ae_public') }}"
+cyhy_feeds_ncps_ae_public_gpg_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/feeds/gpg/ncps_ae_public') }}"
 
 # cyhy-feeds GPG trust
-cyhy_feeds_gpg_trust: "{{ lookup('aws_ssm', '/cyhy/feeds/gpg/trust') }}"
+cyhy_feeds_gpg_trust: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/feeds/gpg/trust') }}"
 
 # reporter mongo username
-cyhy_feeds_reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
+cyhy_feeds_reporter_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
 # reporter mongo password
-cyhy_feeds_reporter_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
+cyhy_feeds_reporter_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
 # reporter mongo database
-cyhy_feeds_reporter_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
+cyhy_feeds_reporter_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
 
 # scan-reader mongo username
-cyhy_feeds_scan_reader_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/user') }}"
+cyhy_feeds_scan_reader_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/user') }}"
 # scan-reader mongo password
-cyhy_feeds_scan_reader_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/password') }}"
+cyhy_feeds_scan_reader_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/password') }}"
 # scan-reader mongo database
-cyhy_feeds_scan_reader_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/database') }}"
+cyhy_feeds_scan_reader_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/database') }}"
 
 # assessment-read mongo username
-cyhy_feeds_assessment_read_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/assessment-read/user') }}"
+cyhy_feeds_assessment_read_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/assessment-read/user') }}"
 # assessment-read mongo password
-cyhy_feeds_assessment_read_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/assessment-read/password') }}"
+cyhy_feeds_assessment_read_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/assessment-read/password') }}"
 # assessment-read mongo database
-cyhy_feeds_assessment_read_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/assessment-read/database') }}"
+cyhy_feeds_assessment_read_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/assessment-read/database') }}"

--- a/ansible/roles/cyhy_mailer/vars/main.yml
+++ b/ansible/roles/cyhy_mailer/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # reporter mongo database
-cyhy_mailer_reporter_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
+cyhy_mailer_reporter_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
 # reporter mongo password
-cyhy_mailer_reporter_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
+cyhy_mailer_reporter_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
 # reporter mongo username
-cyhy_mailer_reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
+cyhy_mailer_reporter_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/user') }}"

--- a/ansible/roles/cyhy_ops/tasks/main.yml
+++ b/ansible/roles/cyhy_ops/tasks/main.yml
@@ -22,7 +22,7 @@
   ansible.builtin.lineinfile:
     create: true
     group: cyhy_ops
-    line: "{{ lookup('aws_ssm', '/ssh/public_keys/' + item) }}"
+    line: "{{ lookup('amazon.aws.aws_ssm', '/ssh/public_keys/' + item) }}"
     mode: u=rw,g=,o=
     owner: cyhy_ops
     path: /home/cyhy_ops/.ssh/authorized_keys

--- a/ansible/roles/cyhy_ops/vars/main.yml
+++ b/ansible/roles/cyhy_ops/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # A list of the CyHy OPS users
-cyhy_ops_users: "{{ lookup('aws_ssm', '/cyhy/ops/users').split(',') }}"
+cyhy_ops_users: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/ops/users').split(',') }}"

--- a/ansible/roles/cyhy_reporter/vars/main.yml
+++ b/ansible/roles/cyhy_reporter/vars/main.yml
@@ -1,20 +1,20 @@
 ---
 # The master key for all reports
-cyhy_reporter_master_report_key: "{{ lookup('aws_ssm', '/cyhy/master_report_key') }}"
+cyhy_reporter_master_report_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/master_report_key') }}"
 
 # commander mongo username
-cyhy_reporter_commander_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/user') }}"
+cyhy_reporter_commander_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/user') }}"
 # commander mongo password
-cyhy_reporter_commander_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/password') }}"
+cyhy_reporter_commander_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/password') }}"
 # commander mongo database
-cyhy_reporter_commander_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/commander/database') }}"
+cyhy_reporter_commander_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/commander/database') }}"
 
 # scan-reader mongo username
-cyhy_reporter_scan_reader_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/user') }}"
+cyhy_reporter_scan_reader_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/user') }}"
 # scan-reader mongo password
-cyhy_reporter_scan_reader_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/password') }}"
+cyhy_reporter_scan_reader_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/password') }}"
 # scan-reader mongo database
-cyhy_reporter_scan_reader_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/database') }}"
+cyhy_reporter_scan_reader_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/database') }}"
 
 # The development users
-cyhy_reporter_dev_users: "{{ lookup('aws_ssm', '/cyhy/dev/users').split(',') }}"
+cyhy_reporter_dev_users: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/dev/users').split(',') }}"

--- a/ansible/roles/groups/vars/main.yml
+++ b/ansible/roles/groups/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # The development users
-groups_dev_users: "{{ lookup('aws_ssm', '/cyhy/dev/users').split(',') }}"
+groups_dev_users: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/dev/users').split(',') }}"

--- a/ansible/roles/mgmt_ops/tasks/main.yml
+++ b/ansible/roles/mgmt_ops/tasks/main.yml
@@ -22,7 +22,7 @@
   ansible.builtin.lineinfile:
     create: true
     group: mgmt_ops
-    line: "{{ lookup('aws_ssm', '/ssh/public_keys/' + item) }}"
+    line: "{{ lookup('amazon.aws.aws_ssm', '/ssh/public_keys/' + item) }}"
     mode: u=rw,g=,o=
     owner: mgmt_ops
     path: /home/mgmt_ops/.ssh/authorized_keys

--- a/ansible/roles/mgmt_ops/vars/main.yml
+++ b/ansible/roles/mgmt_ops/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # A list of the management OPS users
-mgmt_ops_users: "{{ lookup('aws_ssm', '/mgmt/ops/users').split(',') }}"
+mgmt_ops_users: "{{ lookup('amazon.aws.aws_ssm', '/mgmt/ops/users').split(',') }}"

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -41,13 +41,13 @@
 
 - name: Update other users (authenticate as admin)
   community.mongodb.mongodb_user:
-    database: "{{ lookup('aws_ssm', '/cyhy/mongo/users/' + item + '/database') }}"
+    database: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/' + item + '/database') }}"
     login_database: "{{ mongo_admin_db }}"
     login_password: "{{ mongo_admin_pw }}"
     login_user: "{{ mongo_admin_user }}"
-    name: "{{ lookup('aws_ssm', '/cyhy/mongo/users/' + item + '/user') }}"
-    password: "{{ lookup('aws_ssm', '/cyhy/mongo/users/' + item + '/password') }}"
-    roles: "{{ lookup('aws_ssm', '/cyhy/mongo/users/' + item + '/roles').split(',') }}"
+    name: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/' + item + '/user') }}"
+    password: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/' + item + '/password') }}"
+    roles: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/' + item + '/roles').split(',') }}"
     state: present
   # Loop over all the users *except* for admin
   loop: "{{ mongo_non_admin_users }}"

--- a/ansible/roles/mongo/vars/main.yml
+++ b/ansible/roles/mongo/vars/main.yml
@@ -1,14 +1,14 @@
 ---
 # admin mongo username
-mongo_admin_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/admin/user') }}"
+mongo_admin_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/admin/user') }}"
 # Old admin mongo password
-mongo_admin_old_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/admin/old_password') }}"
+mongo_admin_old_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/admin/old_password') }}"
 # admin mongo password
-mongo_admin_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/admin/password') }}"
+mongo_admin_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/admin/password') }}"
 # admin mongo database
-mongo_admin_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/admin/database') }}"
+mongo_admin_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/admin/database') }}"
 # admin mongo roles
-mongo_admin_roles: "{{ lookup('aws_ssm', '/cyhy/mongo/users/admin/roles').split(',') }}"
+mongo_admin_roles: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/admin/roles').split(',') }}"
 
 # Non-admin MongoDB users
-mongo_non_admin_users: "{{ lookup('aws_ssm', '/cyhy/mongo/users', shortnames=false, recursive=true, bypath=true) | dict2items | map(attribute='key') | map('regex_replace', '^/cyhy/mongo/users/([^/]*).*', '\\1') | unique | reject('equalto', 'admin') | list }}"
+mongo_non_admin_users: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users', shortnames=false, recursive=true, bypath=true) | dict2items | map(attribute='key') | map('regex_replace', '^/cyhy/mongo/users/([^/]*).*', '\\1') | unique | reject('equalto', 'admin') | list }}"

--- a/ansible/roles/nessus/vars/main.yml
+++ b/ansible/roles/nessus/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 # The Nessus username
-nessus_username: "{{ lookup('aws_ssm', '/cyhy/nessus/username') }}"
+nessus_username: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/nessus/username') }}"
 # The Nessus password
-nessus_password: "{{ lookup('aws_ssm', '/cyhy/nessus/password') }}"
+nessus_password: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/nessus/password') }}"

--- a/ansible/roles/orchestrator/vars/main.yml
+++ b/ansible/roles/orchestrator/vars/main.yml
@@ -1,21 +1,21 @@
 ---
 # reporter mongo username
-orchestrator_reporter_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
+orchestrator_reporter_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/user') }}"
 # reporter mongo password
-orchestrator_reporter_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
+orchestrator_reporter_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/password') }}"
 # reporter mongo database
-orchestrator_reporter_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
+orchestrator_reporter_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/reporter/database') }}"
 
 # scan-reader mongo username
-orchestrator_scan_reader_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/user') }}"
+orchestrator_scan_reader_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/user') }}"
 # scan-reader mongo password
-orchestrator_scan_reader_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/password') }}"
+orchestrator_scan_reader_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/password') }}"
 # scan-reader mongo database
-orchestrator_scan_reader_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-reader/database') }}"
+orchestrator_scan_reader_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-reader/database') }}"
 
 # scan-writer mongo username
-orchestrator_scan_writer_user: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-writer/user') }}"
+orchestrator_scan_writer_user: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-writer/user') }}"
 # scan-writer mongo password
-orchestrator_scan_writer_pw: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-writer/password') }}"
+orchestrator_scan_writer_pw: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-writer/password') }}"
 # scan-writer mongo database
-orchestrator_scan_writer_db: "{{ lookup('aws_ssm', '/cyhy/mongo/users/scan-writer/database') }}"
+orchestrator_scan_writer_db: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/mongo/users/scan-writer/database') }}"

--- a/packer/ansible/vars/maxmind_information.yml
+++ b/packer/ansible/vars/maxmind_information.yml
@@ -1,5 +1,5 @@
 ---
 # Retrieve the MaxMind GeoIP2 account ID and license key from the AWS SSM
 # Parameter Store
-maxmind_account_id: "{{ lookup('aws_ssm', '/cyhy/core/geoip/account_id') }}"
-maxmind_license_key: "{{ lookup('aws_ssm', '/cyhy/core/geoip/license_key') }}"
+maxmind_account_id: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/core/geoip/account_id') }}"
+maxmind_license_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/core/geoip/license_key') }}"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates any `lookup` calls in Ansible configurations that use the `aws_ssm` module to use the fully qualified collection name (FQCN) instead (`amazon.aws.aws_ssm`).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Ansible has pushed to use FQCNs for a while now to help avoid namespace collisions and better describe what collection provides functionality. This simply carries that over to our use of `lookup`.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. Verified by searching with `grep -rin \'aws_ssm\'` and seeing there were no results. I was able to successfully build a `mongo` AMI and I am assuming that the use of Ansible in our Packer configuration working will mean that the Ansible roles defined in this repository will work.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
