### PR TITLE
Copy README content into the Packer template README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ packer init .
 packer build .
 ```
 
-If building a non-default image (for testing as an example) the prefix for the
+If building a non-default AMI (e.g., for testing), the prefix for the
 created AMI can be changed from the default value of `cyhy` like so:
 
 ```console

--- a/packer/README.md
+++ b/packer/README.md
@@ -36,7 +36,7 @@ or you can build all of the AMIs in the template:
 packer build .
 ```
 
-If building a non-default image (for testing as an example) the prefix for the
+If building a non-default AMI (e.g., for testing), the prefix for the
 created AMI can be changed from the default value of `cyhy` like so:
 
 ```console

--- a/packer/README.md
+++ b/packer/README.md
@@ -14,7 +14,7 @@ The following AMIs are available in this Packer template:
 | nmap | An Nmap scanner for the Cyber Hygiene scanning system (referred to as a `portscanner`). |
 | reporter | Runs the daily notification and weekly report generation using [cisagov/cyhy-reports]. |
 
-## Building ##
+## Building the AMIs ##
 
 Install Ansible requirements and initialize the Packer template:
 
@@ -34,6 +34,19 @@ or you can build all of the AMIs in the template:
 
 ```console
 packer build .
+```
+
+If building a non-default image (for testing as an example) the prefix for the
+created AMI can be changed from the default value of `cyhy` like so:
+
+```console
+packer build -var ami_prefix=testing -only amazon-ebs.bastion .
+```
+
+You can also use a `.pkrvars.hcl` file to set any variables.  For example:
+
+```hcl
+ami_prefix = "testing"
 ```
 
 Also note that


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request simply copies over the mention of using a `.pkrvars.hcl` file and mirrors titles for a section from the main repository README into the Packer template's README.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I was working on another PR and realized there was no mention of passing variables into the template in its README.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
