### PR TITLE
Bake Packer Ansible requirements installation into the template

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -16,11 +16,13 @@ The following AMIs are available in this Packer template:
 
 ## Building the AMIs ##
 
-Install Ansible requirements and initialize the Packer template:
+> [!NOTE]
+> Ansible requirements should be installed automatically when you build an image.
+
+Initialize the Packer template:
 
 ```console
 cd packer
-ansible-galaxy install --role-file ansible/requirements.yml
 packer init .
 ```
 
@@ -49,16 +51,12 @@ You can also use a `.pkrvars.hcl` file to set any variables.  For example:
 ami_prefix = "testing"
 ```
 
-Also note that
-
-```console
-ansible-galaxy install --force --role-file ansible/requirements.yml
-```
-
-will update the roles that are being pulled from external sources.  This
-may be required, for example, if a role that is being pulled from a
-GitHub repository has been updated and you want the new changes.  By
-default `ansible-galaxy install` *will not* upgrade roles.
+Also note that if you need to update the Ansible roles that are used by the
+Packer template, you can adjust the `force_install_ansible_requirements` and
+`force_install_ansible_requirements_with_dependencies` variables in the same
+manner as the `ami_prefix` variable above. This may be required, for example,
+if a role that is being pulled from a GitHub repository has been updated and
+you want the new changes. This will not occur by default when you build an AMI.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/packer/README.md
+++ b/packer/README.md
@@ -89,6 +89,8 @@ No modules.
 | ami\_prefix | The prefix to use for the names of AMIs created. | `string` | `"cyhy"` | no |
 | ami\_regions | The list of AWS regions to copy the AMI to once it has been created. Example: ["us-east-1"] | `list(string)` | ```[ "us-east-1", "us-west-1", "us-west-2" ]``` | no |
 | build\_region | The region in which to retrieve the base AMI from and build the new AMI. | `string` | `"us-east-2"` | no |
+| force\_install\_ansible\_requirements | Indicate if the Ansible requirements should be force installed. | `bool` | `false` | no |
+| force\_install\_ansible\_requirements\_with\_dependencies | Indicate if the Ansible requirements *and* their dependencies should be force installed. | `bool` | `false` | no |
 | is\_prerelease | The pre-release status to use for the tags applied to the created AMI. | `bool` | `false` | no |
 
 ## Outputs ##

--- a/packer/bastion.pkr.hcl
+++ b/packer/bastion.pkr.hcl
@@ -35,11 +35,13 @@ build {
   sources = ["source.amazon-ebs.bastion"]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    groups        = ["bastion"]
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["bastion"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/packer/bastion.pkr.hcl
+++ b/packer/bastion.pkr.hcl
@@ -35,6 +35,7 @@ build {
   sources = ["source.amazon-ebs.bastion"]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     groups        = ["bastion"]
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false

--- a/packer/dashboard.pkr.hcl
+++ b/packer/dashboard.pkr.hcl
@@ -35,6 +35,7 @@ build {
   sources = ["source.amazon-ebs.dashboard"]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     groups        = ["dashboard"]
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false

--- a/packer/dashboard.pkr.hcl
+++ b/packer/dashboard.pkr.hcl
@@ -35,11 +35,13 @@ build {
   sources = ["source.amazon-ebs.dashboard"]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    groups        = ["dashboard"]
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["dashboard"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/packer/docker.pkr.hcl
+++ b/packer/docker.pkr.hcl
@@ -35,6 +35,7 @@ build {
   sources = ["source.amazon-ebs.docker"]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     groups        = ["docker"]
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false

--- a/packer/docker.pkr.hcl
+++ b/packer/docker.pkr.hcl
@@ -35,11 +35,13 @@ build {
   sources = ["source.amazon-ebs.docker"]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    groups        = ["docker"]
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["docker"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/packer/mongo.pkr.hcl
+++ b/packer/mongo.pkr.hcl
@@ -35,6 +35,7 @@ build {
   sources = ["source.amazon-ebs.mongo"]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     groups        = ["mongo"]
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false

--- a/packer/mongo.pkr.hcl
+++ b/packer/mongo.pkr.hcl
@@ -35,11 +35,13 @@ build {
   sources = ["source.amazon-ebs.mongo"]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    groups        = ["mongo"]
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["mongo"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/packer/nessus.pkr.hcl
+++ b/packer/nessus.pkr.hcl
@@ -35,11 +35,13 @@ build {
   sources = ["source.amazon-ebs.nessus"]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    groups        = ["nessus"]
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["nessus"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/packer/nessus.pkr.hcl
+++ b/packer/nessus.pkr.hcl
@@ -35,6 +35,7 @@ build {
   sources = ["source.amazon-ebs.nessus"]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     groups        = ["nessus"]
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false

--- a/packer/nmap.pkr.hcl
+++ b/packer/nmap.pkr.hcl
@@ -35,6 +35,7 @@ build {
   sources = ["source.amazon-ebs.nmap"]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     groups        = ["nmap"]
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false

--- a/packer/nmap.pkr.hcl
+++ b/packer/nmap.pkr.hcl
@@ -35,11 +35,13 @@ build {
   sources = ["source.amazon-ebs.nmap"]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    groups        = ["nmap"]
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["nmap"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/packer/reporter.pkr.hcl
+++ b/packer/reporter.pkr.hcl
@@ -35,11 +35,13 @@ build {
   sources = ["source.amazon-ebs.reporter"]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    groups        = ["reporter"]
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["reporter"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/packer/reporter.pkr.hcl
+++ b/packer/reporter.pkr.hcl
@@ -35,6 +35,7 @@ build {
   sources = ["source.amazon-ebs.reporter"]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     groups        = ["reporter"]
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -31,6 +31,18 @@ variable "build_region" {
   type        = string
 }
 
+variable "force_install_ansible_requirements" {
+  default     = false
+  description = "Indicate if the Ansible requirements should be force installed."
+  type        = bool
+}
+
+variable "force_install_ansible_requirements_with_dependencies" {
+  default     = false
+  description = "Indicate if the Ansible requirements *and* their dependencies should be force installed."
+  type        = bool
+}
+
 variable "is_prerelease" {
   default     = false
   description = "The pre-release status to use for the tags applied to the created AMI."


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull requests adjusts the Packer template to automatically install Ansible requirements when you try to build any of the AMIs. This mirrors what was added to our standalone Packer projects in https://github.com/cisagov/skeleton-packer/pull/428.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Not only is it good to mirror functionality from our standalone Packer projects but it will help ensure these requirements are installed before building any AMIs. This is especially important because we do not have an automated build process in place for the AMIs defined in the Packer template contained in this project.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified when I built a `bastion` image that the Ansible requirement installation step occurred.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
