### PR TITLE
Add an ARM64 build configuration for the `bastion` AMI

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -77,7 +77,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [amazon-ami_amazon-ami.debian_bookworm](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
+| [amazon-ami_amazon-ami.debian_bookworm_arm64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
+| [amazon-ami_amazon-ami.debian_bookworm_x86_64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
 | [amazon-ami_amazon-ami.debian_buster](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
 
 ## Inputs ##

--- a/packer/README.md
+++ b/packer/README.md
@@ -6,7 +6,7 @@ The following AMIs are available in this Packer template:
 
 | AMI name | Description |
 | ------------- | ----------- |
-| bastion | Provides a jump box to a private VPC. |
+| bastion | Provides a jump box to a private VPC. This is available in both arm64 and x86_64 versions.|
 | dashboard | The Cyber Hygiene dashboard application. |
 | docker | Runs Docker configurations to perform BOD 18-01 and 20-01 scanning as well as generate the DHS [code.gov](https://code.gov) inventory. |
 | mongo | Provides the MongoDB database used by the Cyber Hygiene scanning system as well as running [cisagov/cyhy-commander]. |
@@ -27,6 +27,11 @@ packer init .
 ```
 
 Once that is completed you can build a specific AMI:
+
+> [!NOTE]
+> If you are building an AMI that is available for more than one architecture
+> (e.g., `bastion`), you must append the architecture if building a specific
+> AMI (e.g., `bastion_arm64`).
 
 ```console
 packer build -only amazon-ebs.<target AMI> .

--- a/packer/base_images.pkr.hcl
+++ b/packer/base_images.pkr.hcl
@@ -9,7 +9,18 @@ data "amazon-ami" "debian_buster" {
   region      = var.build_region
 }
 
-data "amazon-ami" "debian_bookworm" {
+data "amazon-ami" "debian_bookworm_arm64" {
+  filters = {
+    name                = "debian-12-arm64-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["136693071363"]
+  region      = var.build_region
+}
+
+data "amazon-ami" "debian_bookworm_x86_64" {
   filters = {
     name                = "debian-12-amd64-*"
     root-device-type    = "ebs"

--- a/packer/bastion.pkr.hcl
+++ b/packer/bastion.pkr.hcl
@@ -17,12 +17,12 @@ source "amazon-ebs" "bastion" {
     volume_type           = "gp3"
   }
   region       = var.build_region
-  source_ami   = data.amazon-ami.debian_bookworm.id
+  source_ami   = data.amazon-ami.debian_bookworm_x86_64.id
   ssh_username = "admin"
   tags = {
     Application   = "Cyber Hygiene"
     Architecture  = "x86_64"
-    Base_AMI_Name = data.amazon-ami.debian_bookworm.name
+    Base_AMI_Name = data.amazon-ami.debian_bookworm_x86_64.name
     OS_Version    = "Debian Bookworm"
     Pre_Release   = var.is_prerelease
     Release       = "Latest"

--- a/packer/bastion_arm64.pkr.hcl
+++ b/packer/bastion_arm64.pkr.hcl
@@ -1,0 +1,32 @@
+source "amazon-ebs" "bastion_arm64" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = true
+    volume_size           = 8
+    volume_type           = "gp3"
+  }
+  ami_name      = "${var.ami_prefix}-bastion-hvm-${local.timestamp}-arm64-ebs"
+  ami_regions   = var.ami_regions
+  instance_type = "t4g.small"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = true
+    volume_size           = 8
+    volume_type           = "gp3"
+  }
+  region       = var.build_region
+  source_ami   = data.amazon-ami.debian_bookworm_arm64.id
+  ssh_username = "admin"
+  tags = {
+    Application   = "Cyber Hygiene"
+    Architecture  = "arm64"
+    Base_AMI_Name = data.amazon-ami.debian_bookworm_arm64.name
+    OS_Version    = "Debian Bookworm"
+    Pre_Release   = var.is_prerelease
+    Release       = "Latest"
+    Team          = "VM Fusion - Development"
+  }
+  temporary_key_pair_type = "ed25519"
+}

--- a/packer/bastion_build.pkr.hcl
+++ b/packer/bastion_build.pkr.hcl
@@ -1,0 +1,31 @@
+build {
+  sources = [
+    "source.amazon-ebs.bastion_arm64",
+    "source.amazon-ebs.bastion_x86_64",
+  ]
+
+  provisioner "ansible" {
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    groups                 = ["bastion"]
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
+  }
+
+  provisioner "ansible" {
+    groups        = ["bastion"]
+    playbook_file = "ansible/python.yml"
+    use_proxy     = false
+    use_sftp      = true
+  }
+
+  provisioner "ansible" {
+    ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
+    groups           = ["bastion"]
+    playbook_file    = "ansible/playbook.yml"
+    use_proxy        = false
+    use_sftp         = true
+  }
+}

--- a/packer/bastion_x86_64.pkr.hcl
+++ b/packer/bastion_x86_64.pkr.hcl
@@ -1,4 +1,4 @@
-source "amazon-ebs" "bastion" {
+source "amazon-ebs" "bastion_x86_64" {
   ami_block_device_mappings {
     delete_on_termination = true
     device_name           = "/dev/xvda"
@@ -29,33 +29,4 @@ source "amazon-ebs" "bastion" {
     Team          = "VM Fusion - Development"
   }
   temporary_key_pair_type = "ed25519"
-}
-
-build {
-  sources = ["source.amazon-ebs.bastion"]
-
-  provisioner "ansible" {
-    galaxy_file            = "ansible/requirements.yml"
-    galaxy_force_install   = var.force_install_ansible_requirements
-    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
-    groups                 = ["bastion"]
-    playbook_file          = "ansible/upgrade.yml"
-    use_proxy              = false
-    use_sftp               = true
-  }
-
-  provisioner "ansible" {
-    groups        = ["bastion"]
-    playbook_file = "ansible/python.yml"
-    use_proxy     = false
-    use_sftp      = true
-  }
-
-  provisioner "ansible" {
-    ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
-    groups           = ["bastion"]
-    playbook_file    = "ansible/playbook.yml"
-    use_proxy        = false
-    use_sftp         = true
-  }
 }

--- a/packer/docker.pkr.hcl
+++ b/packer/docker.pkr.hcl
@@ -17,12 +17,12 @@ source "amazon-ebs" "docker" {
     volume_type           = "gp3"
   }
   region       = var.build_region
-  source_ami   = data.amazon-ami.debian_bookworm.id
+  source_ami   = data.amazon-ami.debian_bookworm_x86_64.id
   ssh_username = "admin"
   tags = {
     Application   = "Cyber Hygiene"
     Architecture  = "x86_64"
-    Base_AMI_Name = data.amazon-ami.debian_bookworm.name
+    Base_AMI_Name = data.amazon-ami.debian_bookworm_x86_64.name
     OS_Version    = "Debian Bookworm"
     Pre_Release   = var.is_prerelease
     Release       = "Latest"

--- a/packer/nessus.pkr.hcl
+++ b/packer/nessus.pkr.hcl
@@ -17,12 +17,12 @@ source "amazon-ebs" "nessus" {
     volume_type           = "gp3"
   }
   region       = var.build_region
-  source_ami   = data.amazon-ami.debian_bookworm.id
+  source_ami   = data.amazon-ami.debian_bookworm_x86_64.id
   ssh_username = "admin"
   tags = {
     Application   = "Cyber Hygiene"
     Architecture  = "x86_64"
-    Base_AMI_Name = data.amazon-ami.debian_bookworm.name
+    Base_AMI_Name = data.amazon-ami.debian_bookworm_x86_64.name
     OS_Version    = "Debian Bookworm"
     Pre_Release   = var.is_prerelease
     Release       = "Latest"

--- a/packer/nmap.pkr.hcl
+++ b/packer/nmap.pkr.hcl
@@ -17,12 +17,12 @@ source "amazon-ebs" "nmap" {
     volume_type           = "gp3"
   }
   region       = var.build_region
-  source_ami   = data.amazon-ami.debian_bookworm.id
+  source_ami   = data.amazon-ami.debian_bookworm_x86_64.id
   ssh_username = "admin"
   tags = {
     Application   = "Cyber Hygiene"
     Architecture  = "x86_64"
-    Base_AMI_Name = data.amazon-ami.debian_bookworm.name
+    Base_AMI_Name = data.amazon-ami.debian_bookworm_x86_64.name
     OS_Version    = "Debian Bookworm"
     Pre_Release   = var.is_prerelease
     Release       = "Latest"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Packer template to add a build configuration to create an ARM64 version of the `bastion` AMI in addition to the existing AMD64 version.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We would like to move to using Graviton (ARM64) instances where it makes sense and the `bastion` instance is the most straightforward target. This gets the process started by producing an ARM64 AMI for testing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified I could successfully build the ARM64 AMI.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
