### PR TITLE
Point to the Packer template README in the repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,38 +5,8 @@
 
 ## Building the AMIs ##
 
-The AMIs are built like so:
-
-```console
-cd packer
-ansible-galaxy install --role-file ansible/requirements.yml
-packer init .
-packer build .
-```
-
-If building a non-default AMI (e.g., for testing), the prefix for the
-created AMI can be changed from the default value of `cyhy` like so:
-
-```console
-packer build -var ami_prefix=testing -only amazon-ebs.bastion .
-```
-
-You can also use a `.pkrvars.hcl` file to set any variables.  For example:
-
-```hcl
-ami_prefix = "testing"
-```
-
-Also note that
-
-```console
-ansible-galaxy install --force --role-file ansible/requirements.yml
-```
-
-will update the roles that are being pulled from external sources.  This
-may be required, for example, if a role that is being pulled from a
-GitHub repository has been updated and you want the new changes.  By
-default `ansible-galaxy install` *will not* upgrade roles.
+Instructions for building the AMIs defined in this project can be found in the
+[Packer template's README](packer/README.md).
 
 ## Building the Terraform-based infrastructure ##
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `Building the AMIs` section of the repository README to instead direct users to the Packer template's README for directions.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Instead of duplicating instructions for how to build the AMIs defined in this project it makes sense to point to a single source of information. This was motivated because I neglected to update the repository README in #863.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified the link worked.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
