### PR TITLE
Add an ARM64 build configuration for the `nmap` AMI

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -11,7 +11,7 @@ The following AMIs are available in this Packer template:
 | docker | Runs Docker configurations to perform BOD 18-01 and 20-01 scanning as well as generate the DHS [code.gov](https://code.gov) inventory. | ✔ | ❌ |
 | mongo | Provides the MongoDB database used by the Cyber Hygiene scanning system as well as running [cisagov/cyhy-commander]. | ✔ | ❌ |
 | nessus | A Nessus scanner for the Cyber Hygiene scanning system (referred to as a `vulnscanner`). | ✔ | ❌ |
-| nmap | An Nmap scanner for the Cyber Hygiene scanning system (referred to as a `portscanner`). | ✔ | ❌ |
+| nmap | An Nmap scanner for the Cyber Hygiene scanning system (referred to as a `portscanner`). | ✔ | ✔ |
 | reporter | Runs the daily notification and weekly report generation using [cisagov/cyhy-reports]. | ✔ | ❌ |
 
 ## Building the AMIs ##

--- a/packer/nmap_ami_arm64.pkr.hcl
+++ b/packer/nmap_ami_arm64.pkr.hcl
@@ -1,0 +1,32 @@
+source "amazon-ebs" "nmap_arm64" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = true
+    volume_size           = 8
+    volume_type           = "gp3"
+  }
+  ami_name      = "${var.ami_prefix}-nmap-hvm-${local.timestamp}-arm64-ebs"
+  ami_regions   = var.ami_regions
+  instance_type = "t4g.small"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = true
+    volume_size           = 8
+    volume_type           = "gp3"
+  }
+  region       = var.build_region
+  source_ami   = data.amazon-ami.debian_bookworm_arm64.id
+  ssh_username = "admin"
+  tags = {
+    Application   = "Cyber Hygiene"
+    Architecture  = "arm64"
+    Base_AMI_Name = data.amazon-ami.debian_bookworm_arm64.name
+    OS_Version    = "Debian Bookworm"
+    Pre_Release   = var.is_prerelease
+    Release       = "Latest"
+    Team          = "VM Fusion - Development"
+  }
+  temporary_key_pair_type = "ed25519"
+}

--- a/packer/nmap_build.pkr.hcl
+++ b/packer/nmap_build.pkr.hcl
@@ -1,5 +1,8 @@
 build {
-  sources = ["source.amazon-ebs.nmap_x86_64"]
+  sources = [
+    "source.amazon-ebs.nmap_arm64",
+    "source.amazon-ebs.nmap_x86_64",
+  ]
 
   provisioner "ansible" {
     galaxy_file            = "ansible/requirements.yml"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Packer template to add a build configuration to create an ARM64 version of the `nmap` AMI in addition to the existing AMD64 version.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As mentioned in #864 we would like to move to using Graviton (ARM64) instances where it makes sense. The `nmap` instance is another straightforward target. This gets the process started by producing an ARM64 AMI for testing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified I could successfully build the ARM64 AMI.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
