### PR TITLE
Move SSM Parameter Store lookups out of the Packer Ansible configuration

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -88,6 +88,7 @@ No modules.
 | ami\_prefix | The prefix to use for the names of AMIs created. | `string` | `"cyhy"` | no |
 | ami\_regions | The list of AWS regions to copy the AMI to once it has been created. Example: ["us-east-1"] | `list(string)` | ```[ "us-east-1", "us-west-1", "us-west-2" ]``` | no |
 | build\_region | The region in which to retrieve the base AMI from and build the new AMI. | `string` | `"us-east-2"` | no |
+| cyhy\_user\_information | The user information for the Cyber Hygiene user. | ```object({ home_directory = string ssh_public_key = string user_id = string username = string })``` | ```{ "home_directory": "/var/cyhy", "ssh_public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy", "user_id": "2048", "username": "cyhy" }``` | no |
 | force\_install\_ansible\_requirements | Indicate if the Ansible requirements should be force installed. | `bool` | `false` | no |
 | force\_install\_ansible\_requirements\_with\_dependencies | Indicate if the Ansible requirements *and* their dependencies should be force installed. | `bool` | `false` | no |
 | is\_prerelease | The pre-release status to use for the tags applied to the created AMI. | `bool` | `false` | no |

--- a/packer/README.md
+++ b/packer/README.md
@@ -68,6 +68,7 @@ No requirements.
 | Name | Version |
 |------|---------|
 | amazon-ami | n/a |
+| amazon-parameterstore | n/a |
 
 ## Modules ##
 
@@ -80,6 +81,8 @@ No modules.
 | [amazon-ami_amazon-ami.debian_bookworm_arm64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
 | [amazon-ami_amazon-ami.debian_bookworm_x86_64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
 | [amazon-ami_amazon-ami.debian_buster_x86_64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
+| [amazon-parameterstore_amazon-parameterstore.maxmind_account_id](https://registry.terraform.io/providers/hashicorp/amazon-parameterstore/latest/docs/data-sources/amazon-parameterstore) | data source |
+| [amazon-parameterstore_amazon-parameterstore.maxmind_license_key](https://registry.terraform.io/providers/hashicorp/amazon-parameterstore/latest/docs/data-sources/amazon-parameterstore) | data source |
 
 ## Inputs ##
 
@@ -92,6 +95,7 @@ No modules.
 | force\_install\_ansible\_requirements | Indicate if the Ansible requirements should be force installed. | `bool` | `false` | no |
 | force\_install\_ansible\_requirements\_with\_dependencies | Indicate if the Ansible requirements *and* their dependencies should be force installed. | `bool` | `false` | no |
 | is\_prerelease | The pre-release status to use for the tags applied to the created AMI. | `bool` | `false` | no |
+| maxmind\_ssm\_parameter\_names | The SSM parameter store names that contain the MaxMind account ID and license key. | ```object({ account_id = string license_key = string })``` | ```{ "account_id": "/cyhy/core/geoip/account_id", "license_key": "/cyhy/core/geoip/license_key" }``` | no |
 
 ## Outputs ##
 

--- a/packer/ansible/create_credentials_directory.yml
+++ b/packer/ansible/create_credentials_directory.yml
@@ -11,5 +11,3 @@
         owner: "{{ cyhy_user_username }}"
         path: /etc/cyhy
         state: directory
-  vars_files:
-    - vars/cyhy_user.yml

--- a/packer/ansible/create_cyhy_user.yml
+++ b/packer/ansible/create_cyhy_user.yml
@@ -21,7 +21,5 @@
 
     - name: Add the SSH public key as an authorized key
       ansible.posix.authorized_key:
-        key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy
+        key: "{{ cyhy_user_ssh_public_key }}"
         user: "{{ cyhy_user_username }}"
-  vars_files:
-    - vars/cyhy_user.yml

--- a/packer/ansible/cyhy_archive.yml
+++ b/packer/ansible/cyhy_archive.yml
@@ -8,5 +8,3 @@
       vars:
         cyhy_archive_maxmind_account_id: "{{ maxmind_account_id }}"
         cyhy_archive_maxmind_license_key: "{{ maxmind_license_key }}"
-  vars_files:
-    - vars/maxmind_information.yml

--- a/packer/ansible/cyhy_archive.yml
+++ b/packer/ansible/cyhy_archive.yml
@@ -6,5 +6,5 @@
   roles:
     - role: cyhy_archive
       vars:
-        cyhy_archive_maxmind_account_id: "{{ maxmind_account_id }}"
-        cyhy_archive_maxmind_license_key: "{{ maxmind_license_key }}"
+        cyhy_archive_maxmind_account_id: "{{ maxmind_account_id_secret }}"
+        cyhy_archive_maxmind_license_key: "{{ maxmind_license_key_secret }}"

--- a/packer/ansible/cyhy_commander.yml
+++ b/packer/ansible/cyhy_commander.yml
@@ -7,5 +7,5 @@
     - role: cyhy_commander
       vars:
         cyhy_commander_install_geoipupdate: true
-        cyhy_commander_maxmind_account_id: "{{ maxmind_account_id }}"
-        cyhy_commander_maxmind_license_key: "{{ maxmind_license_key }}"
+        cyhy_commander_maxmind_account_id: "{{ maxmind_account_id_secret }}"
+        cyhy_commander_maxmind_license_key: "{{ maxmind_license_key_secret }}"

--- a/packer/ansible/cyhy_commander.yml
+++ b/packer/ansible/cyhy_commander.yml
@@ -9,5 +9,3 @@
         cyhy_commander_install_geoipupdate: true
         cyhy_commander_maxmind_account_id: "{{ maxmind_account_id }}"
         cyhy_commander_maxmind_license_key: "{{ maxmind_license_key }}"
-  vars_files:
-    - vars/maxmind_information.yml

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -6,6 +6,6 @@
   roles:
     - role: ncats_webd
       vars:
-        ncats_webd_maxmind_account_id: "{{ maxmind_account_id }}"
-        ncats_webd_maxmind_license_key: "{{ maxmind_license_key }}"
+        ncats_webd_maxmind_account_id: "{{ maxmind_account_id_secret }}"
+        ncats_webd_maxmind_license_key: "{{ maxmind_license_key_secret }}"
     - ncats_webui

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -9,5 +9,3 @@
         ncats_webd_maxmind_account_id: "{{ maxmind_account_id }}"
         ncats_webd_maxmind_license_key: "{{ maxmind_license_key }}"
     - ncats_webui
-  vars_files:
-    - vars/maxmind_information.yml

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -12,5 +12,3 @@
         cyhy_reports_texmf_buffer_size: 100000000
         cyhy_reports_texmf_main_memory: 10000000
     - cyhy_mailer
-  vars_files:
-    - vars/maxmind_information.yml

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -7,8 +7,8 @@
     - xfs
     - role: cyhy_reports
       vars:
-        cyhy_reports_maxmind_account_id: "{{ maxmind_account_id }}"
-        cyhy_reports_maxmind_license_key: "{{ maxmind_license_key }}"
+        cyhy_reports_maxmind_account_id: "{{ maxmind_account_id_secret }}"
+        cyhy_reports_maxmind_license_key: "{{ maxmind_license_key_secret }}"
         cyhy_reports_texmf_buffer_size: 100000000
         cyhy_reports_texmf_main_memory: 10000000
     - cyhy_mailer

--- a/packer/ansible/vars/cyhy_user.yml
+++ b/packer/ansible/vars/cyhy_user.yml
@@ -1,5 +1,0 @@
----
-# CyHy user information
-cyhy_user_home_directory: /var/cyhy
-cyhy_user_uid: 2048
-cyhy_user_username: cyhy

--- a/packer/ansible/vars/maxmind_information.yml
+++ b/packer/ansible/vars/maxmind_information.yml
@@ -1,5 +1,0 @@
----
-# Retrieve the MaxMind GeoIP2 account ID and license key from the AWS SSM
-# Parameter Store
-maxmind_account_id: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/core/geoip/account_id') }}"
-maxmind_license_key: "{{ lookup('amazon.aws.aws_ssm', '/cyhy/core/geoip/license_key') }}"

--- a/packer/dashboard_build.pkr.hcl
+++ b/packer/dashboard_build.pkr.hcl
@@ -29,8 +29,8 @@ build {
       format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
       "cyhy_user_username=${var.cyhy_user_information.username}",
       "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-      "maxmind_account_id=${data.amazon-parameterstore.maxmind_account_id.value}",
-      "maxmind_license_key=${data.amazon-parameterstore.maxmind_license_key.value}",
+      "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
+      "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
     ]))
     groups        = ["cyhy_dashboard"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/dashboard_build.pkr.hcl
+++ b/packer/dashboard_build.pkr.hcl
@@ -22,7 +22,13 @@ build {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     # Create the list of variables to pass to Ansible. We create a list of
     # arguments with preceding `--extra-vars` and then flatten it to ensure
-    # that it is a single list of arguments.
+    # that it is a single list of arguments. This will result in a list like:
+    # [
+    #   "--extra-vars",
+    #   "foo=bar",
+    #   "--extra-vars",
+    #   "ham=eggs",
+    # ]
     extra_arguments = flatten(setproduct(["--extra-vars"], [
       "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
       # Since the SSH public key has spaces in it, we need to ensure it is quoted.

--- a/packer/dashboard_build.pkr.hcl
+++ b/packer/dashboard_build.pkr.hcl
@@ -29,6 +29,8 @@ build {
       format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
       "cyhy_user_username=${var.cyhy_user_information.username}",
       "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+      "maxmind_account_id=${data.amazon-parameterstore.maxmind_account_id.value}",
+      "maxmind_license_key=${data.amazon-parameterstore.maxmind_license_key.value}",
     ]))
     groups        = ["cyhy_dashboard"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/dashboard_build.pkr.hcl
+++ b/packer/dashboard_build.pkr.hcl
@@ -29,15 +29,10 @@ build {
     #   "--extra-vars",
     #   "ham=eggs",
     # ]
-    extra_arguments = flatten(setproduct(["--extra-vars"], [
-      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
-      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
-      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
-      "cyhy_user_username=${var.cyhy_user_information.username}",
-      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-      "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
-      "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
-    ]))
+    extra_arguments = flatten(setproduct(["--extra-vars"], concat(
+      local.cyhy_user_ansible_variables,
+      local.maxmind_account_ansible_variables,
+    )))
     groups        = ["cyhy_dashboard"]
     playbook_file = "ansible/playbook.yml"
     use_proxy     = false

--- a/packer/dashboard_build.pkr.hcl
+++ b/packer/dashboard_build.pkr.hcl
@@ -20,9 +20,19 @@ build {
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
-    groups           = ["cyhy_dashboard"]
-    playbook_file    = "ansible/playbook.yml"
-    use_proxy        = false
-    use_sftp         = true
+    # Create the list of variables to pass to Ansible. We create a list of
+    # arguments with preceding `--extra-vars` and then flatten it to ensure
+    # that it is a single list of arguments.
+    extra_arguments = flatten(setproduct(["--extra-vars"], [
+      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
+      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
+      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
+      "cyhy_user_username=${var.cyhy_user_information.username}",
+      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+    ]))
+    groups        = ["cyhy_dashboard"]
+    playbook_file = "ansible/playbook.yml"
+    use_proxy     = false
+    use_sftp      = true
   }
 }

--- a/packer/docker_build.pkr.hcl
+++ b/packer/docker_build.pkr.hcl
@@ -29,13 +29,9 @@ build {
     #   "--extra-vars",
     #   "ham=eggs",
     # ]
-    extra_arguments = flatten(setproduct(["--extra-vars"], [
-      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
-      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
-      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
-      "cyhy_user_username=${var.cyhy_user_information.username}",
-      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-    ]))
+    extra_arguments = flatten(setproduct(["--extra-vars"], concat(
+      local.cyhy_user_ansible_variables,
+    )))
     groups        = ["bod", "code_gov", "vdp_scan"]
     playbook_file = "ansible/playbook.yml"
     use_proxy     = false

--- a/packer/docker_build.pkr.hcl
+++ b/packer/docker_build.pkr.hcl
@@ -20,9 +20,19 @@ build {
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
-    groups           = ["bod", "code_gov", "vdp_scan"]
-    playbook_file    = "ansible/playbook.yml"
-    use_proxy        = false
-    use_sftp         = true
+    # Create the list of variables to pass to Ansible. We create a list of
+    # arguments with preceding `--extra-vars` and then flatten it to ensure
+    # that it is a single list of arguments.
+    extra_arguments = flatten(setproduct(["--extra-vars"], [
+      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
+      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
+      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
+      "cyhy_user_username=${var.cyhy_user_information.username}",
+      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+    ]))
+    groups        = ["bod", "code_gov", "vdp_scan"]
+    playbook_file = "ansible/playbook.yml"
+    use_proxy     = false
+    use_sftp      = true
   }
 }

--- a/packer/docker_build.pkr.hcl
+++ b/packer/docker_build.pkr.hcl
@@ -22,7 +22,13 @@ build {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     # Create the list of variables to pass to Ansible. We create a list of
     # arguments with preceding `--extra-vars` and then flatten it to ensure
-    # that it is a single list of arguments.
+    # that it is a single list of arguments. This will result in a list like:
+    # [
+    #   "--extra-vars",
+    #   "foo=bar",
+    #   "--extra-vars",
+    #   "ham=eggs",
+    # ]
     extra_arguments = flatten(setproduct(["--extra-vars"], [
       "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
       # Since the SSH public key has spaces in it, we need to ensure it is quoted.

--- a/packer/locals.pkr.hcl
+++ b/packer/locals.pkr.hcl
@@ -1,3 +1,16 @@
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+
+  cyhy_user_ansible_variables = [
+    "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
+    # Since the SSH public key has spaces in it, we need to ensure it is quoted.
+    format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
+    "cyhy_user_username=${var.cyhy_user_information.username}",
+    "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+  ]
+
+  maxmind_account_ansible_variables = [
+    "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
+    "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
+  ]
 }

--- a/packer/mongo_build.pkr.hcl
+++ b/packer/mongo_build.pkr.hcl
@@ -29,8 +29,8 @@ build {
       format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
       "cyhy_user_username=${var.cyhy_user_information.username}",
       "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-      "maxmind_account_id=${data.amazon-parameterstore.maxmind_account_id.value}",
-      "maxmind_license_key=${data.amazon-parameterstore.maxmind_license_key.value}",
+      "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
+      "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
     ]))
     groups        = ["cyhy_archive", "cyhy_commander", "cyhy_feeds", "mongo"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/mongo_build.pkr.hcl
+++ b/packer/mongo_build.pkr.hcl
@@ -22,7 +22,13 @@ build {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     # Create the list of variables to pass to Ansible. We create a list of
     # arguments with preceding `--extra-vars` and then flatten it to ensure
-    # that it is a single list of arguments.
+    # that it is a single list of arguments. This will result in a list like:
+    # [
+    #   "--extra-vars",
+    #   "foo=bar",
+    #   "--extra-vars",
+    #   "ham=eggs",
+    # ]
     extra_arguments = flatten(setproduct(["--extra-vars"], [
       "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
       # Since the SSH public key has spaces in it, we need to ensure it is quoted.

--- a/packer/mongo_build.pkr.hcl
+++ b/packer/mongo_build.pkr.hcl
@@ -29,6 +29,8 @@ build {
       format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
       "cyhy_user_username=${var.cyhy_user_information.username}",
       "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+      "maxmind_account_id=${data.amazon-parameterstore.maxmind_account_id.value}",
+      "maxmind_license_key=${data.amazon-parameterstore.maxmind_license_key.value}",
     ]))
     groups        = ["cyhy_archive", "cyhy_commander", "cyhy_feeds", "mongo"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/mongo_build.pkr.hcl
+++ b/packer/mongo_build.pkr.hcl
@@ -20,9 +20,19 @@ build {
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
-    groups           = ["cyhy_archive", "cyhy_commander", "cyhy_feeds", "mongo"]
-    playbook_file    = "ansible/playbook.yml"
-    use_proxy        = false
-    use_sftp         = true
+    # Create the list of variables to pass to Ansible. We create a list of
+    # arguments with preceding `--extra-vars` and then flatten it to ensure
+    # that it is a single list of arguments.
+    extra_arguments = flatten(setproduct(["--extra-vars"], [
+      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
+      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
+      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
+      "cyhy_user_username=${var.cyhy_user_information.username}",
+      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+    ]))
+    groups        = ["cyhy_archive", "cyhy_commander", "cyhy_feeds", "mongo"]
+    playbook_file = "ansible/playbook.yml"
+    use_proxy     = false
+    use_sftp      = true
   }
 }

--- a/packer/mongo_build.pkr.hcl
+++ b/packer/mongo_build.pkr.hcl
@@ -29,15 +29,10 @@ build {
     #   "--extra-vars",
     #   "ham=eggs",
     # ]
-    extra_arguments = flatten(setproduct(["--extra-vars"], [
-      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
-      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
-      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
-      "cyhy_user_username=${var.cyhy_user_information.username}",
-      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-      "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
-      "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
-    ]))
+    extra_arguments = flatten(setproduct(["--extra-vars"], concat(
+      local.cyhy_user_ansible_variables,
+      local.maxmind_account_ansible_variables,
+    )))
     groups        = ["cyhy_archive", "cyhy_commander", "cyhy_feeds", "mongo"]
     playbook_file = "ansible/playbook.yml"
     use_proxy     = false

--- a/packer/nessus_build.pkr.hcl
+++ b/packer/nessus_build.pkr.hcl
@@ -29,13 +29,9 @@ build {
     #   "--extra-vars",
     #   "ham=eggs",
     # ]
-    extra_arguments = flatten(setproduct(["--extra-vars"], [
-      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
-      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
-      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
-      "cyhy_user_username=${var.cyhy_user_information.username}",
-      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-    ]))
+    extra_arguments = flatten(setproduct(["--extra-vars"], concat(
+      local.cyhy_user_ansible_variables,
+    )))
     groups        = ["nessus"]
     playbook_file = "ansible/playbook.yml"
     use_proxy     = false

--- a/packer/nessus_build.pkr.hcl
+++ b/packer/nessus_build.pkr.hcl
@@ -22,7 +22,13 @@ build {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     # Create the list of variables to pass to Ansible. We create a list of
     # arguments with preceding `--extra-vars` and then flatten it to ensure
-    # that it is a single list of arguments.
+    # that it is a single list of arguments. This will result in a list like:
+    # [
+    #   "--extra-vars",
+    #   "foo=bar",
+    #   "--extra-vars",
+    #   "ham=eggs",
+    # ]
     extra_arguments = flatten(setproduct(["--extra-vars"], [
       "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
       # Since the SSH public key has spaces in it, we need to ensure it is quoted.

--- a/packer/nessus_build.pkr.hcl
+++ b/packer/nessus_build.pkr.hcl
@@ -20,9 +20,19 @@ build {
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
-    groups           = ["nessus"]
-    playbook_file    = "ansible/playbook.yml"
-    use_proxy        = false
-    use_sftp         = true
+    # Create the list of variables to pass to Ansible. We create a list of
+    # arguments with preceding `--extra-vars` and then flatten it to ensure
+    # that it is a single list of arguments.
+    extra_arguments = flatten(setproduct(["--extra-vars"], [
+      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
+      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
+      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
+      "cyhy_user_username=${var.cyhy_user_information.username}",
+      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+    ]))
+    groups        = ["nessus"]
+    playbook_file = "ansible/playbook.yml"
+    use_proxy     = false
+    use_sftp      = true
   }
 }

--- a/packer/nmap_build.pkr.hcl
+++ b/packer/nmap_build.pkr.hcl
@@ -23,9 +23,19 @@ build {
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
-    groups           = ["nmap"]
-    playbook_file    = "ansible/playbook.yml"
-    use_proxy        = false
-    use_sftp         = true
+    # Create the list of variables to pass to Ansible. We create a list of
+    # arguments with preceding `--extra-vars` and then flatten it to ensure
+    # that it is a single list of arguments.
+    extra_arguments = flatten(setproduct(["--extra-vars"], [
+      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
+      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
+      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
+      "cyhy_user_username=${var.cyhy_user_information.username}",
+      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+    ]))
+    groups        = ["nmap"]
+    playbook_file = "ansible/playbook.yml"
+    use_proxy     = false
+    use_sftp      = true
   }
 }

--- a/packer/nmap_build.pkr.hcl
+++ b/packer/nmap_build.pkr.hcl
@@ -32,13 +32,9 @@ build {
     #   "--extra-vars",
     #   "ham=eggs",
     # ]
-    extra_arguments = flatten(setproduct(["--extra-vars"], [
-      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
-      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
-      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
-      "cyhy_user_username=${var.cyhy_user_information.username}",
-      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-    ]))
+    extra_arguments = flatten(setproduct(["--extra-vars"], concat(
+      local.cyhy_user_ansible_variables,
+    )))
     groups        = ["nmap"]
     playbook_file = "ansible/playbook.yml"
     use_proxy     = false

--- a/packer/nmap_build.pkr.hcl
+++ b/packer/nmap_build.pkr.hcl
@@ -25,7 +25,13 @@ build {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     # Create the list of variables to pass to Ansible. We create a list of
     # arguments with preceding `--extra-vars` and then flatten it to ensure
-    # that it is a single list of arguments.
+    # that it is a single list of arguments. This will result in a list like:
+    # [
+    #   "--extra-vars",
+    #   "foo=bar",
+    #   "--extra-vars",
+    #   "ham=eggs",
+    # ]
     extra_arguments = flatten(setproduct(["--extra-vars"], [
       "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
       # Since the SSH public key has spaces in it, we need to ensure it is quoted.

--- a/packer/reporter_build.pkr.hcl
+++ b/packer/reporter_build.pkr.hcl
@@ -20,9 +20,19 @@ build {
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
-    groups           = ["cyhy_reporter"]
-    playbook_file    = "ansible/playbook.yml"
-    use_proxy        = false
-    use_sftp         = true
+    # Create the list of variables to pass to Ansible. We create a list of
+    # arguments with preceding `--extra-vars` and then flatten it to ensure
+    # that it is a single list of arguments.
+    extra_arguments = flatten(setproduct(["--extra-vars"], [
+      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
+      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
+      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
+      "cyhy_user_username=${var.cyhy_user_information.username}",
+      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+    ]))
+    groups        = ["cyhy_reporter"]
+    playbook_file = "ansible/playbook.yml"
+    use_proxy     = false
+    use_sftp      = true
   }
 }

--- a/packer/reporter_build.pkr.hcl
+++ b/packer/reporter_build.pkr.hcl
@@ -29,8 +29,8 @@ build {
       format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
       "cyhy_user_username=${var.cyhy_user_information.username}",
       "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-      "maxmind_account_id=${data.amazon-parameterstore.maxmind_account_id.value}",
-      "maxmind_license_key=${data.amazon-parameterstore.maxmind_license_key.value}",
+      "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
+      "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
     ]))
     groups        = ["cyhy_reporter"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/reporter_build.pkr.hcl
+++ b/packer/reporter_build.pkr.hcl
@@ -29,15 +29,10 @@ build {
     #   "--extra-vars",
     #   "ham=eggs",
     # ]
-    extra_arguments = flatten(setproduct(["--extra-vars"], [
-      "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
-      # Since the SSH public key has spaces in it, we need to ensure it is quoted.
-      format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
-      "cyhy_user_username=${var.cyhy_user_information.username}",
-      "cyhy_user_uid=${var.cyhy_user_information.user_id}",
-      "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
-      "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
-    ]))
+    extra_arguments = flatten(setproduct(["--extra-vars"], concat(
+      local.cyhy_user_ansible_variables,
+      local.maxmind_account_ansible_variables,
+    )))
     groups        = ["cyhy_reporter"]
     playbook_file = "ansible/playbook.yml"
     use_proxy     = false

--- a/packer/reporter_build.pkr.hcl
+++ b/packer/reporter_build.pkr.hcl
@@ -22,7 +22,13 @@ build {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     # Create the list of variables to pass to Ansible. We create a list of
     # arguments with preceding `--extra-vars` and then flatten it to ensure
-    # that it is a single list of arguments.
+    # that it is a single list of arguments. This will result in a list like:
+    # [
+    #   "--extra-vars",
+    #   "foo=bar",
+    #   "--extra-vars",
+    #   "ham=eggs",
+    # ]
     extra_arguments = flatten(setproduct(["--extra-vars"], [
       "cyhy_user_home_directory=${var.cyhy_user_information.home_directory}",
       # Since the SSH public key has spaces in it, we need to ensure it is quoted.

--- a/packer/reporter_build.pkr.hcl
+++ b/packer/reporter_build.pkr.hcl
@@ -29,6 +29,8 @@ build {
       format("cyhy_user_ssh_public_key=%q", var.cyhy_user_information.ssh_public_key),
       "cyhy_user_username=${var.cyhy_user_information.username}",
       "cyhy_user_uid=${var.cyhy_user_information.user_id}",
+      "maxmind_account_id=${data.amazon-parameterstore.maxmind_account_id.value}",
+      "maxmind_license_key=${data.amazon-parameterstore.maxmind_license_key.value}",
     ]))
     groups        = ["cyhy_reporter"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/ssm_parameters.pkr.hcl
+++ b/packer/ssm_parameters.pkr.hcl
@@ -1,0 +1,9 @@
+data "amazon-parameterstore" "maxmind_account_id" {
+  name            = var.maxmind_ssm_parameter_names.account_id
+  with_decryption = true
+}
+
+data "amazon-parameterstore" "maxmind_license_key" {
+  name            = var.maxmind_ssm_parameter_names.license_key
+  with_decryption = true
+}

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -64,3 +64,15 @@ variable "is_prerelease" {
   description = "The pre-release status to use for the tags applied to the created AMI."
   type        = bool
 }
+
+variable "maxmind_ssm_parameter_names" {
+  default = {
+    "account_id"  = "/cyhy/core/geoip/account_id"
+    "license_key" = "/cyhy/core/geoip/license_key"
+  }
+  description = "The SSM parameter store names that contain the MaxMind account ID and license key."
+  type = object({
+    account_id  = string
+    license_key = string
+  })
+}

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -31,6 +31,22 @@ variable "build_region" {
   type        = string
 }
 
+variable "cyhy_user_information" {
+  default = {
+    home_directory = "/var/cyhy"
+    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy"
+    user_id        = "2048"
+    username       = "cyhy"
+  }
+  description = "The user information for the Cyber Hygiene user."
+  type = object({
+    home_directory = string
+    ssh_public_key = string
+    user_id        = string
+    username       = string
+  })
+}
+
 variable "force_install_ansible_requirements" {
   default     = false
   description = "Indicate if the Ansible requirements should be force installed."


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request moves any `lookup` calls to the SSM Parameter Store from the Ansible configuration and moves providing those values into the Packer template.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I am trying to eliminate `lookup` calls to the SSM Parameter Store in our Ansible configurations in this project where feasible. We will instead pass these values through the Packer template either as variables or using data sources.

> [!NOTE]
> I verified that the two MaxMind values were *'d out of the Packer log when building an AMI. Related to this I would like to have a discussion about doing similar work in the Terraform configuration and sensitive values in the Terraform state.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified all images build by running `packer build .`. I also redeployed my `reporter` test instance and verified against an old instance deployment that the public SSH key correctly deployed and that the dates for the MaxMind GeoIP2 files reflected the fresh build.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
