### PR TITLE
Use the Debian Archive on Buster

### DIFF
--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -34,6 +34,9 @@ roles:
     src: https://github.com/cisagov/ansible-role-cyhy-reports
   - name: cyhy_runner
     src: https://github.com/cisagov/ansible-role-cyhy-runner
+  - name: debian_archive
+    src: https://github.com/cisagov/ansible-role-debian-archive
+    version: first-commits
   - name: dev_ssh_access
     src: https://github.com/cisagov/ansible-role-dev-ssh-access
   - name: disable_numa

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -36,7 +36,6 @@ roles:
     src: https://github.com/cisagov/ansible-role-cyhy-runner
   - name: debian_archive
     src: https://github.com/cisagov/ansible-role-debian-archive
-    version: first-commits
   - name: dev_ssh_access
     src: https://github.com/cisagov/ansible-role-dev-ssh-access
   - name: disable_numa

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -4,6 +4,13 @@
   become: true
   become_method: ansible.builtin.sudo
   tasks:
+    - name: Use the Debian Archive on Buster
+      when:
+        - ansible_distribution == "Debian"
+        - ansible_distribution_release == "buster"
+      ansible.builtin.include_role:
+        name: debian_archive
+
     - name: Upgrade system packages
       ansible.builtin.include_role:
         name: upgrade


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request runs the new [cisagov/ansible-role-debian-archive] role on Debian Buster hosts when building AMIs.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It appears that Debian Buster is no longer a supported distribution on the non-Archive Debian repositories. This follows the removal of Debian Backports support for Debian Buster. Just as we did in https://github.com/cisagov/ansible-role-backports/pull/45, we must switch the apt repository configuration to use the Debian Archive for packages.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.

[cisagov/ansible-role-debian-archive]: https://github.com/cisagov/ansible-role-debian-archive