### PR TITLE
Use a GitHub token for Packer when running `pre-commit`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,14 @@ jobs:
       - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
       - name: Run pre-commit on all files
+        env:
+          # We have seen some failures of packer init in GitHub Actions due to
+          # rate limiting when pulling Packer plugins from GitHub.  Having
+          # Packer use a GitHub API token should reduce this.  The rate
+          # limiting for unauthenticated requests is 60 requests/hour while
+          # the rate limiting for authenticated requests is 5000
+          # requests/hour.
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pre-commit run --all-files
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request sets the `PACKER_GITHUB_API_TOKEN` environment variable for the step of the `lint` job in the `build.yml` GitHub Actions workflow that runs `pre-commit`. This pulls in the change in cisagov/skeleton-packer#437 to allow `packer` commands to make authenticated requests to GitHub.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The `packer_validate` hook will run a `packer init` command as part of its operation and I have observed failures in that specific hook when run in GitHub Actions. I am pulling in the aforementioned change to hopefully prevent any related failures when this repository is being linted in GitHub Actions.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
