### PR TITLE
Simplify how PTR records are constructed

### DIFF
--- a/terraform/bod_bastion_route53.tf
+++ b/terraform/bod_bastion_route53.tf
@@ -25,11 +25,8 @@ resource "aws_route53_record" "bod_bastion_A" {
 resource "aws_route53_record" "bod_rev_bastion_PTR" {
   zone_id = aws_route53_zone.bod_public_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.bod_bastion.private_ip), 3),
-    element(split(".", aws_instance.bod_bastion.private_ip), 2),
-    element(split(".", aws_instance.bod_bastion.private_ip), 1),
-    element(split(".", aws_instance.bod_bastion.private_ip), 0),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.bod_bastion.private_ip))),
   )
 
   type = "PTR"

--- a/terraform/bod_docker_route53.tf
+++ b/terraform/bod_docker_route53.tf
@@ -12,11 +12,8 @@ resource "aws_route53_record" "bod_docker_A" {
 resource "aws_route53_record" "bod_rev_docker_PTR" {
   zone_id = aws_route53_zone.bod_private_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.bod_docker.private_ip), 3),
-    element(split(".", aws_instance.bod_docker.private_ip), 2),
-    element(split(".", aws_instance.bod_docker.private_ip), 1),
-    element(split(".", aws_instance.bod_docker.private_ip), 0),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.bod_docker.private_ip))),
   )
 
   type = "PTR"

--- a/terraform/cyhy_bastion_route53.tf
+++ b/terraform/cyhy_bastion_route53.tf
@@ -25,11 +25,8 @@ resource "aws_route53_record" "cyhy_bastion_A" {
 resource "aws_route53_record" "cyhy_rev_bastion_PTR" {
   zone_id = aws_route53_zone.cyhy_public_private_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.cyhy_bastion.private_ip), 3),
-    element(split(".", aws_instance.cyhy_bastion.private_ip), 2),
-    element(split(".", aws_instance.cyhy_bastion.private_ip), 1),
-    element(split(".", aws_instance.cyhy_bastion.private_ip), 0),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.cyhy_bastion.private_ip))),
   )
 
   type = "PTR"

--- a/terraform/cyhy_dashboard_route53.tf
+++ b/terraform/cyhy_dashboard_route53.tf
@@ -12,11 +12,8 @@ resource "aws_route53_record" "cyhy_dashboard_A" {
 resource "aws_route53_record" "cyhy_rev_dashboard_PTR" {
   zone_id = aws_route53_zone.cyhy_public_private_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.cyhy_dashboard.private_ip), 3),
-    element(split(".", aws_instance.cyhy_dashboard.private_ip), 2),
-    element(split(".", aws_instance.cyhy_dashboard.private_ip), 1),
-    element(split(".", aws_instance.cyhy_dashboard.private_ip), 0),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.cyhy_dashboard.private_ip))),
   )
 
   type = "PTR"

--- a/terraform/cyhy_mongo_route53.tf
+++ b/terraform/cyhy_mongo_route53.tf
@@ -14,11 +14,8 @@ resource "aws_route53_record" "cyhy_rev_database_PTR" {
   count   = local.count_database
   zone_id = aws_route53_zone.cyhy_public_private_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.cyhy_mongo[count.index].private_ip), 3),
-    element(split(".", aws_instance.cyhy_mongo[count.index].private_ip), 2),
-    element(split(".", aws_instance.cyhy_mongo[count.index].private_ip), 1),
-    element(split(".", aws_instance.cyhy_mongo[count.index].private_ip), 0),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.cyhy_mongo[count.index].private_ip))),
   )
 
   type = "PTR"

--- a/terraform/cyhy_nessus_route53.tf
+++ b/terraform/cyhy_nessus_route53.tf
@@ -52,35 +52,8 @@ resource "aws_route53_record" "cyhy_rev_vulnscan_PTR" {
   count   = local.count_vuln_scanner
   zone_id = aws_route53_zone.cyhy_scanner_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nessus[count.index].private_ip,
-      ),
-      3,
-    ),
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nessus[count.index].private_ip,
-      ),
-      2,
-    ),
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nessus[count.index].private_ip,
-      ),
-      1,
-    ),
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nessus[count.index].private_ip,
-      ),
-      0,
-    ),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.cyhy_nessus[count.index].private_ip))),
   )
 
   type = "PTR"

--- a/terraform/cyhy_nmap_route53.tf
+++ b/terraform/cyhy_nmap_route53.tf
@@ -14,35 +14,8 @@ resource "aws_route53_record" "cyhy_rev_portscan_PTR" {
   count   = local.count_port_scanner
   zone_id = aws_route53_zone.cyhy_scanner_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nmap[count.index].private_ip,
-      ),
-      3,
-    ),
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nmap[count.index].private_ip,
-      ),
-      2,
-    ),
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nmap[count.index].private_ip,
-      ),
-      1,
-    ),
-    element(
-      split(
-        ".",
-        aws_instance.cyhy_nmap[count.index].private_ip,
-      ),
-      0,
-    ),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.cyhy_nmap[count.index].private_ip))),
   )
 
   type = "PTR"

--- a/terraform/cyhy_reporter_route53.tf
+++ b/terraform/cyhy_reporter_route53.tf
@@ -12,11 +12,8 @@ resource "aws_route53_record" "cyhy_reporter_A" {
 resource "aws_route53_record" "cyhy_rev_reporter_PTR" {
   zone_id = aws_route53_zone.cyhy_public_private_zone_reverse.zone_id
   name = format(
-    "%s.%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_instance.cyhy_reporter.private_ip), 3),
-    element(split(".", aws_instance.cyhy_reporter.private_ip), 2),
-    element(split(".", aws_instance.cyhy_reporter.private_ip), 1),
-    element(split(".", aws_instance.cyhy_reporter.private_ip), 0),
+    "%s.in-addr.arpa.",
+    join(".", reverse(split(".", aws_instance.cyhy_reporter.private_ip))),
   )
 
   type = "PTR"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates how PTR records for instances are created.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I happened to look at the existing code and thought that better leveraging Terraform built-in functions would make it much simpler.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that an appropriate looking value was in the Terraform resources after deploying with these changes in my testing environment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
