### PR TITLE
Add a lifecycle configuration to the S3 bucket that stores `cyhy-archive` backups

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -448,6 +448,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_route_table_association.mgmt_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_s3_bucket.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_notification.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_ownership_controls.cyhy_archive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.moe_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
@@ -645,6 +646,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | create\_bod\_flow\_logs | Whether or not to create flow logs for the BOD 18-01 VPC. | `bool` | `false` | no |
 | create\_cyhy\_flow\_logs | Whether or not to create flow logs for the CyHy VPC. | `bool` | `false` | no |
 | create\_mgmt\_flow\_logs | Whether or not to create flow logs for the Management VPC. | `bool` | `false` | no |
+| cyhy\_archive\_bucket\_lifecycle\_rule\_name | The name of the lifecycle rule for the cyhy-archive S3 bucket. | `string` | `"cyhy-archive-object-storage-class-transitions"` | no |
 | cyhy\_archive\_bucket\_name | S3 bucket for storing compressed archive files created by cyhy-archive. | `string` | `"ncats-cyhy-archive"` | no |
 | cyhy\_elastic\_ip\_cidr\_block | The CIDR block of elastic addresses available for use by CyHy scanner instances. | `string` | `""` | no |
 | cyhy\_portscan\_first\_elastic\_ip\_offset | The offset of the address (from the start of the elastic IP CIDR block) to be assigned to the *first* CyHy portscan instance.  For example, if the CIDR block is 192.168.1.0/24 and the offset is set to 10, the first portscan address used will be 192.168.1.10.  This is only used in production workspaces.  Each additional portscan instance will get the next consecutive address in the block.  NOTE: This will only work as intended when a contiguous CIDR block of EIP addresses is available. | `number` | `0` | no |

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -37,6 +37,40 @@ resource "aws_s3_bucket_ownership_controls" "cyhy_archive" {
   }
 }
 
+# Add a lifecycle configuration to the bucket to transition any cyhy-archive objects to
+# progressively slower and/or more expensive to access, but cheaper to store, storage
+# classes. The dates to transition take into account the minimum retention period
+# requirements for the storage class the object is transitioning from.
+resource "aws_s3_bucket_lifecycle_configuration" "cyhy_archive" {
+  bucket = aws_s3_bucket.cyhy_archive.id
+
+  rule {
+    id     = var.cyhy_archive_bucket_lifecycle_rule_name
+    status = "Enabled"
+
+    filter {
+      # This matches the prefix for the archive files produced by the cyhy-archive
+      # script.
+      prefix = "cyhy_archive_"
+    }
+
+    # After 30 days, transition archive objects to the Glacier Instant Retrieval
+    # storage class. This storage class has a 90 day minimum retention period.
+    transition {
+      days          = 30
+      storage_class = "GLACIER_IR"
+    }
+
+    # After another 90 days, transition archive objects to the Glacier Deep Archive
+    # storage class. This storage class has a 180 day minimum retention period. This is
+    # the final storage class for these objects.
+    transition {
+      days          = 120
+      storage_class = "DEEP_ARCHIVE"
+    }
+  }
+}
+
 # IAM policy document that that allows S3 PutObject (write) on our
 # cyhy-archive bucket.  This will be applied to the cyhy-archive role.
 data "aws_iam_policy_document" "s3_cyhy_archive_write_doc" {

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -61,9 +61,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "cyhy_archive" {
       storage_class = "GLACIER_IR"
     }
 
-    # After another 90 days, transition archive objects to the Glacier Deep Archive
-    # storage class. This storage class has a 180 day minimum retention period. This is
-    # the final storage class for these objects.
+    # After 120 days, 30 in Standard and 90 in Glacier Instant Retrieval, transition
+    # archive objects to the Glacier Deep Archive storage class. This storage class has
+    # a 180 day minimum retention period. This is the final storage class for these
+    # objects.
     transition {
       days          = 120
       storage_class = "DEEP_ARCHIVE"

--- a/terraform/cyhy_archive_bucket.tf
+++ b/terraform/cyhy_archive_bucket.tf
@@ -61,7 +61,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "cyhy_archive" {
       storage_class = "GLACIER_IR"
     }
 
-    # After 120 days, 30 in Standard and 90 in Glacier Instant Retrieval, transition
+    # After 120 days (30 in Standard and 90 in Glacier Instant Retrieval), transition
     # archive objects to the Glacier Deep Archive storage class. This storage class has
     # a 180 day minimum retention period. This is the final storage class for these
     # objects.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -189,6 +189,13 @@ variable "create_mgmt_flow_logs" {
   type        = bool
 }
 
+variable "cyhy_archive_bucket_lifecycle_rule_name" {
+  default     = "cyhy-archive-object-storage-class-transitions"
+  description = "The name of the lifecycle rule for the cyhy-archive S3 bucket."
+  nullable    = false
+  type        = string
+}
+
 variable "cyhy_archive_bucket_name" {
   default     = "ncats-cyhy-archive"
   description = "S3 bucket for storing compressed archive files created by cyhy-archive."


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds an S3 bucket lifecycle configuration to the bucket that stores [`cyhy-archive`] archives. This lifecycle configuration transitions any objects that start with the [archive prefix] to [Glacier Instant Retrieval] at 30 days and to [Glacier Deep Archive] after another 90 days.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As was pointed out in #871 there are some cost savings to be had by managing the lifecycle of objects we store in S3 long-term. Since we do not typically use this data it makes sense to move it directly into Glacier storage classes once enough time has passed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.

> [!NOTE]
> Once we have settled on storage classes and age for transitioning objects I will deploy this to my test environment and verify that objects are transitioned. As mentioned in the [user guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html): "the configuration rules apply to both existing objects and objects that you add later".
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

[`cyhy-archive`]: https://github.com/cisagov/cyhy-core/blob/develop/bin/cyhy-archive
[archive prefix]: https://github.com/cisagov/cyhy-core/blob/5661d725e8ca192948234fe7dfc4e3ad02519ac7/bin/cyhy-archive#L137
[Glacier Instant Retrieval]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/glacier-storage-classes.html#GIR
[Glacier Deep Archive]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/glacier-storage-classes.html#GDA