### PR TITLE
Fix Nessus activation code extraction

### DIFF
--- a/ansible/roles/nessus/tasks/main.yml
+++ b/ansible/roles/nessus/tasks/main.yml
@@ -21,7 +21,7 @@
     - name: Extract the key in use
       ansible.builtin.set_fact:
         nessus_registered_key: >-
-          {{ nessus_key_result.stdout | regex_search(nessus_license_regexp, '\\1') }}
+          {{ nessus_key_result.stdout | regex_search(nessus_license_regexp, '\1') }}
       vars:
         # Looking for key in format:
         # XXXX-XXXX-XXXX-XXXX or XXXX-XXXX-XXXX-XXXX-XXXX


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request fixes the `regex_search` used to extract the Nessus activation code from the output of the call to `nessuscli`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In #856 the line that extracts the Nessus activation code was turned into a multiline string. However, testing for that pull request did not include running the provisioner against an already deployed instance. When testing other changes I did so and found that the `regex_search` did not function as expected. This was correctly done in that PR for the `mongo` role in https://github.com/cisagov/cyhy_amis/commit/224e3fb72f3d7a048ef47a4088b563ed88536a12.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the activation code is successfully extracted when the provisioner, and thus the `nessus` role, is run against a deployed vulnscanner instance.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
