### PR TITLE
Base the `bastion` AMI on Debian Trixie

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -81,6 +81,8 @@ No modules.
 | [amazon-ami_amazon-ami.debian_bookworm_arm64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
 | [amazon-ami_amazon-ami.debian_bookworm_x86_64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
 | [amazon-ami_amazon-ami.debian_buster_x86_64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
+| [amazon-ami_amazon-ami.debian_trixie_arm64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
+| [amazon-ami_amazon-ami.debian_trixie_x86_64](https://registry.terraform.io/providers/hashicorp/amazon-ami/latest/docs/data-sources/amazon-ami) | data source |
 | [amazon-parameterstore_amazon-parameterstore.maxmind_account_id](https://registry.terraform.io/providers/hashicorp/amazon-parameterstore/latest/docs/data-sources/amazon-parameterstore) | data source |
 | [amazon-parameterstore_amazon-parameterstore.maxmind_license_key](https://registry.terraform.io/providers/hashicorp/amazon-parameterstore/latest/docs/data-sources/amazon-parameterstore) | data source |
 

--- a/packer/base_amis.pkr.hcl
+++ b/packer/base_amis.pkr.hcl
@@ -30,3 +30,25 @@ data "amazon-ami" "debian_bookworm_x86_64" {
   owners      = ["136693071363"]
   region      = var.build_region
 }
+
+data "amazon-ami" "debian_trixie_arm64" {
+  filters = {
+    name                = "debian-13-arm64-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["136693071363"]
+  region      = var.build_region
+}
+
+data "amazon-ami" "debian_trixie_x86_64" {
+  filters = {
+    name                = "debian-13-amd64-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["136693071363"]
+  region      = var.build_region
+}

--- a/packer/bastion_ami_arm64.pkr.hcl
+++ b/packer/bastion_ami_arm64.pkr.hcl
@@ -17,13 +17,13 @@ source "amazon-ebs" "bastion_arm64" {
     volume_type           = "gp3"
   }
   region       = var.build_region
-  source_ami   = data.amazon-ami.debian_bookworm_arm64.id
+  source_ami   = data.amazon-ami.debian_trixie_arm64.id
   ssh_username = "admin"
   tags = {
     Application   = "Cyber Hygiene"
     Architecture  = "arm64"
-    Base_AMI_Name = data.amazon-ami.debian_bookworm_arm64.name
-    OS_Version    = "Debian Bookworm"
+    Base_AMI_Name = data.amazon-ami.debian_trixie_arm64.name
+    OS_Version    = "Debian Trixie"
     Pre_Release   = var.is_prerelease
     Release       = "Latest"
     Team          = "VM Fusion - Development"

--- a/packer/bastion_ami_x86_64.pkr.hcl
+++ b/packer/bastion_ami_x86_64.pkr.hcl
@@ -17,13 +17,13 @@ source "amazon-ebs" "bastion_x86_64" {
     volume_type           = "gp3"
   }
   region       = var.build_region
-  source_ami   = data.amazon-ami.debian_bookworm_x86_64.id
+  source_ami   = data.amazon-ami.debian_trixie_x86_64.id
   ssh_username = "admin"
   tags = {
     Application   = "Cyber Hygiene"
     Architecture  = "x86_64"
-    Base_AMI_Name = data.amazon-ami.debian_bookworm_x86_64.name
-    OS_Version    = "Debian Bookworm"
+    Base_AMI_Name = data.amazon-ami.debian_trixie_x86_64.name
+    OS_Version    = "Debian Trixie"
     Pre_Release   = var.is_prerelease
     Release       = "Latest"
     Team          = "VM Fusion - Development"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds Debian Trixie base AMIs in the Packer template and uses them to build the `bastion` AMI.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the [release of Debian Trixie](https://www.debian.org/News/2025/20250809) it makes sense to start migrating any of our Debian Bookworm AMIs to Debian Trixie. This starts that process with the `bastion` AMI.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that both `arm64` and `x86_64` AMIs built successfully. I also deployed new bastion instances in my testing environment based using the `x86_64` AMI I built and verified that they both (`cyhy` and `bod`) deployed successfully. I also connected to each and verified that the codename from `lsb_release -c` was `trixie`.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
