### PR TITLE
Add serverless Valkey ElastiCache cache for CyHy-BOD reporting orchestration

### DIFF
--- a/packer/ansible/bod.yml
+++ b/packer/ansible/bod.yml
@@ -7,3 +7,4 @@
     - xfs
     - orchestrator
     - cyhy_mailer
+    - valkey_cli

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -12,3 +12,12 @@
         cyhy_reports_texmf_buffer_size: 100000000
         cyhy_reports_texmf_main_memory: 10000000
     - cyhy_mailer
+  tasks:
+    # This Docker image is used to communicate with the serverless
+    # Valkey ElastiCache resource in the BOD VPC.  We cannot install
+    # valkey-tools on the CyHy reporter instance directly because it
+    # is still using Debian Buster, which does not offer this package.
+    - name: Pull official valkey Docker image
+      community.general.docker_image:
+        name: valkey/valkey:alpine
+        source: pull

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -18,6 +18,6 @@
     # valkey-tools on the CyHy reporter instance directly because it
     # is still using Debian Buster, which does not offer this package.
     - name: Pull official valkey Docker image
-      community.general.docker_image:
+      community.docker.docker_image:
         name: valkey/valkey:alpine
         source: pull

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -1,6 +1,6 @@
 collections:
   - ansible.posix
-  - community.general
+  - community.docker
 
 roles:
   - name: amazon_ssm_agent

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -1,5 +1,6 @@
 collections:
   - ansible.posix
+  - community.general
 
 roles:
   - name: amazon_ssm_agent

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -76,6 +76,8 @@ roles:
     src: https://github.com/cisagov/ansible-role-systemd-resolved
   - name: upgrade
     src: https://github.com/cisagov/ansible-role-upgrade
+  - name: valkey_cli
+    src: https://github.com/cisagov/ansible-role-valkey-cli
   - name: vdp_scanner
     src: https://github.com/cisagov/ansible-role-vdp-scanner
   - name: xfs

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -208,6 +208,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_eip.mgmt_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_eip_association.cyhy_nessus_eip_assocs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_eip_association.cyhy_nmap_eip_assocs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
+| [aws_elasticache_serverless_cache.cyhy_bod_orch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_serverless_cache) | resource |
 | [aws_flow_log.bod_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_flow_log.cyhy_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_flow_log.mgmt_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
@@ -457,6 +458,8 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_security_group.bod_bastion_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.bod_docker_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.bod_lambda_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.cache_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.cyhy_bastion_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.cyhy_private_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.cyhy_scanner_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -498,7 +501,10 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_security_group_rule.docker_anywhere](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.docker_egress_to_cyhy_private_via_mongodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.docker_ssh_ingress_from_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_to_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ephemeral_port_egress_anywhere](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_cache_clients](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_cyhy_private_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lambda_anywhere](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lambda_egress_to_mongo_via_mongo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lambda_https_egress_to_anywhere](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -173,6 +173,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | cyhy\_nessus\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
 | cyhy\_nmap\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
 | cyhy\_reporter\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
+| docker | github.com/cisagov/distributed-subnets-tf-module | n/a |
 | mgmt\_bastion\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
 | mgmt\_nessus\_ansible\_provisioner | github.com/cloudposse/terraform-null-ansible | n/a |
 
@@ -555,7 +556,6 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_sns_topic_subscription.account_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_sns_topic_subscription.fdi_failure_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_sns_topic_subscription.kevsync_failure_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
-| [aws_subnet.bod_docker_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.bod_lambda_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.bod_public_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.cyhy_portscanner_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -540,6 +540,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_security_group_rule.private_mongodb_ingress_from_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.private_ssh_egress_to_scanner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.private_ssh_ingress_from_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.private_valkey_egress_to_bod_docker_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.private_webd_egress_to_webui](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.private_webd_ingress_from_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.scanner_egress_anywhere](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/terraform/bod_docker_acl_rules.tf
+++ b/terraform/bod_docker_acl_rules.tf
@@ -12,8 +12,8 @@ resource "aws_network_acl_rule" "docker_ingress_from_public_via_ssh" {
 
 # Allow ingress via ephemeral ports from anywhere via TCP
 #
-# Note that this includes ingress on port 6379 from the CyHy private
-# subnet.
+# Note that this includes ingress on port 6379 (Valkey) from the CyHy
+# private subnet.
 resource "aws_network_acl_rule" "docker_ingress_anywhere_via_ephemeral_ports_tcp" {
   network_acl_id = aws_network_acl.bod_docker_acl.id
   egress         = false

--- a/terraform/bod_docker_acl_rules.tf
+++ b/terraform/bod_docker_acl_rules.tf
@@ -11,6 +11,9 @@ resource "aws_network_acl_rule" "docker_ingress_from_public_via_ssh" {
 }
 
 # Allow ingress via ephemeral ports from anywhere via TCP
+#
+# Note that this includes ingress on port 6379 from the CyHy private
+# subnet.
 resource "aws_network_acl_rule" "docker_ingress_anywhere_via_ephemeral_ports_tcp" {
   network_acl_id = aws_network_acl.bod_docker_acl.id
   egress         = false

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -23,12 +23,11 @@ data "aws_ami" "bod_docker" {
 
 # The docker EC2 instance
 resource "aws_instance" "bod_docker" {
-  ami               = data.aws_ami.bod_docker.id
-  instance_type     = local.production_workspace ? "r5.xlarge" : "t3.small"
-  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+  ami           = data.aws_ami.bod_docker.id
+  instance_type = local.production_workspace ? "r5.xlarge" : "t3.small"
 
-  # This is the private subnet
-  subnet_id = aws_subnet.bod_docker_subnet.id
+  # This is the first Docker subnet
+  subnet_id = values(tomap(module.docker.subnets))[0].id
 
   # AWS Instance Metadata Service (IMDS) options
   metadata_options {
@@ -95,7 +94,9 @@ resource "aws_instance" "bod_docker" {
 # inside of the lifecycle block
 # (https://github.com/hashicorp/terraform/issues/3116).
 resource "aws_ebs_volume" "bod_report_data" {
-  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+  # The volume and the instance to which it attaches must be in the
+  # same availability zone.
+  availability_zone = values(tomap(module.docker.subnets))[0].availability_zone
   type              = "io2"
   size              = local.production_workspace ? 200 : 5
   iops              = 100
@@ -128,7 +129,9 @@ resource "aws_volume_attachment" "bod_report_data_attachment" {
 # We use the minimum size for io2 volumes because the output of the VDP process
 # is small.
 resource "aws_ebs_volume" "vdp_report_data" {
-  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+  # The volume and the instance to which it attaches must be in the
+  # same availability zone.
+  availability_zone = values(tomap(module.docker.subnets))[0].availability_zone
   type              = "io2"
   size              = 4
   iops              = 100

--- a/terraform/bod_docker_ec2.tf
+++ b/terraform/bod_docker_ec2.tf
@@ -56,6 +56,7 @@ resource "aws_instance" "bod_docker" {
   }
 
   vpc_security_group_ids = [
+    aws_security_group.cache_client.id,
     aws_security_group.bod_docker_sg.id,
   ]
 

--- a/terraform/bod_docker_route53.tf
+++ b/terraform/bod_docker_route53.tf
@@ -10,7 +10,8 @@ resource "aws_route53_record" "bod_docker_A" {
 }
 
 resource "aws_route53_record" "bod_rev_docker_PTR" {
-  zone_id = aws_route53_zone.bod_private_zone_reverse.zone_id
+  # The Docker instance lives in the first Docker subnet
+  zone_id = values(tomap(aws_route53_zone.bod_private_zone_reverse))[0].zone_id
   name = format(
     "%s.in-addr.arpa.",
     join(".", reverse(split(".", aws_instance.bod_docker.private_ip))),

--- a/terraform/bod_public_acl_rules.tf
+++ b/terraform/bod_public_acl_rules.tf
@@ -1,6 +1,6 @@
-# Allow ingress from the docker subnet via HTTP (for downloading the
-# public suffix list), HTTPS (for AWS CLI), FTP (for downloading ASN
-# information).  This allows EC2 instances in the docker subnet to
+# Allow ingress from the first Docker subnet via HTTP (for downloading
+# the public suffix list), HTTPS (for AWS CLI), FTP (for downloading
+# ASN information).  This allows EC2 instances in the docker subnet to
 # send the traffic they want via the NAT gateway, subject to their own
 # security group and network ACL restrictions.
 resource "aws_network_acl_rule" "bod_public_ingress_from_docker" {
@@ -11,9 +11,10 @@ resource "aws_network_acl_rule" "bod_public_ingress_from_docker" {
   protocol       = "tcp"
   rule_number    = 80 + count.index
   rule_action    = "allow"
-  cidr_block     = aws_subnet.bod_docker_subnet.cidr_block
-  from_port      = local.bod_docker_egress_anywhere_ports[count.index]
-  to_port        = local.bod_docker_egress_anywhere_ports[count.index]
+  # This is the first Docker subnet
+  cidr_block = keys(tomap(module.docker.subnets))[0]
+  from_port  = local.bod_docker_egress_anywhere_ports[count.index]
+  to_port    = local.bod_docker_egress_anywhere_ports[count.index]
 }
 
 # Allow ingress from the Lambda subnet via HTTP and HTTPS (for pshtt),
@@ -59,16 +60,17 @@ resource "aws_network_acl_rule" "bod_public_ingress_from_anywhere_via_ssh" {
   to_port        = 22
 }
 
-# Allow egress to the docker subnet via ssh
+# Allow egress to the first docker subnet via ssh
 resource "aws_network_acl_rule" "bod_public_egress_to_docker_via_ssh" {
   network_acl_id = aws_network_acl.bod_public_acl.id
   egress         = true
   protocol       = "tcp"
   rule_number    = 150
   rule_action    = "allow"
-  cidr_block     = aws_subnet.bod_docker_subnet.cidr_block
-  from_port      = 22
-  to_port        = 22
+  # This is the first Docker subnet
+  cidr_block = keys(tomap(module.docker.subnets))[0]
+  from_port  = 22
+  to_port    = 22
 }
 
 # Allow egress to the bastion via ssh.  This is necessary because

--- a/terraform/bod_route53.tf
+++ b/terraform/bod_route53.tf
@@ -34,11 +34,12 @@ resource "aws_route53_record" "bod_router_A" {
   name    = "router.${aws_route53_zone.bod_private_zone.name}"
   type    = "A"
   ttl     = 300
-  records = [
+  records = concat([
+    for subnet in module.docker.subnets : cidrhost(subnet.cidr_block, 1)
+    ], [
     cidrhost(aws_subnet.bod_public_subnet.cidr_block, 1),
-    cidrhost(aws_subnet.bod_docker_subnet.cidr_block, 1),
     cidrhost(aws_subnet.bod_lambda_subnet.cidr_block, 1),
-  ]
+  ])
 }
 
 resource "aws_route53_record" "bod_ns_A" {
@@ -46,11 +47,12 @@ resource "aws_route53_record" "bod_ns_A" {
   name    = "ns.${aws_route53_zone.bod_private_zone.name}"
   type    = "A"
   ttl     = 300
-  records = [
+  records = concat([
+    for subnet in module.docker.subnets : cidrhost(subnet.cidr_block, 2)
+    ], [
     cidrhost(aws_subnet.bod_public_subnet.cidr_block, 2),
-    cidrhost(aws_subnet.bod_docker_subnet.cidr_block, 2),
     cidrhost(aws_subnet.bod_lambda_subnet.cidr_block, 2),
-  ]
+  ])
 }
 
 resource "aws_route53_record" "bod_reserved_A" {
@@ -58,11 +60,12 @@ resource "aws_route53_record" "bod_reserved_A" {
   name    = "reserved.${aws_route53_zone.bod_private_zone.name}"
   type    = "A"
   ttl     = 300
-  records = [
+  records = concat([
+    for subnet in module.docker.subnets : cidrhost(subnet.cidr_block, 3)
+    ], [
     cidrhost(aws_subnet.bod_public_subnet.cidr_block, 3),
-    cidrhost(aws_subnet.bod_docker_subnet.cidr_block, 3),
     cidrhost(aws_subnet.bod_lambda_subnet.cidr_block, 3),
-  ]
+  ])
 }
 
 ##################################
@@ -122,12 +125,14 @@ resource "aws_route53_record" "bod_rev_3_PTR" {
 ##################################
 
 resource "aws_route53_zone" "bod_private_zone_reverse" {
+  for_each = tomap(module.docker.subnets)
+
   # NOTE:  This assumes that we are using /24 blocks
   name = format(
     "%s.%s.%s.in-addr.arpa.",
-    element(split(".", aws_subnet.bod_docker_subnet.cidr_block), 2),
-    element(split(".", aws_subnet.bod_docker_subnet.cidr_block), 1),
-    element(split(".", aws_subnet.bod_docker_subnet.cidr_block), 0),
+    element(split(".", each.key), 2),
+    element(split(".", each.key), 1),
+    element(split(".", each.key), 0),
   )
 
   vpc {

--- a/terraform/bod_vpc.tf
+++ b/terraform/bod_vpc.tf
@@ -21,15 +21,19 @@ resource "aws_vpc_dhcp_options_association" "bod_vpc_dhcp" {
   dhcp_options_id = aws_vpc_dhcp_options.bod_dhcp_options.id
 }
 
-# Docker subnet of the VPC
-resource "aws_subnet" "bod_docker_subnet" {
-  vpc_id            = aws_vpc.bod_vpc.id
-  cidr_block        = "10.11.1.0/24"
-  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-
+# Docker subnets of the VPC
+module "docker" {
+  source     = "github.com/cisagov/distributed-subnets-tf-module"
   depends_on = [aws_internet_gateway.bod_igw]
+  providers = {
+    aws = aws
+  }
 
-  tags = { "Name" = "BOD 18-01 Docker" }
+  subnet_cidr_blocks = [
+    "10.11.1.0/24",
+    "10.11.2.0/24",
+  ]
+  vpc_id = aws_vpc.bod_vpc.id
 }
 
 # Lambda subnet of the VPC
@@ -168,12 +172,10 @@ resource "aws_route_table_association" "bod_association" {
   route_table_id = aws_route_table.bod_public_route_table.id
 }
 
-# ACL for the docker subnet of the VPC
+# ACL for the Docker subnets of the VPC
 resource "aws_network_acl" "bod_docker_acl" {
-  vpc_id = aws_vpc.bod_vpc.id
-  subnet_ids = [
-    aws_subnet.bod_docker_subnet.id,
-  ]
+  vpc_id     = aws_vpc.bod_vpc.id
+  subnet_ids = keys(tomap(module.docker.subnets))
 
   tags = { "Name" = "BOD 18-01 Docker" }
 }

--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -1,0 +1,13 @@
+# A serverless Valkey ElastiCache instance for CyHy-BOD reporting
+# orchestration
+resource "aws_elasticache_serverless_cache" "cyhy_bod_orch" {
+  description = "A serverless Valkey ElastiCache cache for CyHy-BOD reporting orchestration."
+  engine      = "valkey"
+  name        = "cyhy-bod-orchestration"
+  security_group_ids = [
+    aws_security_group.cache.id,
+  ]
+  subnet_ids = [
+    aws_subnet.bod_docker_subnet.id,
+  ]
+}

--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -7,7 +7,5 @@ resource "aws_elasticache_serverless_cache" "cyhy_bod_orch" {
   security_group_ids = [
     aws_security_group.cache.id,
   ]
-  subnet_ids = [
-    aws_subnet.bod_docker_subnet.id,
-  ]
+  subnet_ids = [for subnet in tomap(module.docker.subnets) : subnet.id]
 }

--- a/terraform/cache_client_sg.tf
+++ b/terraform/cache_client_sg.tf
@@ -1,0 +1,19 @@
+# A security group for cache clients
+resource "aws_security_group" "cache_client" {
+  description = "Allow egress to the cache security group"
+  name        = "cache_client"
+  tags = {
+    Name = "Cache client"
+  }
+  vpc_id = aws_vpc.bod_vpc.id
+}
+
+# Allow egress via port 6379 to the cache
+resource "aws_security_group_rule" "egress_to_cache" {
+  from_port                = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.cache_client.id
+  source_security_group_id = aws_security_group.cache.id
+  to_port                  = 6379
+  type                     = "egress"
+}

--- a/terraform/cache_sg.tf
+++ b/terraform/cache_sg.tf
@@ -1,0 +1,30 @@
+# A security group for the cache itself
+resource "aws_security_group" "cache" {
+  description = "Allow ingress from the cache client security group"
+  name        = "cache"
+  tags = {
+    Name = "Cache"
+  }
+  vpc_id = aws_vpc.bod_vpc.id
+}
+
+# Allow ingress via port 6379 from cache clients
+resource "aws_security_group_rule" "ingress_from_cache_clients" {
+  from_port                = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.cache.id
+  source_security_group_id = aws_security_group.cache_client.id
+  to_port                  = 6379
+  type                     = "ingress"
+}
+
+# Allow ingress via port 6379 from the CyHy private subnet, so those
+# instances can access the cache.
+resource "aws_security_group_rule" "ingress_from_cyhy_private_subnet" {
+  cidr_blocks       = [aws_subnet.cyhy_private_subnet.cidr_block]
+  from_port         = 6379
+  protocol          = "tcp"
+  security_group_id = aws_security_group.cache.id
+  to_port           = 6379
+  type              = "ingress"
+}

--- a/terraform/cyhy_private_acl_rules.tf
+++ b/terraform/cyhy_private_acl_rules.tf
@@ -88,12 +88,14 @@ resource "aws_network_acl_rule" "private_egress_to_bastion_via_ephemeral_ports" 
 # Note that this includes egress to ElastiCache in the BOD 18-01
 # Docker subnet via port 6379.
 resource "aws_network_acl_rule" "private_egress_to_bod_docker_via_ephemeral_ports" {
+  for_each = tomap(module.docker.subnets)
+
   network_acl_id = aws_network_acl.cyhy_private_acl.id
   egress         = true
   protocol       = "tcp"
-  rule_number    = 120
+  rule_number    = 120 + index(keys(tomap(module.docker.subnets)), each.key)
   rule_action    = "allow"
-  cidr_block     = aws_subnet.bod_docker_subnet.cidr_block
+  cidr_block     = each.key
   from_port      = 1024
   to_port        = 65535
 }

--- a/terraform/cyhy_private_acl_rules.tf
+++ b/terraform/cyhy_private_acl_rules.tf
@@ -84,6 +84,9 @@ resource "aws_network_acl_rule" "private_egress_to_bastion_via_ephemeral_ports" 
 }
 
 # Allow egress to the BOD 18-01 docker subnet via ephemeral ports
+#
+# Note that this includes egress to ElastiCache in the BOD 18-01
+# Docker subnet via port 6379.
 resource "aws_network_acl_rule" "private_egress_to_bod_docker_via_ephemeral_ports" {
   network_acl_id = aws_network_acl.cyhy_private_acl.id
   egress         = true

--- a/terraform/cyhy_private_acl_rules.tf
+++ b/terraform/cyhy_private_acl_rules.tf
@@ -1,4 +1,4 @@
-# Allow egress to the both scanner subnets via ssh
+# Allow egress to both scanner subnets via ssh
 resource "aws_network_acl_rule" "private_egress_to_portscanner_via_ssh" {
   network_acl_id = aws_network_acl.cyhy_private_acl.id
   egress         = true
@@ -47,7 +47,8 @@ resource "aws_network_acl_rule" "cyhy_private_egress_anywhere_via_https" {
 }
 
 # Allow ingress from anywhere via ephemeral ports
-# Note: includes ingress from the BOD 18-01 private subnet via mongodb
+#
+# Note: includes ingress from the BOD 18-01 private subnet via MongoDB
 resource "aws_network_acl_rule" "private_ingress_from_anywhere_via_ephemeral_ports" {
   network_acl_id = aws_network_acl.cyhy_private_acl.id
   egress         = false

--- a/terraform/cyhy_private_security_group_rules.tf
+++ b/terraform/cyhy_private_security_group_rules.tf
@@ -18,6 +18,16 @@ resource "aws_security_group_rule" "private_https_egress_to_anywhere" {
   to_port           = 443
 }
 
+# Allow egress to the BOD Docker subnets via port 6379 (Valkey)
+resource "aws_security_group_rule" "private_valkey_egress_to_bod_docker_subnets" {
+  security_group_id = aws_security_group.cyhy_private_sg.id
+  type              = "egress"
+  protocol          = "tcp"
+  cidr_blocks       = keys(tomap(module.docker.subnets))
+  from_port         = 6379
+  to_port           = 6379
+}
+
 # Allow SSH ingress from the bastion
 resource "aws_security_group_rule" "private_ssh_ingress_from_bastion" {
   security_group_id = aws_security_group.cyhy_private_sg.id


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a serverless Valkey ElastiCache cache for CyHy-BOD reporting orchestration.

See also:
- cisagov/ansible-role-cyhy-reports#88
- cisagov/ansible-role-valkey-cli#1

> [!WARNING]
> Pay particular attention to the commit log of fbc1a240ce623a1a98f8d0d3a3d41705ed36c97e before applying these changes to a production environment!

> [!WARNING]
> The BOD Docker instance will be destroyed and recreated when you apply these changes, so make sure BOD scanning/reporting isn't taking place when you do so.

## 💭 Motivation and context ##

We need such a thing to allow the CyHy reporting process to automatically begin as soon as the BOD 18-01 reporting completes.

## 🧪 Testing ##

I deployed these changes into my `jsf9k` CyHy test deployment in `us-west-1` and verified that I was able to communicate with the Valkey cache from both the BOD Docker and CyHy reporter instances.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.