### PR TITLE
Migrate `bastion` instances to Graviton-based models

### DIFF
--- a/terraform/bastion_ami.tf
+++ b/terraform/bastion_ami.tf
@@ -3,7 +3,7 @@ data "aws_ami" "bastion" {
   filter {
     name = "name"
     values = [
-      "${var.ami_prefixes.bastion}-bastion-hvm-*-x86_64-ebs",
+      "${var.ami_prefixes.bastion}-bastion-hvm-*-arm64-ebs",
     ]
   }
 

--- a/terraform/bod_bastion_ec2.tf
+++ b/terraform/bod_bastion_ec2.tf
@@ -1,7 +1,7 @@
 # The bastion EC2 instance
 resource "aws_instance" "bod_bastion" {
   ami               = data.aws_ami.bastion.id
-  instance_type     = "t3.small"
+  instance_type     = "t4g.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the public subnet

--- a/terraform/cyhy_bastion_ec2.tf
+++ b/terraform/cyhy_bastion_ec2.tf
@@ -1,7 +1,7 @@
 # The bastion EC2 instance
 resource "aws_instance" "cyhy_bastion" {
   ami               = data.aws_ami.bastion.id
-  instance_type     = local.production_workspace ? "c5n.large" : "t3.small"
+  instance_type     = local.production_workspace ? "c6gn.large" : "t4g.small"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # This is the public subnet


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request moves the BOD and CyHy `bastion` instances from their existing x86_64 models to equivalent arm64 models.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Graviton models can be cheaper than equivalent/similar x86_64 models so it makes sense to convert instances as we are able. Since these are straightforward SSH bastion servers they are good candidates for our first conversion.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I deployed this in my testing environment and had no issue connecting to each `bastion` as well as an instance behind the `bastion`.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
