### PR TITLE
Add an `ExecStop` configuration to the service that manages `cisagov/ncats-webui` usage

### DIFF
--- a/ansible/roles/cyhy_dashboard/files/ncats-webui.service
+++ b/ansible/roles/cyhy_dashboard/files/ncats-webui.service
@@ -7,3 +7,4 @@ Restart=on-failure
 RestartSec=10
 User=cyhy
 ExecStart=/usr/bin/make --directory /var/cyhy/ncats-webui/ dev-start
+ExecStop=/usr/bin/make --directory /var/cyhy/ncats-webui/ dev-stop


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds an appropriate `ExecStop` argument to the systemd service that manages the use of [cisagov/ncats-webui](https://github.com/cisagov/ncats-webuid) on the `dashboard` instance.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Not only is it good practice to have an `ExecStop` argument configured to accompany an `ExecStart` argument, but this is necessary to cleanly perform a service restart as [according to the `ExecStop` documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecStop=):
> Service restart requests are implemented as stop operations followed by start operations. This means that ExecStop= and ExecStopPost= are executed during a service restart operation.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified this worked as expected in my test environment.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
