### PR TITLE
Support Graviton `portscan` instances

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -587,7 +587,8 @@ terraform apply -var-file=<your_workspace>.tfvars
 | [aws_ami.cyhy_mongo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.dashboard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
-| [aws_ami.nmap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.nmap_arm64](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.nmap_x86_64](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.reporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -677,7 +678,7 @@ terraform apply -var-file=<your_workspace>.tfvars
 | nessus\_cyhy\_runner\_disk | The cyhy-runner data volume for the Nessus instance(s). | `string` | `"/dev/xvdb"` | no |
 | nessus\_instance\_count | The number of Nessus instances to create. | `number` | n/a | yes |
 | nmap\_cyhy\_runner\_disk | The cyhy-runner data volume for the Nmap instance(s). | `string` | `"/dev/nvme1n1"` | no |
-| nmap\_instance\_count | The number of Nmap instances to create. | `number` | n/a | yes |
+| nmap\_instance\_count | The number of Nmap instances to create, broken down by architecture. Note that x86\_64 instances will be deployed first, followed by arm64 instances. | `object({ arm64 = number, x86_64 = number })` | n/a | yes |
 | remote\_ssh\_user | The username to use when sshing to the EC2 instances. | `string` | n/a | yes |
 | reporter\_mailer\_override\_filename | This file is used to add/override any Docker composition settings for cyhy-mailer for the reporter EC2 instance.  It must already exist in /var/cyhy/cyhy-mailer. | `string` | `"docker-compose.cyhy.yml"` | no |
 | ses\_aws\_region | The AWS region where SES is configured. | `string` | `"us-east-1"` | no |

--- a/terraform/cyhy_mongo_ec2.tf
+++ b/terraform/cyhy_mongo_ec2.tf
@@ -190,7 +190,7 @@ module "cyhy_mongo_ansible_provisioner" {
     "cyhy_commander_jobs_per_nmap_host=${var.commander_config.jobs_per_nmap_host}",
     "cyhy_commander_nessus_hosts=${join(",", formatlist("vulnscan%d", range(1, var.nessus_instance_count + 1)))}",
     "cyhy_commander_next_scan_limit=${var.commander_config.next_scan_limit}",
-    "cyhy_commander_nmap_hosts=${join(",", formatlist("portscan%d", range(1, var.nmap_instance_count + 1)))}",
+    "cyhy_commander_nmap_hosts=${join(",", formatlist("portscan%d", range(1, local.nmap_total_instance_count + 1)))}",
     "cyhy_feeds_aws_region=${var.aws_region}",
     "cyhy_feeds_dmarc_import_aws_region=${var.dmarc_import_aws_region}",
     "cyhy_feeds_dmarc_import_es_role=${var.dmarc_import_es_role_arn}",

--- a/terraform/cyhy_nmap_cloud_init.tf
+++ b/terraform/cyhy_nmap_cloud_init.tf
@@ -2,7 +2,7 @@
 # volume, and setting the hostname
 
 data "cloudinit_config" "cyhy_nmap_cloud_init_tasks" {
-  count = var.nmap_instance_count
+  count = local.nmap_total_instance_count
 
   base64_encode = true
   gzip          = true

--- a/terraform/cyhy_nmap_ec2.tf
+++ b/terraform/cyhy_nmap_ec2.tf
@@ -1,4 +1,26 @@
-data "aws_ami" "nmap" {
+data "aws_ami" "nmap_arm64" {
+  filter {
+    name = "name"
+    values = [
+      "${var.ami_prefixes.nmap}-nmap-hvm-*-arm64-ebs",
+    ]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners      = [data.aws_caller_identity.current.account_id] # This is us
+  most_recent = true
+}
+
+data "aws_ami" "nmap_x86_64" {
   filter {
     name = "name"
     values = [
@@ -21,9 +43,9 @@ data "aws_ami" "nmap" {
 }
 
 resource "aws_instance" "cyhy_nmap" {
-  ami           = data.aws_ami.nmap.id
-  instance_type = local.production_workspace ? "t3.medium" : "t3.small"
-  count         = var.nmap_instance_count
+  ami           = count.index < var.nmap_instance_count.x86_64 ? data.aws_ami.nmap_x86_64.id : data.aws_ami.nmap_arm64.id
+  instance_type = count.index < var.nmap_instance_count.x86_64 ? (local.production_workspace ? "t3.medium" : "t3.small") : (local.production_workspace ? "t4g.medium" : "t4g.small")
+  count         = local.nmap_total_instance_count
 
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
@@ -83,7 +105,7 @@ resource "aws_instance" "cyhy_nmap" {
 # manually and are intended to be a public IP address that rarely
 # changes.
 data "aws_eip" "cyhy_nmap_eips" {
-  count = local.production_workspace ? var.nmap_instance_count : 0
+  count = local.production_workspace ? local.nmap_total_instance_count : 0
   public_ip = cidrhost(
     var.cyhy_elastic_ip_cidr_block,
     var.cyhy_portscan_first_elastic_ip_offset + count.index,
@@ -95,7 +117,7 @@ data "aws_eip" "cyhy_nmap_eips" {
 # workspaces and are randomly-assigned public IP address for temporary
 # use.
 resource "aws_eip" "cyhy_nmap_random_eips" {
-  count = local.production_workspace ? 0 : var.nmap_instance_count
+  count = local.production_workspace ? 0 : local.nmap_total_instance_count
 
   domain = "vpc"
 
@@ -121,7 +143,7 @@ resource "aws_eip" "cyhy_nmap_random_eips" {
 #
 # VOTED WORST LINE OF TERRAFORM 2018 (so far) BY DEV TEAM WEEKLY!!
 resource "aws_eip_association" "cyhy_nmap_eip_assocs" {
-  count       = var.nmap_instance_count
+  count       = local.nmap_total_instance_count
   instance_id = aws_instance.cyhy_nmap[count.index].id
   allocation_id = element(
     coalescelist(
@@ -143,7 +165,7 @@ resource "aws_eip_association" "cyhy_nmap_eip_assocs" {
 # inside of the lifecycle block
 # (https://github.com/hashicorp/terraform/issues/3116).
 resource "aws_ebs_volume" "nmap_cyhy_runner_data" {
-  count             = var.nmap_instance_count
+  count             = local.nmap_total_instance_count
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
   # availability_zone = "${element(data.aws_availability_zones.all.names, count.index)}"
@@ -159,7 +181,7 @@ resource "aws_ebs_volume" "nmap_cyhy_runner_data" {
 }
 
 resource "aws_volume_attachment" "nmap_cyhy_runner_data_attachment" {
-  count       = var.nmap_instance_count
+  count       = local.nmap_total_instance_count
   device_name = "/dev/xvdb"
   volume_id   = aws_ebs_volume.nmap_cyhy_runner_data[count.index].id
   instance_id = aws_instance.cyhy_nmap[count.index].id

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -130,8 +130,11 @@ locals {
   # NOTE: there is an assumption that subnets are /24 or smaller in
   # the reverse zone names.
 
+  # Total number of Port Scanners
+  nmap_total_instance_count = var.nmap_instance_count.arm64 + var.nmap_instance_count.x86_64
+
   # Port Scanners DNS entries
-  count_port_scanner = var.nmap_instance_count
+  count_port_scanner = local.nmap_total_instance_count
 
   # Vulnerability Scanners DNS entries
   count_vuln_scanner = var.nessus_instance_count

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -59,9 +59,9 @@ variable "nessus_instance_count" {
 }
 
 variable "nmap_instance_count" {
-  description = "The number of Nmap instances to create."
+  description = "The number of Nmap instances to create, broken down by architecture. Note that x86_64 instances will be deployed first, followed by arm64 instances."
   nullable    = false
-  type        = number
+  type        = object({ arm64 = number, x86_64 = number })
 }
 
 variable "remote_ssh_user" {


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Add the ability spin up Graviton-based `portscan` instances in addition to x86_64 ones.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As part of our move to use Graviton-based instances (mainly for cost-benefits), and with the addition of ARM64-based AMIs added in #867, we can use `portscan` instances running on Graviton instances due to their straightforward configuration. Any Graviton-based instances will be deployed _after_ any x86_64-based instances in sequence. Thus, with the configuration

```hcl
nmap_instance_count = {
  arm64  = 1
  x86_64 = 1
}
```

`portscan1` will be x86_64 and `portscan2` will be ARM64. This method was chosen because it is of minimal impact to our existing configuration and helper scripts.

> [!WARNING]
> This is a breaking change because the format of the `nmap_instance_count` variable has changed from a number to an object where each key is an architecture and the value is the number of instances using that architecture.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I deployed Graviton-based `portscan` instances in my testing environment both in addition to x86_64 instances and exclusively. I verified that they received work and were able to process it successfully.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
