### PR TITLE
Specify the user account to own created directories when building AMIs

### DIFF
--- a/packer/ansible/code_gov.yml
+++ b/packer/ansible/code_gov.yml
@@ -4,4 +4,7 @@
   become: true
   become_method: ansible.builtin.sudo
   roles:
-    - code_gov_update
+    - role: code_gov_update
+      vars:
+        code_gov_update_file_owner_group: "{{ cyhy_user_username }}"
+        code_gov_update_file_owner_username: "{{ cyhy_user_username }}"

--- a/packer/ansible/cyhy_archive.yml
+++ b/packer/ansible/cyhy_archive.yml
@@ -6,5 +6,7 @@
   roles:
     - role: cyhy_archive
       vars:
+        cyhy_archive_file_owner_group: "{{ cyhy_user_username }}"
+        cyhy_archive_file_owner_username: "{{ cyhy_user_username }}"
         cyhy_archive_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         cyhy_archive_maxmind_license_key: "{{ maxmind_license_key_secret }}"

--- a/packer/ansible/cyhy_commander.yml
+++ b/packer/ansible/cyhy_commander.yml
@@ -6,6 +6,8 @@
   roles:
     - role: cyhy_commander
       vars:
+        cyhy_commander_file_owner_group: "{{ cyhy_user_username }}"
+        cyhy_commander_file_owner_username: "{{ cyhy_user_username }}"
         cyhy_commander_install_geoipupdate: true
         cyhy_commander_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         cyhy_commander_maxmind_license_key: "{{ maxmind_license_key_secret }}"

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -8,4 +8,7 @@
       vars:
         ncats_webd_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         ncats_webd_maxmind_license_key: "{{ maxmind_license_key_secret }}"
-    - ncats_webui
+    - role: ncats_webui
+      vars:
+        ncats_webui_file_owner_group: "{{ cyhy_user_username }}"
+        ncats_webui_file_owner_username: "{{ cyhy_user_username }}"

--- a/packer/ansible/cyhy_feeds.yml
+++ b/packer/ansible/cyhy_feeds.yml
@@ -4,4 +4,7 @@
   become: true
   become_method: ansible.builtin.sudo
   roles:
-    - cyhy_feeds
+    - role: cyhy_feeds
+      vars:
+        cyhy_feeds_file_owner_group: "{{ cyhy_user_username }}"
+        cyhy_feeds_file_owner_username: "{{ cyhy_user_username }}"

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -7,6 +7,8 @@
     - xfs
     - role: cyhy_reports
       vars:
+        cyhy_reports_file_owner_group: "{{ cyhy_user_username }}"
+        cyhy_reports_file_owner_username: "{{ cyhy_user_username }}"
         cyhy_reports_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         cyhy_reports_maxmind_license_key: "{{ maxmind_license_key_secret }}"
         cyhy_reports_texmf_buffer_size: 100000000

--- a/packer/ansible/nessus.yml
+++ b/packer/ansible/nessus.yml
@@ -4,7 +4,10 @@
   become: true
   become_method: ansible.builtin.sudo
   roles:
-    - cyhy_runner
+    - role: cyhy_runner
+      vars:
+        cyhy_runner_file_owner_group: "{{ cyhy_user_username }}"
+        cyhy_runner_file_owner_username: "{{ cyhy_user_username }}"
     - role: nessus
       vars:
         nessus_package_bucket: ncats-3rd-party-packages

--- a/packer/ansible/nmap.yml
+++ b/packer/ansible/nmap.yml
@@ -4,6 +4,9 @@
   become: true
   become_method: ansible.builtin.sudo
   roles:
-    - cyhy_runner
+    - role: cyhy_runner
+      vars:
+        cyhy_runner_file_owner_group: "{{ cyhy_user_username }}"
+        cyhy_runner_file_owner_username: "{{ cyhy_user_username }}"
     - nmap
     - more_ephemeral_ports

--- a/packer/ansible/vdp_scan.yml
+++ b/packer/ansible/vdp_scan.yml
@@ -4,4 +4,7 @@
   become: true
   become_method: ansible.builtin.sudo
   roles:
-    - vdp_scanner
+    - role: vdp_scanner
+      vars:
+        vdp_scanner_file_owner_group: "{{ cyhy_user_username }}"
+        vdp_scanner_file_owner_username: "{{ cyhy_user_username }}"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Packer template's Ansible configuration to specify the user and group to use as owners of directories and files created by roles where available.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is done to hopefully ensure that files and directories are created with the desired permissions instead of relying on cloud-init to fix permissions when instances are deployed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
