### PR TITLE
Update the usage of the ClamAV Ansible role for Debian Buster

### DIFF
--- a/packer/ansible/base.yml
+++ b/packer/ansible/base.yml
@@ -6,7 +6,33 @@
   roles:
     - automated_security_updates
     - banner
-    - clamav
     - htop
     - persist_journald
     - dev_ssh_access
+  tasks:
+    - name: Install and configure ClamAV
+      block:
+        # We have to treat Debian Buster as a special case because it
+        # is so old.
+        - name: Install and configure ClamAV (Debian Buster)
+          ansible.builtin.include_role:
+            name: clamav
+          vars:
+            # The version of ClamAV offered by Debian Buster is so
+            # ancient that it is no longer allowed to download updated
+            # signatures from ClamAV.  See
+            # https://github.com/cisagov/ansible-role-clamav/pull/100/commits/75810362c165b4fe746a415aa831a2d0ea0dbf76
+            # for more details.
+            clamav_install_from_package_manager: false
+          when:
+            - ansible_distribution == "Debian"
+            - ansible_distribution_release == "buster"
+
+        # If we're not on Debian Buster then we can just install the
+        # role as we normally do.
+        - name: Install and configure ClamAV (not Debian Buster)
+          ansible.builtin.include_role:
+            name: clamav
+          when: >-
+            ansible_distribution != "Debian" or
+            ansible_distribution_release != "buster"


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the usage of the ClamAV Ansible role for Debian Buster.

## 💭 Motivation and context ##

We have to treat Debian Buster as a special case because it is so old. In particular, the version of ClamAV offered by Debian Buster is so ancient that it is no longer allowed to download updated signatures from ClamAV.  See [this commit](
https://github.com/cisagov/ansible-role-clamav/pull/100/commits/75810362c165b4fe746a415aa831a2d0ea0dbf76) from cisagov/ansible-role-clamav#100 for more details.

## 🧪 Testing ##

All automated tests pass.  I also successfully built bastion and MongoDB AMIs for my `jsf9k` deployment of this repository and verified that they each followed their expected usage of the ClamAV Ansible role.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.