### PR TITLE
Specify the versions of `cisagov/cyhy-commander`, `cisagov/cyhy-core`, and `cisagov/cyhy-reports` to use when building AMIs

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -93,6 +93,9 @@ No modules.
 | ami\_prefix | The prefix to use for the names of AMIs created. | `string` | `"cyhy"` | no |
 | ami\_regions | The list of AWS regions to copy the AMI to once it has been created. Example: ["us-east-1"] | `list(string)` | ```[ "us-east-1", "us-west-1", "us-west-2" ]``` | no |
 | build\_region | The region in which to retrieve the base AMI from and build the new AMI. | `string` | `"us-east-2"` | no |
+| cyhy\_commander\_version | The version of cisagov/cyhy-commander to use; must be a valid git reference. | `string` | `"v1.1.0"` | no |
+| cyhy\_core\_version | The version of cisagov/cyhy-core to use; must be a valid git reference. | `string` | `"v1.1.14"` | no |
+| cyhy\_reports\_version | The version of cisagov/cyhy-reports to use; must be a valid git reference. | `string` | `"v1.1.1"` | no |
 | cyhy\_user\_information | The user information for the Cyber Hygiene user. | ```object({ home_directory = string ssh_public_key = string user_id = string username = string })``` | ```{ "home_directory": "/var/cyhy", "ssh_public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOreUDnms12MPI0gh7K+YGaESYgC2TY1zA+kSK/g+n5+ cyhy", "user_id": "2048", "username": "cyhy" }``` | no |
 | force\_install\_ansible\_requirements | Indicate if the Ansible requirements should be force installed. | `bool` | `false` | no |
 | force\_install\_ansible\_requirements\_with\_dependencies | Indicate if the Ansible requirements *and* their dependencies should be force installed. | `bool` | `false` | no |

--- a/packer/ansible/cyhy_archive.yml
+++ b/packer/ansible/cyhy_archive.yml
@@ -6,5 +6,6 @@
   roles:
     - role: cyhy_archive
       vars:
+        cyhy_archive_cyhy_core_version: "{{ cyhy_core_version }}"
         cyhy_archive_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         cyhy_archive_maxmind_license_key: "{{ maxmind_license_key_secret }}"

--- a/packer/ansible/cyhy_commander.yml
+++ b/packer/ansible/cyhy_commander.yml
@@ -6,6 +6,8 @@
   roles:
     - role: cyhy_commander
       vars:
+        cyhy_commander_cyhy_core_version: "{{ cyhy_core_version }}"
         cyhy_commander_install_geoipupdate: true
         cyhy_commander_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         cyhy_commander_maxmind_license_key: "{{ maxmind_license_key_secret }}"
+        cyhy_commander_version: "{{ cyhy_commander_version }}"

--- a/packer/ansible/cyhy_dashboard.yml
+++ b/packer/ansible/cyhy_dashboard.yml
@@ -6,6 +6,7 @@
   roles:
     - role: ncats_webd
       vars:
+        ncats_webd_cyhy_core_version: "{{ cyhy_core_version }}"
         ncats_webd_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         ncats_webd_maxmind_license_key: "{{ maxmind_license_key_secret }}"
     - ncats_webui

--- a/packer/ansible/cyhy_reporter.yml
+++ b/packer/ansible/cyhy_reporter.yml
@@ -7,8 +7,10 @@
     - xfs
     - role: cyhy_reports
       vars:
+        cyhy_reports_cyhy_core_version: "{{ cyhy_core_version }}"
         cyhy_reports_maxmind_account_id: "{{ maxmind_account_id_secret }}"
         cyhy_reports_maxmind_license_key: "{{ maxmind_license_key_secret }}"
         cyhy_reports_texmf_buffer_size: 100000000
         cyhy_reports_texmf_main_memory: 10000000
+        cyhy_reports_version: "{{ cyhy_reports_version }}"
     - cyhy_mailer

--- a/packer/dashboard_build.pkr.hcl
+++ b/packer/dashboard_build.pkr.hcl
@@ -32,6 +32,7 @@ build {
     extra_arguments = flatten(setproduct(["--extra-vars"], concat(
       local.cyhy_user_ansible_variables,
       local.maxmind_account_ansible_variables,
+      local.python_package_variables,
     )))
     groups        = ["cyhy_dashboard"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/locals.pkr.hcl
+++ b/packer/locals.pkr.hcl
@@ -13,4 +13,10 @@ locals {
     "maxmind_account_id_secret=${data.amazon-parameterstore.maxmind_account_id.value}",
     "maxmind_license_key_secret=${data.amazon-parameterstore.maxmind_license_key.value}",
   ]
+
+  python_package_variables = [
+    "cyhy_commander_version=${var.cyhy_commander_version}",
+    "cyhy_core_version=${var.cyhy_core_version}",
+    "cyhy_reports_version=${var.cyhy_reports_version}",
+  ]
 }

--- a/packer/mongo_build.pkr.hcl
+++ b/packer/mongo_build.pkr.hcl
@@ -32,6 +32,7 @@ build {
     extra_arguments = flatten(setproduct(["--extra-vars"], concat(
       local.cyhy_user_ansible_variables,
       local.maxmind_account_ansible_variables,
+      local.python_package_variables,
     )))
     groups        = ["cyhy_archive", "cyhy_commander", "cyhy_feeds", "mongo"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/reporter_build.pkr.hcl
+++ b/packer/reporter_build.pkr.hcl
@@ -32,6 +32,7 @@ build {
     extra_arguments = flatten(setproduct(["--extra-vars"], concat(
       local.cyhy_user_ansible_variables,
       local.maxmind_account_ansible_variables,
+      local.python_package_variables,
     )))
     groups        = ["cyhy_reporter"]
     playbook_file = "ansible/playbook.yml"

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -31,6 +31,24 @@ variable "build_region" {
   type        = string
 }
 
+variable "cyhy_commander_version" {
+  default     = "v1.1.0"
+  description = "The version of cisagov/cyhy-commander to use; must be a valid git reference."
+  type        = string
+}
+
+variable "cyhy_core_version" {
+  default     = "v1.1.14"
+  description = "The version of cisagov/cyhy-core to use; must be a valid git reference."
+  type        = string
+}
+
+variable "cyhy_reports_version" {
+  default     = "v1.1.1"
+  description = "The version of cisagov/cyhy-reports to use; must be a valid git reference."
+  type        = string
+}
+
 variable "cyhy_user_information" {
   default = {
     home_directory = "/var/cyhy"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Packer template to support specifying the versions of [cisagov/cyhy-commander], [cisagov/cyhy-core], and [cisagov/cyhy-reports] to install when building AMIs. This is done by adding three variables to the template, updating the `ansible` provisioners for AMIs that use these packages to pass in the new variables, and updating the template's Ansible configuration to use the values of these new variables.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will ensure that AMIs built will consistently use specific versions (git references) of the [cisagov/cyhy-commander], [cisagov/cyhy-core], and [cisagov/cyhy-reports] packages. This not only ensures consistency across AMIs but also makes it easier to test changes to these packages since the git reference can now be controlled in the Packer template.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I am waiting for https://github.com/cisagov/ansible-role-cyhy-archive/pull/70, https://github.com/cisagov/ansible-role-cyhy-commander/pull/96, https://github.com/cisagov/ansible-role-cyhy-reports/pull/94, and https://github.com/cisagov/ansible-role-ncats-webd/pull/89 to pass review before proceeding with building test AMIs.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

[cisagov/cyhy-commander]: https://github.com/cisagov/cyhy-commander
[cisagov/cyhy-core]: https://github.com/cisagov/cyhy-core
[cisagov/cyhy-reports]: https://github.com/cisagov/cyhy-reports
