### PR TITLE
Add a GitHub Actions workflow to lock Terraform providers

### DIFF
--- a/.github/workflows/lock-terraform-providers.yml
+++ b/.github/workflows/lock-terraform-providers.yml
@@ -96,6 +96,9 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ steps.setup-env.outputs.terraform-version }}
+      - name: Initialize the Terraform configuration
+        run: terraform init
+        working-directory: ./terraform
       - name: Lock Terraform providers
         run: >-
           terraform providers lock

--- a/.github/workflows/lock-terraform-providers.yml
+++ b/.github/workflows/lock-terraform-providers.yml
@@ -1,0 +1,110 @@
+---
+name: Lock Terraform providers
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    paths:
+      - terrform/.terraform.lock.hcl
+
+# Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
+# nounset, errexit, and pipefail. The `-x` will print all commands as they are
+# run. Please see the GitHub Actions documentation for more information:
+# https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+  lock-providers:
+    needs:
+      - diagnostics
+    permissions:
+      # stefanzweifel/git-auto-commit-action needs this to commit changes
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - id: setup-env
+        uses: cisagov/setup-env-github-action@v1
+      - uses: actions/checkout@v6
+        with:
+          # Needed by stefanzweifel/git-auto-commit-action to support the pull_request
+          # trigger.
+          ref: ${{ github.head_ref }}
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.setup-env.outputs.terraform-version }}
+      - name: Lock Terraform providers
+        run: >-
+          terraform providers lock
+          -platform=darwin_amd64
+          -platform=darwin_arm64
+          -platform=linux_amd64
+          -platform=linux_arm64
+        working-directory: ./terraform
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: Lock Terraform providers

--- a/.github/workflows/lock-terraform-providers.yml
+++ b/.github/workflows/lock-terraform-providers.yml
@@ -4,7 +4,7 @@ name: Lock Terraform providers
 on:  # yamllint disable-line rule:truthy
   pull_request:
     paths:
-      - terrform/.terraform.lock.hcl
+      - terraform/.terraform.lock.hcl
 
 # Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
 # nounset, errexit, and pipefail. The `-x` will print all commands as they are

--- a/.github/workflows/lock-terraform-providers.yml
+++ b/.github/workflows/lock-terraform-providers.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           terraform_version: ${{ steps.setup-env.outputs.terraform-version }}
       - name: Initialize the Terraform configuration
-        run: terraform init
+        run: terraform init -backend=false
         working-directory: ./terraform
       - name: Lock Terraform providers
         run: >-

--- a/.github/workflows/lock-terraform-providers.yml
+++ b/.github/workflows/lock-terraform-providers.yml
@@ -52,6 +52,9 @@ jobs:
           # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
   lock-providers:
+    # Prevent the workflow from running if the trigger was a previous workflow run that
+    # updated the lock file.
+    if: ${{ github.actor != 'github-actions[bot]' }}
     needs:
       - diagnostics
     permissions:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a new GitHub Actions workflow that will lock Terraform providers in pull requests that modify the `terraform/.terraform.lock.hcl` file.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When performing an upgrade only hashes for the platform performing the upgrade are added. This can result in changes to the Terraform lockfile when initializing on a platform different from the one that performed an upgrade. This workflow will ensure the lockfile has information for all of our standard platforms (macOS and Linux on both amd64 and arm64).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
