### PR TITLE
Add Debian Archive SourceList to list of files to convert to use HTTPS

### DIFF
--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -26,6 +26,7 @@
         apt_over_https_apt_source_files:
           # Legacy SourceList files (pre Debian Bookworm)
           - /etc/apt/sources.list
+          - /etc/apt/sources.list.d/archive.list
           - /etc/apt/sources.list.d/backports.list
           # DEB822 SourceList files (Debian Bookworm and later)
           - /etc/apt/sources.list.d/debian.sources


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This pull request makes a small update to the Ansible upgrade configuration by adding an additional source list file for apt-over-https checks.

* Added `/etc/apt/sources.list.d/archive.list` to the `apt_over_https_apt_source_files` list in `packer/ansible/upgrade.yml` to ensure all relevant apt source files are included.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This small item was overlooked when we added Debian Archive to Buster in #872.  It ensures that `apt upgrade` will be able to run successfully, which is important for [automated security updates](https://github.com/cisagov/cyhy_amis/blob/45d4df9ea049750a46cde55f6255954d0ce654ac/packer/ansible/base.yml#L7) to run on the instance.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this by manually changing the `http` to `https` in a deployed Buster instance and confirmed that after the change, I was able to successfully run `apt upgrade`.  Before that change, `apt upgrade` was failing because these deployed instances cannot communicate out to the internet on port 80.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

