### PR TITLE
Restart the `cyhy-commander` service only if dependent files have changed

### DIFF
--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -42,6 +42,7 @@
     mode: u=rw,g=rw,o=
     owner: cyhy
     src: cyhy.conf.j2
+  register: cyhy_commander_cyhy_conf
   when: not cyhy_commander_cyhy_conf_result.stat.exists
 
 # yamllint complains about the line length in the block below, but it is
@@ -57,6 +58,7 @@
       database-name = {{ cyhy_commander_commander_db }}
     marker: ; {mark} ANSIBLE MANAGED BLOCK commander
     path: /etc/cyhy/cyhy.conf
+  register: cyhy_commander_cyhy_conf
   when: cyhy_commander_cyhy_conf_result.stat.exists
 # yamllint enable rule:line-length
 
@@ -75,7 +77,10 @@
   ansible.builtin.service:
     name: cyhy-commander
     state: stopped
-  when: cyhy_commander_cyhy_ssh_private_key.changed or cyhy_commander_conf.changed
+  when: >-
+    cyhy_commander_cyhy_ssh_private_key.changed
+    or cyhy_commander_conf.changed
+    or cyhy_commander_cyhy_conf.changed
 
 - name: Enable and start cyhy-commander
   ansible.builtin.service:

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -9,6 +9,7 @@
     group: cyhy
     mode: u=rw,g=,o=
     owner: cyhy
+  no_log: true
   register: cyhy_commander_cyhy_ssh_private_key
 
 #
@@ -63,6 +64,7 @@
         mode: u=rw,g=rw,o=
         owner: cyhy
         path: /etc/cyhy/cyhy.conf
+      no_log: true
       register: cyhy_commander_cyhy_conf_modified
       when: cyhy_commander_cyhy_conf_result.stat.exists
     # yamllint enable rule:line-length

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -58,7 +58,10 @@
           [production]
           database-uri = mongodb://{{ cyhy_commander_commander_user }}:{{ cyhy_commander_commander_pw }}@database1.cyhy:27017/{{ cyhy_commander_commander_db }}
           database-name = {{ cyhy_commander_commander_db }}
+        group: cyhy
         marker: ; {mark} ANSIBLE MANAGED BLOCK commander
+        mode: u=rw,g=rw,o=
+        owner: cyhy
         path: /etc/cyhy/cyhy.conf
       register: cyhy_commander_cyhy_conf_modified
       when: cyhy_commander_cyhy_conf_result.stat.exists

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -21,6 +21,45 @@
     src: commander.conf.j2
   register: cyhy_commander_conf
 
+- name: Check if cyhy.conf already exists
+  ansible.builtin.stat:
+    path: /etc/cyhy/cyhy.conf
+  register: cyhy_commander_cyhy_conf_result
+
+#
+# Set up /etc/cyhy/cyhy.conf with commander creds
+#
+# This is a little messy.  The real solution is to just create a
+# cyhy.conf with credentials for each user in mongo_users.other_users.
+# That will cause some heartburn, though, since the credential
+# sections will have to be named using the MongoDB username.  That
+# will necessitate some changes elsewhere in the code where named
+# sections from cyhy.conf are explicitly referenced.
+- name: Create cyhy.conf (with commander credentials) if it doesn't exist
+  ansible.builtin.template:
+    dest: /etc/cyhy/cyhy.conf
+    group: cyhy
+    mode: u=rw,g=rw,o=
+    owner: cyhy
+    src: cyhy.conf.j2
+  when: not cyhy_commander_cyhy_conf_result.stat.exists
+
+# yamllint complains about the line length in the block below, but it is
+# necessary to ensure that the block is formatted correctly in the
+# cyhy.conf file.
+#
+# yamllint disable rule:line-length
+- name: Add commander credentials block to cyhy.conf if necessary
+  ansible.builtin.blockinfile:
+    block: |
+      [production]
+      database-uri = mongodb://{{ cyhy_commander_commander_user }}:{{ cyhy_commander_commander_pw }}@database1.cyhy:27017/{{ cyhy_commander_commander_db }}
+      database-name = {{ cyhy_commander_commander_db }}
+    marker: ; {mark} ANSIBLE MANAGED BLOCK commander
+    path: /etc/cyhy/cyhy.conf
+  when: cyhy_commander_cyhy_conf_result.stat.exists
+# yamllint enable rule:line-length
+
 #
 # Create empty cyhy ssh config with cyhy as owner and group
 #
@@ -73,45 +112,6 @@
     dest: /tmp/cyhy-places/extras/ADDL_CYHY_PLACES.txt
     mode: u=rw,g=r,o=r
     url: https://raw.githubusercontent.com/cisagov/cyhy-core/develop/extras/ADDL_CYHY_PLACES.txt
-
-- name: Check if cyhy.conf already exists
-  ansible.builtin.stat:
-    path: /etc/cyhy/cyhy.conf
-  register: cyhy_commander_cyhy_conf_result
-
-#
-# Set up /etc/cyhy/cyhy.conf with commander creds
-#
-# This is a little messy.  The real solution is to just create a
-# cyhy.conf with credentials for each user in mongo_users.other_users.
-# That will cause some heartburn, though, since the credential
-# sections will have to be named using the MongoDB username.  That
-# will necessitate some changes elsewhere in the code where named
-# sections from cyhy.conf are explicitly referenced.
-- name: Create cyhy.conf (with commander credentials) if it doesn't exist
-  ansible.builtin.template:
-    dest: /etc/cyhy/cyhy.conf
-    group: cyhy
-    mode: u=rw,g=rw,o=
-    owner: cyhy
-    src: cyhy.conf.j2
-  when: not cyhy_commander_cyhy_conf_result.stat.exists
-
-# yamllint complains about the line length in the block below, but it is
-# necessary to ensure that the block is formatted correctly in the
-# cyhy.conf file.
-#
-# yamllint disable rule:line-length
-- name: Add commander credentials block to cyhy.conf if necessary
-  ansible.builtin.blockinfile:
-    block: |
-      [production]
-      database-uri = mongodb://{{ cyhy_commander_commander_user }}:{{ cyhy_commander_commander_pw }}@database1.cyhy:27017/{{ cyhy_commander_commander_db }}
-      database-name = {{ cyhy_commander_commander_db }}
-    marker: ; {mark} ANSIBLE MANAGED BLOCK commander
-    path: /etc/cyhy/cyhy.conf
-  when: cyhy_commander_cyhy_conf_result.stat.exists
-# yamllint enable rule:line-length
 
 #
 # Run script to create the "places" collection

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -9,6 +9,7 @@
     group: cyhy
     mode: u=rw,g=,o=
     owner: cyhy
+  register: cyhy_commander_cyhy_ssh_private_key
 
 #
 # Copy the cyhy-commander conf file
@@ -18,6 +19,7 @@
     dest: /etc/cyhy/commander.conf
     mode: u=rw,g=r,o=r
     src: commander.conf.j2
+  register: cyhy_commander_conf
 
 #
 # Create empty cyhy ssh config with cyhy as owner and group
@@ -30,11 +32,17 @@
     path: /var/cyhy/.ssh/config
     state: touch
 
+- name: Ensure cyhy-commander is stopped if files have changed
+  ansible.builtin.service:
+    name: cyhy-commander
+    state: stopped
+  when: cyhy_commander_cyhy_ssh_private_key.changed or cyhy_commander_conf.changed
+
 - name: Enable and start cyhy-commander
   ansible.builtin.service:
     name: cyhy-commander
     enabled: true
-    state: restarted
+    state: started
 
 #
 # Grab the files we need to create the "places" collection from cyhy-core

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -44,7 +44,7 @@
         mode: u=rw,g=rw,o=
         owner: cyhy
         src: cyhy.conf.j2
-      register: cyhy_commander_cyhy_conf
+      register: cyhy_commander_cyhy_conf_created
       when: not cyhy_commander_cyhy_conf_result.stat.exists
 
     # yamllint complains about the line length in the block below, but it is
@@ -60,7 +60,7 @@
           database-name = {{ cyhy_commander_commander_db }}
         marker: ; {mark} ANSIBLE MANAGED BLOCK commander
         path: /etc/cyhy/cyhy.conf
-      register: cyhy_commander_cyhy_conf
+      register: cyhy_commander_cyhy_conf_modified
       when: cyhy_commander_cyhy_conf_result.stat.exists
     # yamllint enable rule:line-length
 
@@ -82,7 +82,8 @@
   when: >-
     cyhy_commander_cyhy_ssh_private_key.changed
     or cyhy_commander_conf.changed
-    or cyhy_commander_cyhy_conf.changed
+    or cyhy_commander_cyhy_conf_created.changed
+    or cyhy_commander_cyhy_conf_modified.changed
 
 - name: Enable and start cyhy-commander
   ansible.builtin.service:

--- a/ansible/roles/cyhy_commander/tasks/main.yml
+++ b/ansible/roles/cyhy_commander/tasks/main.yml
@@ -21,46 +21,48 @@
     src: commander.conf.j2
   register: cyhy_commander_conf
 
-- name: Check if cyhy.conf already exists
-  ansible.builtin.stat:
-    path: /etc/cyhy/cyhy.conf
-  register: cyhy_commander_cyhy_conf_result
+- name: Create or update cyhy.conf
+  block:
+    - name: Check if cyhy.conf already exists
+      ansible.builtin.stat:
+        path: /etc/cyhy/cyhy.conf
+      register: cyhy_commander_cyhy_conf_result
 
-#
-# Set up /etc/cyhy/cyhy.conf with commander creds
-#
-# This is a little messy.  The real solution is to just create a
-# cyhy.conf with credentials for each user in mongo_users.other_users.
-# That will cause some heartburn, though, since the credential
-# sections will have to be named using the MongoDB username.  That
-# will necessitate some changes elsewhere in the code where named
-# sections from cyhy.conf are explicitly referenced.
-- name: Create cyhy.conf (with commander credentials) if it doesn't exist
-  ansible.builtin.template:
-    dest: /etc/cyhy/cyhy.conf
-    group: cyhy
-    mode: u=rw,g=rw,o=
-    owner: cyhy
-    src: cyhy.conf.j2
-  register: cyhy_commander_cyhy_conf
-  when: not cyhy_commander_cyhy_conf_result.stat.exists
+    #
+    # Set up /etc/cyhy/cyhy.conf with commander creds
+    #
+    # This is a little messy.  The real solution is to just create a
+    # cyhy.conf with credentials for each user in mongo_users.other_users.
+    # That will cause some heartburn, though, since the credential
+    # sections will have to be named using the MongoDB username.  That
+    # will necessitate some changes elsewhere in the code where named
+    # sections from cyhy.conf are explicitly referenced.
+    - name: Create cyhy.conf (with commander credentials) if it doesn't exist
+      ansible.builtin.template:
+        dest: /etc/cyhy/cyhy.conf
+        group: cyhy
+        mode: u=rw,g=rw,o=
+        owner: cyhy
+        src: cyhy.conf.j2
+      register: cyhy_commander_cyhy_conf
+      when: not cyhy_commander_cyhy_conf_result.stat.exists
 
-# yamllint complains about the line length in the block below, but it is
-# necessary to ensure that the block is formatted correctly in the
-# cyhy.conf file.
-#
-# yamllint disable rule:line-length
-- name: Add commander credentials block to cyhy.conf if necessary
-  ansible.builtin.blockinfile:
-    block: |
-      [production]
-      database-uri = mongodb://{{ cyhy_commander_commander_user }}:{{ cyhy_commander_commander_pw }}@database1.cyhy:27017/{{ cyhy_commander_commander_db }}
-      database-name = {{ cyhy_commander_commander_db }}
-    marker: ; {mark} ANSIBLE MANAGED BLOCK commander
-    path: /etc/cyhy/cyhy.conf
-  register: cyhy_commander_cyhy_conf
-  when: cyhy_commander_cyhy_conf_result.stat.exists
-# yamllint enable rule:line-length
+    # yamllint complains about the line length in the block below, but it is
+    # necessary to ensure that the block is formatted correctly in the
+    # cyhy.conf file.
+    #
+    # yamllint disable rule:line-length
+    - name: Add commander credentials block to cyhy.conf if necessary
+      ansible.builtin.blockinfile:
+        block: |
+          [production]
+          database-uri = mongodb://{{ cyhy_commander_commander_user }}:{{ cyhy_commander_commander_pw }}@database1.cyhy:27017/{{ cyhy_commander_commander_db }}
+          database-name = {{ cyhy_commander_commander_db }}
+        marker: ; {mark} ANSIBLE MANAGED BLOCK commander
+        path: /etc/cyhy/cyhy.conf
+      register: cyhy_commander_cyhy_conf
+      when: cyhy_commander_cyhy_conf_result.stat.exists
+    # yamllint enable rule:line-length
 
 #
 # Create empty cyhy ssh config with cyhy as owner and group


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the behavior of the `cyhy_commander` Ansible role that is used after a `database` instance has been deployed. It changes it to stop the `cyhy-commander` service if a dependent file has changed and then always ensure the service is enabled and started. It also moves creation/updating of the `cyhy.conf` file to before the `cyhy-commander` service is started.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It does not make sense, and can be disruptive, to restart the `cyhy-commander` service every time the `cyhy_commander` role is run. This will help ensure that the `cyhy-commander` service is only restarted when absolutely necessary. The `cyhy.conf` file is used whenever [cisagov/cyhy-commander] accesses the database through [cisagov/cyhy-core], therefore it makes sense to create or update this file before starting the service.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.

> [!IMPORTANT]
> I still need to test this during actual deployment to verify expected functionality.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/cyhy-commander]: https://github.com/cisagov/cyhy-commander
[cisagov/cyhy-core]: https://github.com/cisagov/cyhy-core
