### PR TITLE
Adjust `cyhy-commander` and `mongo` service behavior when updating the MongoDB configuration

### DIFF
--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -73,15 +73,40 @@
     src: mongod.conf
   register: mongo_copy_mongo_conf
 
-- name: Restart mongod service to use new configuration
-  ansible.builtin.service:
-    name: mongod
-    state: restarted
+- name: Restart mongod service and stop/start cyhy-commander service if needed
   when: >-
     mongo_create_admin_user.changed
     or mongo_update_admin_user.changed
     or mongo_update_other_users.changed
     or mongo_copy_mongo_conf.changed
+  block:
+    - name: Get service information
+      ansible.builtin.service_facts:
+
+    - name: Determine if cyhy-commander needs to be stopped
+      ansible.builtin.set_fact:
+        mongo_stop_commander: >-
+          {{
+            'cyhy-commander' in ansible_facts.services
+            and ansible_facts.services['cyhy-commander'].state != 'stopped'
+          }}
+
+    - name: Stop cyhy-commander
+      ansible.builtin.service:
+        name: cyhy-commander
+        state: stopped
+      when: mongo_stop_commander
+
+    - name: Restart mongod service to use new configuration
+      ansible.builtin.service:
+        name: mongod
+        state: restarted
+
+    - name: Start cyhy-commander
+      ansible.builtin.service:
+        name: cyhy-commander
+        state: started
+      when: mongo_stop_commander
 
 - name: Start mongod if it is not already running
   ansible.builtin.service:

--- a/ansible/roles/mongo/tasks/main.yml
+++ b/ansible/roles/mongo/tasks/main.yml
@@ -25,6 +25,7 @@
     password: "{{ mongo_admin_pw }}"
     roles: "{{ mongo_admin_roles }}"
     state: present
+  register: mongo_create_admin_user
   when: mongo_check_for_mongo_users.rc == 0
 
 - name: Update admin user in admin db (authenticate as admin)
@@ -37,6 +38,7 @@
     password: "{{ mongo_admin_pw }}"
     roles: "{{ mongo_admin_roles }}"
     state: present
+  register: mongo_update_admin_user
   when: mongo_check_for_mongo_users.rc != 0
 
 - name: Update other users (authenticate as admin)
@@ -62,14 +64,26 @@
   # miss an edge case like error output on task failure that would leak
   # password information by disabling the rule.
   no_log: true
+  register: mongo_update_other_users
 
 - name: Copy mongo configuration file
   ansible.builtin.template:
     dest: /etc/mongod.conf
     mode: u=rw,g=r,o=r
     src: mongod.conf
+  register: mongo_copy_mongo_conf
 
 - name: Restart mongod service to use new configuration
   ansible.builtin.service:
     name: mongod
     state: restarted
+  when: >-
+    mongo_create_admin_user.changed
+    or mongo_update_admin_user.changed
+    or mongo_update_other_users.changed
+    or mongo_copy_mongo_conf.changed
+
+- name: Start mongod if it is not already running
+  ansible.builtin.service:
+    name: mongod
+    state: started


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adjusts the `mongo` role's behavior when updating MongoDB users and/or the configuration file. Now it will stop the `cyhy-commander` service, restart the `mongo` service, and then start the `cyhy-commander` service if MongoDB users or the configuration have changed. Otherwise it will only ensure that the `mongo` service has been started.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change in behavior will limit disruptions to a running `database` instance if this role is re-run against the instance. This way a running MongoDB server will only restart if its configuration has changed and the `cyhy-commander` service will gracefully handle the restart.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.

> [!IMPORTANT]
> I still need to test this functionality to ensure correct behavior.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
