### PR TITLE
Use more granular profile to access cyber.dhs.gov remote Terraform state

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,7 +6,7 @@ In order to access certain AWS resources, the following AWS profiles must be
 set up in your AWS credentials file:
 
 - `cool-dns-route53resourcechange-cyber.dhs.gov`
-- `cool-terraform-readstate`
+- `cool-terraform-readcyberdhsgovterraformstate-production`
 
 The easiest way to set up those profiles is to use our
 [`aws-profile-sync`](https://github.com/cisagov/aws-profile-sync) utility.

--- a/terraform/remote_state.tf
+++ b/terraform/remote_state.tf
@@ -11,7 +11,7 @@ data "terraform_remote_state" "dns" {
     encrypt        = true
     bucket         = "cisa-cool-terraform-state"
     dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-readstate"
+    profile        = "cool-terraform-readcyberdhsgovterraformstate-production"
     region         = "us-east-1"
     key            = "cool-dns-cyber.dhs.gov.tfstate"
   }


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request makes a minor update to the `terraform/remote_state.tf` configuration. The AWS profile used to access the remote Terraform state for DNS has been changed to use a more specific profile.

- Changed the `profile` in the `terraform_remote_state` data source from `cool-terraform-readstate` to `cool-terraform-readcyberdhsgovterraformstate-production` to improve access control and specificity.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We prefer to use a more granular profile that only has access to the specific resources needed.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that this change worked by applying it in a dev environment and confirming that it was successful.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
