### PR TITLE
Set `include_deprecated` to `true` for Debian Buster base AMI filter

### DIFF
--- a/packer/base_amis.pkr.hcl
+++ b/packer/base_amis.pkr.hcl
@@ -4,9 +4,12 @@ data "amazon-ami" "debian_buster_x86_64" {
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
-  most_recent = true
-  owners      = ["136693071363"]
-  region      = var.build_region
+  # This allows for the use of deprecated AMIs, which is now necessary
+  # for Debian Buster.
+  include_deprecated = true
+  most_recent        = true
+  owners             = ["136693071363"]
+  region             = var.build_region
 }
 
 data "amazon-ami" "debian_bookworm_arm64" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request sets `include_deprecated` to `true` for the Debian Buster base AMI filter.

## 💭 Motivation and context ##

This allows for the use of deprecated AMIs, which is now necessary for the Debian Buster base AMIs.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.